### PR TITLE
Tags and arrays

### DIFF
--- a/tools/python/boutiques/schema/descriptor.schema.json
+++ b/tools/python/boutiques/schema/descriptor.schema.json
@@ -128,7 +128,9 @@
                     "value"
                 ],
                 "additionalProperties": false
-            }
+            },
+	    "minItems": 1,
+	    "uniqueItems": true
         },
         "groups": {
             "id": "http://github.com/boutiques/boutiques-schema/groups",
@@ -188,7 +190,9 @@
                     "members"
                 ],
                 "additionalProperties": false
-            }
+            },
+	    "minItems": 1,
+	    "uniqueItems": true
         },
         "inputs": {
             "id": "http://github.com/boutiques/boutiques-schema/inputs",
@@ -376,7 +380,9 @@
                     "exclusive-maximum": ["maximum"]
                 },
                 "additionalProperties": false
-            }
+            },
+	    "minItems": 1,
+	    "uniqueItems": true
         },
         "output-files": {
             "id": "http://github.com/boutiques/boutiques-schema/output-files",
@@ -479,7 +485,9 @@
                     "command-line-flag-separator": ["command-line-flag"]
                 },
                 "additionalProperties": false
-            }
+            },
+	    "minItems": 1,
+	    "uniqueItems": true
         },
         "invocation-schema": {
             "id": "http://github.com/boutiques/boutiques-schema/invocation-schema",
@@ -519,6 +527,15 @@
                      "description": "Estimated wall time of a task in seconds.",
                      "minimum": 0
                  }
+            }
+        },
+	"tags": {
+            "id": "http://github.com/boutiques/boutiques-schema/tags",
+            "type": "object",
+            "description": "An set of key-value pairs specifying tags describing the pipeline. The tag names are open, they might be more constrained in the future.",
+	    "additionalProperties": {
+                "type": "string",
+                "description": "Tag values"
             }
         },
         "custom": {

--- a/tools/python/boutiques/schema/examples/example1/example1.json
+++ b/tools/python/boutiques/schema/examples/example1/example1.json
@@ -124,7 +124,12 @@
             "path-template": "./config.txt", 
             "value-key": "[CONFIG_FILE]"
         }
-    ], 
+    ],
+    "tags": {
+	"domain": "testing",
+	"programming-language": "Python",
+	"foo": "bar"
+    },
     "schema-version": "0.5", 
     "tool-version": "0.0.1"
 }

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -286,5 +286,10 @@
         "ram": 12,
         "walltime-estimate": 3600
     },
+    "tags": {
+	"domain": "testing",
+	"status": "experimental",
+	"foo": "bar"	
+    },
     "tool-version": "v0.0.41-1"
 }


### PR DESCRIPTION
A tool descriptor may now contain a set of tags such as:
```
"tags": {
	"domain": "testing",
	"programming-language": "Python",
	"foo": "bar"
    }
```
It addresses #186. This is required for https://github.com/fli-iam/CARMIN/issues/79 

Besides, arrays `inputs`, `environment-variables`, `output-files` and `groups` cannot be empty and cannot contain duplicate elements.