### PR TITLE
Added importer for 0.4 and 0.4.5. descriptors to 0.5

### DIFF
--- a/tools/python/boutiques/importer.py
+++ b/tools/python/boutiques/importer.py
@@ -26,20 +26,74 @@
 
 from argparse import ArgumentParser
 from jsonschema import ValidationError
+from boutiques.validator import validate_json
+import json
 import os
 
 
 class Importer():
 
-    def __init__(self,app_dir,output_file):
-        self.app_dir = app_dir
-        path, fil = os.path.split(__file__)
-        self.template_file = os.path.join(path, "bids-app-template", "template.json")
+    def __init__(self, output_file):
         self.output_file = output_file
+    
+    def upgrade_04(self, input_file):
+        """
+         Differences between 0.4 and current (0.5):
+           -schema version (obv)
+           -singularity should now be represented same as docker
+           -walltime should be part of suggested_resources structure
+        
+        I.e.
+        "schema-version": "0.4",
+                    ...... becomes.....
+        "schema-version": "0.5",
+        
+        I.e.  
+        "container-image": {
+          "type": "singularity",
+          "url": "shub://gkiar/ndmg-cbrain:master"
+          },
+                    ...... becomes.....
+        "container-image": {
+          "type": "singularity",
+          "image": "gkiar/ndmg-cbrain:master",
+          "index": "shub://",
+        },
 
-    def get_entry_point(self):
+        I.e. 
+        "walltime-estimate": 3600,
+                    ...... becomes.....
+        "suggested-resources": {
+          "walltime-estimate": 3600
+        },
+        """
+        with open(input_file, 'r') as fhandle:
+            descriptor = json.load(fhandle)
+
+        descriptor["schema-version"] = "0.5"
+
+        if "container-image" in descriptor.keys():
+            if "singularity" == descriptor["container-image"]["type"]:
+                url = descriptor["container-image"]["url"]
+                img = url.split("://")
+                if len(img) == 1:
+                    descriptor["container-image"]["image"] = img[0]
+                elif len(img) == 2:
+                    descriptor["container-image"]["image"] = img[1]
+                    descriptor["container-image"]["index"] = img[0] + "://"
+                del descriptor["container-image"]["url"]
+
+        if "walltime-estimate" in descriptor.keys():
+            descriptor["suggested-resources"] = {"walltime-estimate": descriptor["walltime-estimate"]}
+            del descriptor["walltime-estimate"]
+
+        with open(self.output_file, 'w') as fhandle:
+            fhandle.write(json.dumps(descriptor, indent=4))
+        validate_json(self.output_file)
+
+    def get_entry_point(self, app_dir):
         entrypoint = None
-        with open(os.path.join(self.app_dir,"Dockerfile")) as f:
+        with open(os.path.join(app_dir,"Dockerfile")) as f:
             content = f.readlines()
         for line in content:
             split = line.split()
@@ -47,16 +101,19 @@ class Importer():
                 entrypoint = split[1].strip("[]\"")
         return entrypoint
             
-    def import_bids(self):
-        with open(self.template_file) as f:
+    def import_bids(self, app_dir):
+        path, fil = os.path.split(__file__)
+        template_file = os.path.join(path, "bids-app-template", "template.json")
+
+        with open(template_file) as f:
             template_string = f.read()
 
         errors = []
-        app_name = os.path.basename(os.path.abspath(self.app_dir))
-        with open(os.path.join(self.app_dir,"version"),"r") as f:
+        app_name = os.path.basename(os.path.abspath(app_dir))
+        with open(os.path.join(app_dir,"version"),"r") as f:
             version = f.read().strip()
         git_repo = "https://github.com/BIDS-Apps/"+app_name
-        entrypoint = self.get_entry_point()
+        entrypoint = self.get_entry_point(app_dir)
         container_image = "bids/"+app_name
         analysis_types = "participant\", \"group\", \"session"
 
@@ -81,12 +138,18 @@ def main(args=None):
 
     # Arguments parsing
     parser = ArgumentParser()
-    parser.add_argument("bids_app_dir", help="Root directory of the BIDS app to import.")
+    parser.add_argument("importing", help="Type of import we are performing",
+                        choices=['bids', '0.4'])
     parser.add_argument("output_file", help="File where the Boutiques descriptor will be written.")
+    parser.add_argument("--input_file", help="File for existing Boutiques descriptor of older version")
+    parser.add_argument("--bids_app_dir", help="Root directory of the BIDS app to import.")
     results = parser.parse_args() if args is None else parser.parse_args(args)
-    
-    importer = Importer(results.bids_app_dir,results.output_file)
-    importer.import_bids()
+
+    importer = Importer(results.output_file)
+    if results.importing == '0.4':
+        importer.upgrade_04(results.input_file)
+    elif results.importing == 'bids':
+        importer.import_bids(results.bids_app_dir)
 
 # Execute program
 if  __name__ == "__main__":

--- a/tools/python/boutiques/schema/examples/upgrade04.json
+++ b/tools/python/boutiques/schema/examples/upgrade04.json
@@ -1,0 +1,235 @@
+{
+  "name": "ndmg",
+  "tool-version": "v0.0.50s",
+  "description": "dwi connectome estimation pipeline",
+  "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN]",
+  "container-image": {
+    "type": "singularity",
+    "url": "shub://gkiar/ndmg-cbrain:master"
+    },
+  "schema-version": "0.4",
+  "walltime-estimate": 3600,
+  "groups": [
+    {
+      "id": "parcellation_group",
+      "name": "Group of all used parcellations",
+      "members": [
+        "desikan",
+        "jhu",
+        "talairach",
+        "aal",
+        "harvardoxford",
+        "cpac200"
+      ],
+      "one-is-required": true
+    }
+  ],
+  "inputs": [
+    {
+      "id": "dti_file",
+      "name": "Diffusion Tensor Image",
+      "type": "File",
+      "value-key": "[DTI]",
+      "optional": false
+    },
+    {
+      "id": "bval_file",
+      "name": "B-values file",
+      "type": "File",
+      "value-key": "[BVAL]",
+      "optional": false
+    },
+    {
+      "id": "bvec_file",
+      "name": "Gradient vectors file",
+      "type": "File",
+      "value-key": "[BVEC]",
+      "optional": false
+    },
+    {
+      "id": "mprage_file",
+      "name": "Structural scan file",
+      "type": "File",
+      "value-key": "[MPRAGE]",
+      "optional": false
+    },
+    {
+      "id": "atlas",
+      "name": "Atlas image (MNI152)",
+      "type": "String",
+      "value-key": "[ATLAS]",
+      "optional": false,
+      "value-choices": [
+        "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
+      ]
+    },
+    {
+      "id": "mask",
+      "name": "Atlas brain mask",
+      "type": "String",
+      "value-key": "[MASK]",
+      "optional": false,
+      "value-choices": [
+        "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
+      ]
+    },
+    {
+      "id": "outdir",
+      "name": "Output directory",
+      "type": "String",
+      "value-key": "[OUTDIR]",
+      "optional": false
+    },
+    {
+      "id": "desikan",
+      "name": "Desikan parcellation",
+      "type": "String",
+      "value-key": "[DESIKAN]",
+      "optional": true,
+      "value-choices": [
+        "/ndmg_atlases/labels/desikan.nii.gz"
+      ]
+    },
+    {
+      "id": "jhu",
+      "name": "JHU parcellation",
+      "type": "String",
+      "value-key": "[JHU]",
+      "optional": true,
+      "value-choices": [
+        "/ndmg_atlases/labels/JHU.nii.gz"
+      ]
+    },
+    {
+      "id": "talairach",
+      "name": "Talairach parcellation",
+      "type": "String",
+      "value-key": "[TALAIRACH]",
+      "optional": true,
+      "value-choices": [
+        "/ndmg_atlases/labels/Talairach.nii.gz"
+      ]
+    },
+    {
+      "id": "aal",
+      "name": "AAL parcellation",
+      "type": "String",
+      "value-key": "[AAL]",
+      "optional": true,
+      "value-choices": [
+        "/ndmg_atlases/labels/AAL.nii.gz"
+      ]
+    },
+    {
+      "id": "harvardoxford",
+      "name": "Harvard-Oxford parcellation",
+      "type": "String",
+      "value-key": "[HARVARDOXFORD]",
+      "optional": true,
+      "value-choices": [
+        "/ndmg_atlases/labels/HarvardOxford.nii.gz"
+      ]
+    },
+    {
+      "id": "cpac200",
+      "name": "CPAC200 parcellation",
+      "type": "String",
+      "value-key": "[CPAC200]",
+      "optional": true,
+      "value-choices": [
+        "/ndmg_atlases/labels/CPAC200.nii.gz"
+      ]
+    },
+    {
+      "id": "clean",
+      "name": "Clean-up flag",
+      "type": "Flag",
+      "value-key": "[CLEAN]",
+      "optional": true,
+      "command-line-flag": "-c"
+    }
+  ],
+  "output-files": [
+    {
+      "id": "aligned_dti",
+      "name": "Aligned DTI volume",
+      "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz",
+      "path-template-stripped-extensions": [
+        ".nii", ".nii.gz"
+      ],
+      "optional": true
+    },
+    {
+      "id": "tensors",
+      "name": "Tensor maps",
+      "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz",
+      "path-template-stripped-extensions": [
+        ".nii", ".nii.gz"
+      ],
+      "optional": true
+    },
+    {
+      "id": "fibers",
+      "name": "Fiber streamlines",
+      "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz",
+      "path-template-stripped-extensions": [
+        ".nii", ".nii.gz"
+      ],
+      "optional": true
+    },
+    {
+      "id": "desikan_graph",
+      "name": "Desikan graph",
+      "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle",
+      "path-template-stripped-extensions": [
+        ".nii", ".nii.gz"
+      ],
+      "optional": true
+    },
+    {
+      "id": "jhu_graph",
+      "name": "JHU graph",
+      "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle",
+      "path-template-stripped-extensions": [
+        ".nii", ".nii.gz"
+      ],
+      "optional": true
+    },
+    {
+      "id": "talairach_graph",
+      "name": "Talairach graph",
+      "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle",
+      "path-template-stripped-extensions": [
+        ".nii", ".nii.gz"
+      ],
+      "optional": true
+    },
+    {
+      "id": "aal_graph",
+      "name": "AAL graph",
+      "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle",
+      "path-template-stripped-extensions": [
+        ".nii", ".nii.gz"
+      ],
+      "optional": true
+    },
+    {
+      "id": "harvardoxford_graph",
+      "name": "Harvard-Oxford graph",
+      "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle",
+      "path-template-stripped-extensions": [
+        ".nii", ".nii.gz"
+      ],
+      "optional": true
+    },
+    {
+      "id": "cpac200_graph",
+      "name": "CPAC200 graph",
+      "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle",
+      "path-template-stripped-extensions": [
+        ".nii", ".nii.gz"
+      ],
+      "optional": true
+    }
+  ]
+}

--- a/tools/python/boutiques/tests/test_import.py
+++ b/tools/python/boutiques/tests/test_import.py
@@ -13,14 +13,26 @@ import os
 
 class TestImport(TestCase):
 
-    def test_import_good(self):
-        bids_app = op.join(op.split(bofile)[0], 'schema/examples/bids-apps/example_good')
-        self.assertFalse(main(args=[bids_app, 'test-import.json']))
+    def test_import_bids_good(self):
+        bids_app = op.join(op.split(bofile)[0], "schema/examples/bids-apps/example_good")
+        self.assertFalse(main(args=["bids",
+                                    "--bids_app_dir", bids_app,
+                                    "test-import.json"]))
 
-    def test_import_bad(self):
-        bids_app = op.join(op.split(bofile)[0], 'schema/examples/bids-apps/example_bad')
-        self.assertRaises(ValidationError, main, [bids_app, 'test-import.json'])
+    def test_import_bids_bad(self):
+        bids_app = op.join(op.split(bofile)[0], "schema/examples/bids-apps/example_bad")
+        self.assertRaises(ValidationError, main, ["bids",
+                                                  "--bids_app_dir", bids_app,
+                                                  "test-import.json"])
 
-    def test_import_valid(self):
-        self.assertFalse(main_validate(args=['-b','test-import.json']))
-        os.remove('test-import.json')
+    def test_import_bids_valid(self):
+        self.assertFalse(main_validate(args=["-b","test-import.json"]))
+        os.remove("test-import.json")
+
+    def test_upgrade_04(self):
+        fin = op.join(op.split(bofile)[0], "schema/examples/upgrade04.json")
+        fout = op.join(op.split(bofile)[0], "schema/examples/upgraded05.json")
+        self.assertFalse(main(args=["0.4",  fout,
+                                    "--input_file", fin]))
+        os.remove(fout)
+        

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -52,7 +52,7 @@ def validate_json(json_file):
     try:
         validate(descriptor, schema)
     except ValidationError as e:
-        print("JSON Validation error (Boutiques validation not yet performed)")
+        print("JSON Validation error (Rigorous Boutiques validation not yet performed)")
         raise ValidationError(e)
 
     # Helper get-function

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.5.0"
+VERSION = "0.5.1"
 DEPS = [
          "simplejson",
          "jsonschema",


### PR DESCRIPTION
 - Adds importer for `0.4` versions of boutiques
 - Verified structure of current singularity implementations for all known singularity descriptors deployed in CBRAIN with Natacha, and that this importer properly handles them 
 - Added appropriate test