### PR TITLE
updated validator for cl-key recycling

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2015-2016
+Copyright (c) 2015-2017
               The Royal Institution for the Advancement of Learning McGill University,
               Centre National de la Recherche Scientifique,
               University of Southern California,

--- a/tools/python/boutiques/schema/descriptor.schema.json
+++ b/tools/python/boutiques/schema/descriptor.schema.json
@@ -70,7 +70,7 @@
                         "working-directory": {},
                         "container-hash": {}
                     },
-                    "required": ["type", "image", "entrypoint"],
+                    "required": ["type", "image"],
                     "additionalProperties": false,
                     "description": "Object representing a docker or singularity container for the tool."
                 }, {

--- a/tools/python/boutiques/schema/examples/bad.json
+++ b/tools/python/boutiques/schema/examples/bad.json
@@ -2,7 +2,7 @@
   "name": "demo-tool",
   "tool-version": "v1",
   "description": "a tool that does things",
-  "command-line": "ndmg_pipeline [key1] [key2] [key3] [key4] [key5] [key6] [key7] [flag1]",
+  "command-line": "mytool.py [key1] [key2] [key3] [key4] [key5] [key6] [key7] [flag1]",
   "container-image": {
     "type": "docker",
     "image": "user/image:v1",
@@ -31,7 +31,16 @@
         "key8"
       ],
       "one-is-required": true
-    }
+    },
+		{
+			"id": "group3",
+			"name": "group 3",
+			"members": [
+				"key1",
+				"key1_mod"
+			],
+			"one-is-required": true
+		}
   ],
   "inputs": [
     {
@@ -39,14 +48,20 @@
       "name": "file 1",
       "type": "File",
       "value-key": "[key1]",
-      "optional": false
+      "optional": true
+    },
+    {
+      "id": "key1_mod",
+      "name": "file 1",
+      "type": "File",
+      "value-key": "[key1]",
+      "optional": true
     },
     {
       "id": "key2",
       "name": "file 2",
       "type": "File",
-      "value-key": "[key2]",
-      "optional": false
+      "value-key": "[key2]"
     },
     {
       "id": "key2",

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -12,6 +12,16 @@
   "schema-version": "0.4",
   "walltime-estimate": 3600,
   "groups": [
+		{
+			"id": "dti_group",
+			"name": "Group of two possible dti input files",
+			"members": [
+				"dti_file",
+				"dti_file_minc"
+			],
+			"mutually-exclusive": true,
+			"one-is-required": true
+		},
     {
       "id": "parcellation_group",
       "name": "Group of all used parcellations",
@@ -32,7 +42,14 @@
       "name": "Diffusion Tensor Image",
       "type": "File",
       "value-key": "[DTI]",
-      "optional": false
+      "optional": true
+    },
+    {
+      "id": "dti_file_minc",
+      "name": "Diffusion Tensor Image",
+      "type": "File",
+      "value-key": "[DTI]",
+      "optional": true
     },
     {
       "id": "bval_file",

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2015- 2017:
+# Copyright 2015 - 2017:
 #   The Royal Institution for the Advancement of Learning McGill University,
 #   Centre National de la Recherche Scientifique,
 #   University of Southern California,

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -1,21 +1,29 @@
 #!/usr/bin/env python
+
+# Copyright 2015- 2017:
+#   The Royal Institution for the Advancement of Learning McGill University,
+#   Centre National de la Recherche Scientifique,
+#   University of Southern California,
+#   Concordia University
 #
-# Copyright (C) 2015
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
 #
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 import simplejson
 import os.path as op
 from jsonschema import validate, ValidationError


### PR DESCRIPTION
- Updated validator to verify that command-line keys can be recycled over unique ids, so long as:
  - neither is required,
  - they are members of the same mutually exclusive group
- Updated examples to test successful and failed implementation of this feature
- Ensured we kept full test coverage of the validator after changes
- Updated licensing in a couple files