### PR TITLE
removed -n option with random generation

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -93,21 +93,18 @@ def execute(*params):
                             help="The Boutiques descriptor.")
         parser.add_argument("-i", "--input", action="store",
                             help="Input JSON complying to invocation.")
-        parser.add_argument("-r", "--random", action="store_true",
-                            help="Generate random set of inputs.")
-        parser.add_argument("-n", "--number", type=int, action="store",
-                            help="Number of random input sets to create.")
+        parser.add_argument("-r", "--random", action="store", type=int,
+                            nargs="*", help="Generate random set of inputs.")
         results = parser.parse_args(params)
         descriptor = results.descriptor
 
         # Do some basic input scrubbing
         inp = results.input
-        rand = results.random
-        numb = results.number
+        rand = results.random is not None
+        numb = results.random[0] if rand and len(results.random) > 0 else 1
+
         if numb and numb < 1:
             raise SystemExit("--number value must be positive.")
-        if numb and not rand:
-            raise SystemExit("--number value requires --random setting.")
         if rand and inp:
             raise SystemExit("--random setting and --input value cannot be used together.")
         if inp and not os.path.isfile(inp):
@@ -118,8 +115,6 @@ def execute(*params):
             raise SystemExit("JSON descriptor {} does not seem to exist.".format(descriptor))
         if not rand and not inp:
             raise SystemExit("The default mode requires an input (-i).")
-        if not numb:
-            numb = 1
 
         # Generate object that will perform the commands
         from boutiques.localExec import LocalExecutor

--- a/tools/python/boutiques/tests/test_example1.py
+++ b/tools/python/boutiques/tests/test_example1.py
@@ -32,4 +32,4 @@ class TestExample1(TestCase):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")       
         self.assertFalse(bosh(["exec", "simulate",
                                os.path.join(example1_dir, "example1.json"),
-                               "-r", "-n", "3"]))
+                               "-r", "3"]))

--- a/tools/python/boutiques/tests/test_exec.py
+++ b/tools/python/boutiques/tests/test_exec.py
@@ -52,15 +52,14 @@ class TestExec(TestCase):
         self.assertRaises(SystemExit, bosh, ["exec", "simulate",
                                              os.path.join(example1_dir,
                                                           "example1.json"),
-                                             "-n", "-2"])
+                                             "-r", "-2"])
+        self.assertFalse(bosh(["exec", "simulate",
+                               os.path.join(example1_dir,"example1.json"),
+                               "-r", "1"]))
         self.assertRaises(SystemExit, bosh, ["exec", "simulate",
                                              os.path.join(example1_dir,
                                                           "example1.json"),
-                                             "-n", "1"])
-        self.assertRaises(SystemExit, bosh, ["exec", "simulate",
-                                             os.path.join(example1_dir,
-                                                          "example1.json"),
-                                             "-r", "-i",
+                                             "-r", "1", "-i",
                                              os.path.join(example1_dir,
                                                           "invocation.json")])
         self.assertRaises(SystemExit, bosh, ["exec", "simulate",

--- a/tools/python/cleanup_tests.sh
+++ b/tools/python/cleanup_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+#
+# WARNING: Do not use if you have made changes to the `good.json` descriptor
+# and have not yet committed them!
+#
+
+rm temp-*.sh log-*.txt config*.txt
+git checkout boutiques/schema/examples/good.json


### PR DESCRIPTION
Also added a script to clean-up test files (and revert changes to the `good.json`) after running tests.

Addresses #164 