### PR TITLE
Renaming CARMIN pipeline id property

### DIFF
--- a/tools/python/boutiques/exporter.py
+++ b/tools/python/boutiques/exporter.py
@@ -66,7 +66,7 @@ class Exporter():
         with open(self.descriptor, 'r') as fhandle:
             descriptor = json.load(fhandle)
 
-        carmin_desc['id'] = os.path.splitext(self.descriptor)[0] # not ideal
+        carmin_desc['identifier'] = os.path.splitext(self.descriptor)[0] # not ideal
         carmin_desc['name'] = descriptor.get('name')
         carmin_desc['version'] = descriptor.get('tool-version')
         carmin_desc['description'] = descriptor.get('description')


### PR DESCRIPTION
As described in the Swagger OpenAPI 3.0 descriptor, the pipeline id property should be named "identifier".