### PR TITLE
Added error codes to schema

### DIFF
--- a/tools/python/boutiques/schema/descriptor.schema.json
+++ b/tools/python/boutiques/schema/descriptor.schema.json
@@ -57,9 +57,9 @@
                             "type": "string"
                         },
                         "entrypoint": {
-                          "id": "http://github.com/boutiques/boutiques-schema/container/entrypoint",
-                          "description": "Flag indicating whether or not the container uses an entrypoint.",
-                          "type": "boolean"
+                            "id": "http://github.com/boutiques/boutiques-schema/container/entrypoint",
+                            "description": "Flag indicating whether or not the container uses an entrypoint.",
+                            "type": "boolean"
                         },
                         "index": {
                             "id": "http://github.com/boutiques/boutiques-schema/container/index",
@@ -521,12 +521,12 @@
                     "type": "integer",
                     "minimum": 1
                 },
-                 "walltime-estimate": {
-                     "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/walltime-estimate",
-                     "type": "number",
-                     "description": "Estimated wall time of a task in seconds.",
-                     "minimum": 0
-                 }
+                "walltime-estimate": {
+                    "id": "http://github.com/boutiques/boutiques-schema/suggested-resources/walltime-estimate",
+                    "type": "number",
+                    "description": "Estimated wall time of a task in seconds.",
+                    "minimum": 0
+                }
             }
         },
 	"tags": {
@@ -538,6 +538,34 @@
                 "description": "Tag values"
             }
         },
+	"error-codes": {
+            "id": "http://github.com/boutiques/boutiques-schema/error-codes",
+            "type": "array",
+            "description": "An array of key-value pairs specifying exit codes and their description. Can be used for tools to specify the meaning of particular exit codes. Exit code 0 is assumed to indicate a successful execution.",
+            "items": {
+                "id": "http://github.com/boutiques/boutiques-schema/error-codes",
+                "type": "object",
+                "properties": {
+                    "code": {
+                        "id": "http://github.com/boutiques/boutiques-schema/error-codes/code",
+                        "description": "Value of the exit code",
+                        "type": "integer"
+                    },
+                    "description": {
+                        "id": "http://github.com/boutiques/boutiques-schema/error-codes/description",
+                        "description": "Description of the error code.",
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "code",
+                    "description"
+                ],
+                "additionalProperties": false
+            },
+	    "minItems": 1,
+	    "uniqueItems": true
+	},
         "custom": {
             "id": "http://github.com/boutiques/boutiques-schema/custom",
             "type": "object"

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -291,5 +291,15 @@
 	"status": "experimental",
 	"foo": "bar"	
     },
+    "error-codes": [
+	    {
+		"code": 1,
+		"description": "crashed"
+	    },
+	    {
+		"code": 12,
+		"description": "crashed badly"
+	    }
+    ],
     "tool-version": "v0.0.41-1"
 }


### PR DESCRIPTION
Error codes can now be documented in a tool descriptor as follows:
```
"error-codes": [
	    {
		"code": 1,
		"description": "crashed"
	    },
	    {
		"code": 12,
		"description": "crashed badly"
	    }
]
```
This is useful in case a platform wants to report error messages to users.

Fixes #36.

Required by https://github.com/fli-iam/CARMIN/issues/61