### PR TITLE
Fixing "invocation" typo

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -242,7 +242,7 @@ def invocation(*params):
         try:
             validateSchema(invSchema, data)
         except ValidationError as e:
-            print("Invalid invcoation:")
+            print("Invalid invocation:")
             raise ValidationError(e.message)
 
 


### PR DESCRIPTION
Fixing a small "invocation" typo in print