### PR TITLE
bug fix in importer

### DIFF
--- a/tools/python/boutiques/importer.py
+++ b/tools/python/boutiques/importer.py
@@ -83,7 +83,7 @@ class Importer():
                     descriptor["container-image"]["index"] = img[0] + "://"
                 del descriptor["container-image"]["url"]
             elif "docker" == descriptor["container-image"]["type"] and descriptor["container-image"].get("index"):
-                url = descriptor["container-image"]["index"] = descriptor["container-image"]["index"].split("://")[1]
+                url = descriptor["container-image"]["index"] = descriptor["container-image"]["index"].split("://")[-1]
 
         if "walltime-estimate" in descriptor.keys():
             descriptor["suggested-resources"] = {"walltime-estimate": descriptor["walltime-estimate"]}

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.5.2.1"
+VERSION = "0.5.2.2"
 DEPS = [
          "simplejson",
          "jsonschema",


### PR DESCRIPTION
- would return an `indexError` unintentionally if no "`http://|https://`" were at the start of the Docker `container_index`, as it was trying to access the second (`[1]`) element in a 1-element list. Now, looks at the last element (`[-1]`) which can be either.
