### PR TITLE
added resource requirements/suggestions to schema

### DIFF
--- a/tools/python/boutiques/schema/descriptor.schema.json
+++ b/tools/python/boutiques/schema/descriptor.schema.json
@@ -97,12 +97,6 @@
             "description": "Version of the schema used.",
             "enum": ["0.4"]
         },
-        "walltime-estimate": {
-            "id": "http://github.com/boutiques/boutiques-schema/walltime-estimate",
-            "type": "number",
-            "description": "Estimated wall time of a task in seconds.",
-            "minLength": 1
-        },
         "environment-variables": {
             "id": "http://github.com/boutiques/boutiques-schema/environment-variables",
             "type": "array",
@@ -490,6 +484,42 @@
         "invocation-schema": {
             "id": "http://github.com/boutiques/boutiques-schema/invocation-schema",
             "type": "object"
+        },
+				"suggested-resources": {
+            "id": "http://github.com/boutiques/boutiques-schema/suggested-resources",
+						"type": "object",
+            "properties": {
+                "cpu-cores": {
+                    "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/cpu-cores",
+                    "description": "The requested number of cpu cores to run the described application",
+                    "type": "integer",
+										"minimum": 1
+                },
+                "ram": {
+                    "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/ram",
+                    "description": "The requested number of GB RAM to run the described application",
+                    "type": "number",
+										"minimum": 0
+                },
+                "disk-space": {
+                    "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/disk-space",
+                    "description": "The requested number of GB of storage to run the described application",
+                    "type": "number",
+										"minimum": 0
+                },
+                "nodes": {
+                    "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/nodes",
+                    "description": "The requested number of nodes to spread the described application across",
+                    "type": "integer",
+										"minimum": 1
+                },
+       				  "walltime-estimate": {
+       				      "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/walltime-estimate",
+       				      "type": "number",
+       				      "description": "Estimated wall time of a task in seconds.",
+       				      "minimum": 0
+       				  }
+				    }
         },
         "custom": {
             "id": "http://github.com/boutiques/boutiques-schema/custom",

--- a/tools/python/boutiques/schema/descriptor.schema.json
+++ b/tools/python/boutiques/schema/descriptor.schema.json
@@ -485,41 +485,41 @@
             "id": "http://github.com/boutiques/boutiques-schema/invocation-schema",
             "type": "object"
         },
-				"suggested-resources": {
+        "suggested-resources": {
             "id": "http://github.com/boutiques/boutiques-schema/suggested-resources",
-						"type": "object",
+            "type": "object",
             "properties": {
                 "cpu-cores": {
                     "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/cpu-cores",
                     "description": "The requested number of cpu cores to run the described application",
                     "type": "integer",
-										"minimum": 1
+                    "minimum": 1
                 },
                 "ram": {
                     "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/ram",
                     "description": "The requested number of GB RAM to run the described application",
                     "type": "number",
-										"minimum": 0
+                    "minimum": 0
                 },
                 "disk-space": {
                     "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/disk-space",
                     "description": "The requested number of GB of storage to run the described application",
                     "type": "number",
-										"minimum": 0
+                    "minimum": 0
                 },
                 "nodes": {
                     "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/nodes",
                     "description": "The requested number of nodes to spread the described application across",
                     "type": "integer",
-										"minimum": 1
+                    "minimum": 1
                 },
-       				  "walltime-estimate": {
-       				      "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/walltime-estimate",
-       				      "type": "number",
-       				      "description": "Estimated wall time of a task in seconds.",
-       				      "minimum": 0
-       				  }
-				    }
+                 "walltime-estimate": {
+                     "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/walltime-estimate",
+                     "type": "number",
+                     "description": "Estimated wall time of a task in seconds.",
+                     "minimum": 0
+                 }
+            }
         },
         "custom": {
             "id": "http://github.com/boutiques/boutiques-schema/custom",

--- a/tools/python/boutiques/schema/examples/bad.json
+++ b/tools/python/boutiques/schema/examples/bad.json
@@ -9,7 +9,6 @@
     "index": "http://index.docker.io"
     },
   "schema-version": "0.4",
-  "walltime-estimate": 100,
   "groups": [
 		{
 			"id": "all_or_noner",

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -7,30 +7,34 @@
     "type": "docker",
     "image": "neurodata/ndmg:v0.0.41-1",
     "index": "http://index.docker.io",
-		"entrypoint": false
-    },
+    "entrypoint": false
+  },
   "schema-version": "0.4",
-  "walltime-estimate": 3600,
+  "suggested-resources": {
+    "cpu-cores": 1,
+    "ram": 12,
+    "walltime-estimate": 3600
+  },
   "groups": [
-		{
-			"id": "together_group",
-			"name": "these guys have to be toggled together",
-			"members": [
-				"extra1",
-				"extra2"
-			],
-			"all-or-none": true
-		},
-		{
-			"id": "dti_group",
-			"name": "Group of two possible dti input files",
-			"members": [
-				"dti_file",
-				"dti_file_minc"
-			],
-			"mutually-exclusive": true,
-			"one-is-required": true
-		},
+    {
+      "id": "together_group",
+      "name": "these guys have to be toggled together",
+      "members": [
+        "extra1",
+        "extra2"
+      ],
+      "all-or-none": true
+    },
+    {
+      "id": "dti_group",
+      "name": "Group of two possible dti input files",
+      "members": [
+        "dti_file",
+        "dti_file_minc"
+      ],
+      "mutually-exclusive": true,
+      "one-is-required": true
+    },
     {
       "id": "parcellation_group",
       "name": "Group of all used parcellations",


### PR DESCRIPTION
Addresses #63, https://github.com/boutiques/boutiques-paper/issues/7.

Towards `0.5`, here are the known breaks in backwards compatibility now:
- `walltime-estimate` now resides in `suggested-resources`
- singularity hub container now treated like docker