### PR TITLE
Added `query` functionality to Bosh

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,24 @@ in with the `-i` flag rather than using the `-r` and `-n` flags. Again, as I'm s
 ### Launch Your Tool
 
 Your descriptor has now been vetted both by the validator and simulation to describe meaningful command-lines for your tool - now it's time
-to put it to work! You can also use the `exec` function to launch an analysis, provided you've described your inputs in `inputs.json` with the
+to put it to work! You can also use the `exec` function to launch an analysis, provided you've described your inputs in `invocation.json` with the
 matching key-value pairs as in your descriptor (this is called the `invocationSchema`, which you can also generate and learn about with
 `bosh invocation`). One catch: we assume you have [Docker](https://docker.com) or [Singularity](https://singularity.lbl.gov) installed. A fair
 assumption, nowadays? We hope so:
 
-    $ bosh exec launch descriptor.json inputs.json
+    $ bosh exec launch descriptor.json invocation.json
 
 You just launched your tool! You should be seeing outputs to your terminal, and by default your current working directory will be mounted to the
 container. You can mount more volumes with `-v` (consistent with Docker), and see what other options are available, such as switching users in
 the container, through the usual help menu, `bosh exec launch -h`.
+
+### Query Your Tool
+
+If you've been using your tool and forget what exactly that output file will be named, or if it's optional, but find re-reading the descriptor a
+bit cumbersome, you should just query your invocation! If we wanted to check the location of our output corresponding to the id `my_batmobile`, or
+which of our inputs are numbers and optional, we could do the following two queries, respectively:
+
+    $ bosh query descriptor.json invocation.json output-files/id=my_batmobile inputs/type=Number,optional=True
 
 ### Publish Your Tool
 

--- a/tools/python/boutiques/__init__.py
+++ b/tools/python/boutiques/__init__.py
@@ -5,6 +5,7 @@ from .invocationSchemaHandler import generateInvocationSchema
 from .validator import validate_descriptor
 from .bids import validate_bids
 from .publisher import Publisher
+from .query import queryEngine
 from .bosh import *
 
 __all__ = ['localExec',
@@ -12,5 +13,6 @@ __all__ = ['localExec',
            'validator',
            'bids',
            'publisher',
+           'query',
            'bosh']
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -11,14 +11,20 @@ def validate(*params):
                         help="The Boutiques descriptor.")
     parser.add_argument("--bids", "-b", action="store_true",
                         help="Flag indicating if descriptor is a BIDS app")
+    parser.add_argument("--invocation", "-i", action="store",
+                        help="Invocation to be validated against descriptor")
     results = parser.parse_args(params)
 
-    from boutiques.validator import validate_descriptor
-    descriptor = validate_descriptor(results.descriptor)
+    if results.invocation is None:
+        from boutiques.validator import validate_descriptor
+        descriptor = validate_descriptor(results.descriptor)
+        if results.bids:
+            from boutiques.bids import validate_bids
+            validate_bids(descriptor, valid=True)
 
-    if results.bids:
-        from boutiques.bids import validate_bids
-        validate_bids(descriptor, valid=True)
+    else:
+        from boutiques.validator import validate_invocation
+        invocation = validate_invocation(results.descriptor, results.invocation)
 
     # If it gets here without error, return code 0
     return 0

--- a/tools/python/boutiques/query.py
+++ b/tools/python/boutiques/query.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+# Copyright 2015 - 2017:
+#   The Royal Institution for the Advancement of Learning McGill University,
+#   Centre National de la Recherche Scientifique,
+#   University of Southern California,
+#   Concordia University
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+def queryEngine(executor, query):
+    try:
+        #TODO: improve splitting to not fail in valid situations
+        layers = query.split("/")[:-1]
+        conditions = query.split("/")[-1]
+        if len(conditions) > 0:
+            if "," in conditions:
+                conditions = conditions.split(",")
+            else:
+                conditions = [conditions]
+
+        objs = executor.desc_dict
+        for layer in layers:
+            objs = objs[layer]
+
+        query_result = {}
+        for obj in objs:
+            eligible = True
+            for cond in conditions:
+                lhs, rhs = cond.split("=")
+                try:
+                    rhs = float(rhs)
+                except ValueError:
+                    if rhs == "False":
+                        rhs = False
+                    elif rhs == "True":
+                        rhs = True
+
+                if obj[lhs] != rhs:
+                    eligible = False
+
+            if eligible:
+                if "output-files" in layers:
+                    query_result[obj["id"]] = executor.out_dict.get(obj["id"])
+                elif "inputs" in layers:
+                    # print(obj)
+                    query_result[obj["id"]] = executor.in_dict.get(obj["id"])
+                elif "groups" in layers:
+                    query_result[obj["id"]] = {mem : executor.in_dict.get(mem)
+                                               for mem in obj['members']}
+
+        return query_result
+
+    except:
+        print("Invalid query ({}). See --help.".format(query))
+        return {}
+

--- a/tools/python/boutiques/tests/test_query.py
+++ b/tools/python/boutiques/tests/test_query.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+
+import os
+from unittest import TestCase
+from boutiques import __file__ as bfile
+import boutiques as bosh
+
+class TestQuery(TestCase):
+
+    def set_examples(self):
+        example1_dir = os.path.join(os.path.dirname(bfile), "schema",
+                                    "examples", "example1")
+        self.desc = os.path.join(example1_dir, "example1.json")
+        self.invo = os.path.join(example1_dir, "invocation.json")
+
+    def test_queryoutput(self):
+        self.set_examples()
+        query = bosh.query(self.desc, self.invo, "output-files/")
+        expect = {'logfile': 'log-4.txt',
+                  'output_files': 'output/*_exampleOutputTag.resultType',
+                  'config_file': './config.txt'}
+        assert(query == expect)
+        
+        query = bosh.query(self.desc, self.invo, "output-files/id=logfile")
+        expect = {'logfile': 'log-4.txt'}
+        assert(query == expect)
+
+        query = bosh.query(self.desc, self.invo, "output-files/id=log-file")
+        expect = {}
+        assert(query == expect)
+
+    def test_queryinput(self):
+        self.set_examples()
+        query = bosh.query(self.desc, self.invo, "inputs/")
+        expect = {'str_input': ['foo', 'bar'],
+                  'config_num': 4,
+                  'num_input': None,
+                  'file_input': './setup.py',
+                  'enum_input': 'val1',
+                  'flag_input': None}
+        assert(query == expect)
+        
+        query = bosh.query(self.desc, self.invo,
+                           "inputs/type=Flag,id=flag_input",
+                           "inputs/type=Number")
+        expect = [ {'flag_input': None},
+                   {'config_num': 4,
+                    'num_input': None} ]
+        assert(query == expect)
+
+        query = bosh.query(self.desc, self.invo, "inputs/id=strinputs")
+        expect = {}
+        assert(query == expect)
+
+        query = bosh.query(self.desc, self.invo, "inputt/nonsense=strinputs")
+        expect = {}
+        assert(query == expect)
+
+    def test_querygroups(self):
+        self.set_examples()
+        query = bosh.query(self.desc, self.invo, "groups/")
+        expect = {'an_example_group': {'num_input': None,
+                                       'enum_input': 'val1'}}
+        assert(query == expect)
+        
+        query = bosh.query(self.desc, self.invo, "groups/mutually-exclusive=True")
+        expect = {'an_example_group': {'num_input': None,
+                                       'enum_input': 'val1'}}
+        assert(query == expect)
+

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -32,6 +32,26 @@ from boutiques import __file__ as bfile
 
 
 # Main validation module
+def validate_invocation(descriptor, invocation):
+    """
+    Validates the Boutiques invocation agasint the descriptor schema.
+    """
+    with open(descriptor) as fhandle:
+        descriptor = simplejson.load(fhandle)
+
+    with open(invocation) as fhandle:
+        invocation = simplejson.load(fhandle)
+
+    try:
+        validate(invocation, descriptor)
+    except ValidationError as e:
+        print("JSON Validation error")
+        raise ValidationError(e.message)
+    
+    print("Invocation validation OK")
+    return invocation
+
+# Main validation module
 def validate_descriptor(json_file):
     """
     Validates the Boutiques descriptor against the schema.


### PR DESCRIPTION
Bosh can now:
 - query the values of inputs, output-files, and groups pertaining to a descriptor and invocation
 - perform multiple chained queries
 - (this functionality exists consistently for both the python and shell apis)

Known bugs/things to fix while this is being reviewed:
 - when querying fields that cannot be found in any entry, query will throw an error
 - when not including a trailing slash, query will throw an error

### Example from the BIDS-Example descriptor and invocation found [here](https://github.com/gkiar/clowdr-dev/tree/master/examples/bet)

    $ bosh query descriptor.json invocation.json output-files/path-template=OUTPUT_DIR inputs/type=String,optional=False groups/
    [{'output_dir': 'ds114/outs/'}, {'analysis_level': 'participant'}, {'output_directory': {'output_dir_name': 'ds114/outs/', 'participant_level_analysis_dir': None}}]
