### PR TITLE
updated importer to fix broken docker indices

### DIFF
--- a/tools/python/boutiques/importer.py
+++ b/tools/python/boutiques/importer.py
@@ -82,6 +82,8 @@ class Importer():
                     descriptor["container-image"]["image"] = img[1]
                     descriptor["container-image"]["index"] = img[0] + "://"
                 del descriptor["container-image"]["url"]
+            elif "docker" == descriptor["container-image"]["type"]:
+                url = descriptor["container-image"]["index"] = descriptor["container-image"]["index"].split("://")[1]
 
         if "walltime-estimate" in descriptor.keys():
             descriptor["suggested-resources"] = {"walltime-estimate": descriptor["walltime-estimate"]}

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -1,281 +1,290 @@
 {
-  "name": "ndmg",
-  "tool-version": "v0.0.41-1",
-  "description": "dwi connectome estimation pipeline",
-  "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN] [EXTRA1] [EXTRA2]",
-  "container-image": {
-    "type": "docker",
-    "image": "neurodata/ndmg:v0.0.41-1",
-    "index": "http://index.docker.io",
-    "entrypoint": false
-  },
-  "schema-version": "0.5",
-  "suggested-resources": {
-    "cpu-cores": 1,
-    "ram": 12,
-    "walltime-estimate": 3600
-  },
-  "groups": [
-    {
-      "id": "together_group",
-      "name": "these guys have to be toggled together",
-      "members": [
-        "extra1",
-        "extra2"
-      ],
-      "all-or-none": true
+    "name": "ndmg",
+    "tool-version": "v0.0.41-1",
+    "description": "dwi connectome estimation pipeline",
+    "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN] [EXTRA1] [EXTRA2]",
+    "container-image": {
+        "type": "docker",
+        "image": "neurodata/ndmg:v0.0.41-1",
+        "index": "index.docker.io",
+        "entrypoint": false
     },
-    {
-      "id": "dti_group",
-      "name": "Group of two possible dti input files",
-      "members": [
-        "dti_file",
-        "dti_file_minc"
-      ],
-      "mutually-exclusive": true,
-      "one-is-required": true
+    "schema-version": "0.5",
+    "suggested-resources": {
+        "cpu-cores": 1,
+        "ram": 12,
+        "walltime-estimate": 3600
     },
-    {
-      "id": "parcellation_group",
-      "name": "Group of all used parcellations",
-      "members": [
-        "desikan",
-        "jhu",
-        "talairach",
-        "aal",
-        "harvardoxford",
-        "cpac200"
-      ],
-      "one-is-required": true
-    }
-  ],
-  "inputs": [
-    {
-      "id": "dti_file",
-      "name": "Diffusion Tensor Image",
-      "type": "File",
-      "value-key": "[DTI]",
-      "optional": true
-    },
-    {
-      "id": "extra1",
-      "name": "optional thing at the end",
-      "type": "File",
-      "value-key": "[EXTRA1]",
-      "optional": true
-    },
-    {
-      "id": "extra2",
-      "name": "optional thing at the end",
-      "type": "File",
-      "value-key": "[EXTRA2]",
-      "optional": true
-    },
-    {
-      "id": "dti_file_minc",
-      "name": "Diffusion Tensor Image",
-      "type": "File",
-      "value-key": "[DTI]",
-      "optional": true
-    },
-    {
-      "id": "bval_file",
-      "name": "B-values file",
-      "type": "File",
-      "value-key": "[BVAL]",
-      "optional": false
-    },
-    {
-      "id": "bvec_file",
-      "name": "Gradient vectors file",
-      "type": "File",
-      "value-key": "[BVEC]",
-      "optional": false
-    },
-    {
-      "id": "mprage_file",
-      "name": "Structural scan file",
-      "type": "File",
-      "value-key": "[MPRAGE]",
-      "optional": false
-    },
-    {
-      "id": "atlas",
-      "name": "Atlas image (MNI152)",
-      "type": "String",
-      "value-key": "[ATLAS]",
-      "optional": false,
-      "value-choices": [
-        "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
-      ]
-    },
-    {
-      "id": "mask",
-      "name": "Atlas brain mask",
-      "type": "String",
-      "value-key": "[MASK]",
-      "optional": false,
-      "value-choices": [
-        "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
-      ]
-    },
-    {
-      "id": "outdir",
-      "name": "Output directory",
-      "type": "String",
-      "value-key": "[OUTDIR]",
-      "optional": false
-    },
-    {
-      "id": "desikan",
-      "name": "Desikan parcellation",
-      "type": "String",
-      "value-key": "[DESIKAN]",
-      "optional": true,
-      "value-choices": [
-        "/ndmg_atlases/labels/desikan.nii.gz"
-      ]
-    },
-    {
-      "id": "jhu",
-      "name": "JHU parcellation",
-      "type": "String",
-      "value-key": "[JHU]",
-      "optional": true,
-      "value-choices": [
-        "/ndmg_atlases/labels/JHU.nii.gz"
-      ]
-    },
-    {
-      "id": "talairach",
-      "name": "Talairach parcellation",
-      "type": "String",
-      "value-key": "[TALAIRACH]",
-      "optional": true,
-      "value-choices": [
-        "/ndmg_atlases/labels/Talairach.nii.gz"
-      ]
-    },
-    {
-      "id": "aal",
-      "name": "AAL parcellation",
-      "type": "String",
-      "value-key": "[AAL]",
-      "optional": true,
-      "value-choices": [
-        "/ndmg_atlases/labels/AAL.nii.gz"
-      ]
-    },
-    {
-      "id": "harvardoxford",
-      "name": "Harvard-Oxford parcellation",
-      "type": "String",
-      "value-key": "[HARVARDOXFORD]",
-      "optional": true,
-      "value-choices": [
-        "/ndmg_atlases/labels/HarvardOxford.nii.gz"
-      ]
-    },
-    {
-      "id": "cpac200",
-      "name": "CPAC200 parcellation",
-      "type": "String",
-      "value-key": "[CPAC200]",
-      "optional": true,
-      "value-choices": [
-        "/ndmg_atlases/labels/CPAC200.nii.gz"
-      ]
-    },
-    {
-      "id": "clean",
-      "name": "Clean-up flag",
-      "type": "Flag",
-      "value-key": "[CLEAN]",
-      "optional": true,
-      "command-line-flag": "-c"
-    }
-  ],
-  "output-files": [
-    {
-      "id": "aligned_dti",
-      "name": "Aligned DTI volume",
-      "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz",
-      "path-template-stripped-extensions": [
-        ".nii", ".nii.gz"
-      ],
-      "optional": true
-    },
-    {
-      "id": "tensors",
-      "name": "Tensor maps",
-      "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz",
-      "path-template-stripped-extensions": [
-        ".nii", ".nii.gz"
-      ],
-      "optional": true
-    },
-    {
-      "id": "fibers",
-      "name": "Fiber streamlines",
-      "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz",
-      "path-template-stripped-extensions": [
-        ".nii", ".nii.gz"
-      ],
-      "optional": true
-    },
-    {
-      "id": "desikan_graph",
-      "name": "Desikan graph",
-      "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle",
-      "path-template-stripped-extensions": [
-        ".nii", ".nii.gz"
-      ],
-      "optional": true
-    },
-    {
-      "id": "jhu_graph",
-      "name": "JHU graph",
-      "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle",
-      "path-template-stripped-extensions": [
-        ".nii", ".nii.gz"
-      ],
-      "optional": true
-    },
-    {
-      "id": "talairach_graph",
-      "name": "Talairach graph",
-      "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle",
-      "path-template-stripped-extensions": [
-        ".nii", ".nii.gz"
-      ],
-      "optional": true
-    },
-    {
-      "id": "aal_graph",
-      "name": "AAL graph",
-      "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle",
-      "path-template-stripped-extensions": [
-        ".nii", ".nii.gz"
-      ],
-      "optional": true
-    },
-    {
-      "id": "harvardoxford_graph",
-      "name": "Harvard-Oxford graph",
-      "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle",
-      "path-template-stripped-extensions": [
-        ".nii", ".nii.gz"
-      ],
-      "optional": true
-    },
-    {
-      "id": "cpac200_graph",
-      "name": "CPAC200 graph",
-      "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle",
-      "path-template-stripped-extensions": [
-        ".nii", ".nii.gz"
-      ],
-      "optional": true
-    }
-  ]
+    "groups": [
+        {
+            "id": "together_group",
+            "name": "these guys have to be toggled together",
+            "members": [
+                "extra1",
+                "extra2"
+            ],
+            "all-or-none": true
+        },
+        {
+            "id": "dti_group",
+            "name": "Group of two possible dti input files",
+            "members": [
+                "dti_file",
+                "dti_file_minc"
+            ],
+            "mutually-exclusive": true,
+            "one-is-required": true
+        },
+        {
+            "id": "parcellation_group",
+            "name": "Group of all used parcellations",
+            "members": [
+                "desikan",
+                "jhu",
+                "talairach",
+                "aal",
+                "harvardoxford",
+                "cpac200"
+            ],
+            "one-is-required": true
+        }
+    ],
+    "inputs": [
+        {
+            "id": "dti_file",
+            "name": "Diffusion Tensor Image",
+            "type": "File",
+            "value-key": "[DTI]",
+            "optional": true
+        },
+        {
+            "id": "extra1",
+            "name": "optional thing at the end",
+            "type": "File",
+            "value-key": "[EXTRA1]",
+            "optional": true
+        },
+        {
+            "id": "extra2",
+            "name": "optional thing at the end",
+            "type": "File",
+            "value-key": "[EXTRA2]",
+            "optional": true
+        },
+        {
+            "id": "dti_file_minc",
+            "name": "Diffusion Tensor Image",
+            "type": "File",
+            "value-key": "[DTI]",
+            "optional": true
+        },
+        {
+            "id": "bval_file",
+            "name": "B-values file",
+            "type": "File",
+            "value-key": "[BVAL]",
+            "optional": false
+        },
+        {
+            "id": "bvec_file",
+            "name": "Gradient vectors file",
+            "type": "File",
+            "value-key": "[BVEC]",
+            "optional": false
+        },
+        {
+            "id": "mprage_file",
+            "name": "Structural scan file",
+            "type": "File",
+            "value-key": "[MPRAGE]",
+            "optional": false
+        },
+        {
+            "id": "atlas",
+            "name": "Atlas image (MNI152)",
+            "type": "String",
+            "value-key": "[ATLAS]",
+            "optional": false,
+            "value-choices": [
+                "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
+            ]
+        },
+        {
+            "id": "mask",
+            "name": "Atlas brain mask",
+            "type": "String",
+            "value-key": "[MASK]",
+            "optional": false,
+            "value-choices": [
+                "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
+            ]
+        },
+        {
+            "id": "outdir",
+            "name": "Output directory",
+            "type": "String",
+            "value-key": "[OUTDIR]",
+            "optional": false
+        },
+        {
+            "id": "desikan",
+            "name": "Desikan parcellation",
+            "type": "String",
+            "value-key": "[DESIKAN]",
+            "optional": true,
+            "value-choices": [
+                "/ndmg_atlases/labels/desikan.nii.gz"
+            ]
+        },
+        {
+            "id": "jhu",
+            "name": "JHU parcellation",
+            "type": "String",
+            "value-key": "[JHU]",
+            "optional": true,
+            "value-choices": [
+                "/ndmg_atlases/labels/JHU.nii.gz"
+            ]
+        },
+        {
+            "id": "talairach",
+            "name": "Talairach parcellation",
+            "type": "String",
+            "value-key": "[TALAIRACH]",
+            "optional": true,
+            "value-choices": [
+                "/ndmg_atlases/labels/Talairach.nii.gz"
+            ]
+        },
+        {
+            "id": "aal",
+            "name": "AAL parcellation",
+            "type": "String",
+            "value-key": "[AAL]",
+            "optional": true,
+            "value-choices": [
+                "/ndmg_atlases/labels/AAL.nii.gz"
+            ]
+        },
+        {
+            "id": "harvardoxford",
+            "name": "Harvard-Oxford parcellation",
+            "type": "String",
+            "value-key": "[HARVARDOXFORD]",
+            "optional": true,
+            "value-choices": [
+                "/ndmg_atlases/labels/HarvardOxford.nii.gz"
+            ]
+        },
+        {
+            "id": "cpac200",
+            "name": "CPAC200 parcellation",
+            "type": "String",
+            "value-key": "[CPAC200]",
+            "optional": true,
+            "value-choices": [
+                "/ndmg_atlases/labels/CPAC200.nii.gz"
+            ]
+        },
+        {
+            "id": "clean",
+            "name": "Clean-up flag",
+            "type": "Flag",
+            "value-key": "[CLEAN]",
+            "optional": true,
+            "command-line-flag": "-c"
+        }
+    ],
+    "output-files": [
+        {
+            "id": "aligned_dti",
+            "name": "Aligned DTI volume",
+            "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz",
+            "path-template-stripped-extensions": [
+                ".nii",
+                ".nii.gz"
+            ],
+            "optional": true
+        },
+        {
+            "id": "tensors",
+            "name": "Tensor maps",
+            "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz",
+            "path-template-stripped-extensions": [
+                ".nii",
+                ".nii.gz"
+            ],
+            "optional": true
+        },
+        {
+            "id": "fibers",
+            "name": "Fiber streamlines",
+            "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz",
+            "path-template-stripped-extensions": [
+                ".nii",
+                ".nii.gz"
+            ],
+            "optional": true
+        },
+        {
+            "id": "desikan_graph",
+            "name": "Desikan graph",
+            "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle",
+            "path-template-stripped-extensions": [
+                ".nii",
+                ".nii.gz"
+            ],
+            "optional": true
+        },
+        {
+            "id": "jhu_graph",
+            "name": "JHU graph",
+            "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle",
+            "path-template-stripped-extensions": [
+                ".nii",
+                ".nii.gz"
+            ],
+            "optional": true
+        },
+        {
+            "id": "talairach_graph",
+            "name": "Talairach graph",
+            "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle",
+            "path-template-stripped-extensions": [
+                ".nii",
+                ".nii.gz"
+            ],
+            "optional": true
+        },
+        {
+            "id": "aal_graph",
+            "name": "AAL graph",
+            "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle",
+            "path-template-stripped-extensions": [
+                ".nii",
+                ".nii.gz"
+            ],
+            "optional": true
+        },
+        {
+            "id": "harvardoxford_graph",
+            "name": "Harvard-Oxford graph",
+            "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle",
+            "path-template-stripped-extensions": [
+                ".nii",
+                ".nii.gz"
+            ],
+            "optional": true
+        },
+        {
+            "id": "cpac200_graph",
+            "name": "CPAC200 graph",
+            "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle",
+            "path-template-stripped-extensions": [
+                ".nii",
+                ".nii.gz"
+            ],
+            "optional": true
+        }
+    ]
 }


### PR DESCRIPTION
These broken indices are common, so this will remove the `http://` in front of them.