### PR TITLE
Modifications for Singularity

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -85,17 +85,21 @@ class LocalExecutor(object):
     if conIsPresent:
       if conType == 'docker':
         # Pull the docker image
-        if self._localExecute("docker pull " + str(conImage)):
+        if self._localExecute("docker pull " + str(conImage))[1]:
           print("Container not found online - trying local copy")
       elif conType == 'singularity':
         if not conIndex:
           conIndex = "shub://"
         elif not conIndex.endswith("://"):
           conIndex = conIndex + "://"
-        conName = conImage.replace("/", "-") + ".img"
-        # Pull the docker image
-        if self._localExecute("singularity pull --name \"{}\" {}{}".format(conName, conIndex, conImage)):
-          print("Container not found online - trying local copy")
+        conName = conImage.replace("/", "-") + ".simg"
+
+        if conName not in os.listdir('./'):
+          print(os.listdir('./'))
+          # Pull the singularity image
+          if self._localExecute("singularity pull --name \"{}\" {}{}".format(conName, conIndex, conImage))[1]:
+            print("Container not found online - trying local copy")
+        conName = op.abspath(conName)
       else:
         print('Unrecognized container type: \"%s\"'%conType) 
         sys.exit(1)

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import argparse, os, sys, json, random as rnd, string, math, random, subprocess, time, pwd
+import argparse, os, sys, json, random as rnd, string, math, random, subprocess, time, pwd, os.path as op
 
 # Executor class
 class LocalExecutor(object):
@@ -69,7 +69,7 @@ class LocalExecutor(object):
     command, exit_code, con = self.cmdLine[0], None, self.con or {}
     print('Attempting execution of command:\n\t' + command + '\n---/* Start program output */---')
     # Check for Container image
-    conType, conImage = con['type'], con['image']
+    conType, conImage, conIndex = con.get('type'), con.get('image'), con.get("index")
     conIsPresent = (not conImage is None) 
     # Export environment variables, if they are specified in the descriptor
     envVars = {}
@@ -80,6 +80,7 @@ class LocalExecutor(object):
     # Note that docker/singularity cannot do a local volume mount of files starting with a '.', hence this one does not
     millitime = int(time.time()*1000)
     dsname = 'temp-' + str(random.SystemRandom().randint(0,int(millitime))) + "-" + str(millitime) + '.localExec.boshjob.sh' # time tag to avoid overwrites
+    dsname = op.realpath(dsname)
     # If container is present, alter the command template accordingly
     if conIsPresent:
       if conType == 'docker':
@@ -87,8 +88,13 @@ class LocalExecutor(object):
         if self._localExecute("docker pull " + str(conImage)):
           print("Container not found online - trying local copy")
       elif conType == 'singularity':
+        if not conIndex:
+          conIndex = "shub://"
+        elif not conIndex.endswith("://"):
+          conIndex = conIndex + "://"
+        conName = conImage.replace("/", "-") + ".img"
         # Pull the docker image
-        if self._localExecute("singularity pull shub://" + str(conImage)):
+        if self._localExecute("singularity pull --name \"{}\" {}{}".format(conName, conIndex, conImage)):
           print("Container not found online - trying local copy")
       else:
         print('Unrecognized container type: \"%s\"'%conType)
@@ -109,18 +115,20 @@ class LocalExecutor(object):
       if envVars:
         for (key,val) in list(envVars.items()): envString += "-e " + str(key) + "=\'" + str(val) + '\' '
       # Change launch (working) directory if desired
-      launchDir = '${PWD}' if (self.launchDir is None) else self.launchDir
+      launchDir = op.realpath('./') if (self.launchDir is None) else self.launchDir
+      launchDir = op.realpath(launchDir)
       # Run it in docker
       mount_strings = [] if not mount_strings else mount_strings
-      mount_strings.append('${PWD}:' + launchDir)
+      mount_strings = [op.realpath(m.split(":")[0])+":"+m.split(":")[1] for m in mount_strings]
+      mount_strings.append(op.realpath('./') + ':' + launchDir)
       if conType == 'docker':
         # export mounts to docker string
         docker_mounts = " -v ".join(m for m in mount_strings)
-        dcmd = 'docker run --entrypoint=/bin/sh --rm' + envString + ' -v '+docker_mounts+ ' -w ' + launchDir + ' ' + str(conImage) + ' ./' + dsname
+        dcmd = 'docker run --entrypoint=/bin/sh --rm' + envString + ' -v '+docker_mounts+ ' -w ' + launchDir + ' ' + str(conImage) + ' ' + dsname
       elif conType == 'singularity':
         singularity_mounts = " -B ".join(m for m in mount_strings)
         #TODO: Test singularity runtime on cluster
-        dcmd = 'singularity exec' + envString + ' -B ' + singularity_mounts + ' -W ' + launchDir + ' ' + str(conImage) + ' ./' + dsname
+        dcmd = 'singularity exec' + envString + ' -B ' + singularity_mounts + ' -W ' + launchDir + ' ' + str(conName) + ' ' + dsname
       else:
         print('Unrecognized container type: \"%s\"'%conType)
         sys.exit(1)

--- a/tools/python/boutiques/tests/test_example1.py
+++ b/tools/python/boutiques/tests/test_example1.py
@@ -3,7 +3,7 @@
 import os, subprocess, pytest
 from unittest import TestCase
 from boutiques import __file__ as bfile
-from boutiques import bosh
+import boutiques as bosh
 
 class TestExample1(TestCase):
 
@@ -13,37 +13,36 @@ class TestExample1(TestCase):
 
     def test_example1_no_exec(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")       
-        self.assertFalse(bosh(["exec", "simulate",
-                               os.path.join(example1_dir, "example1.json"),
-                               "-i",
-                               os.path.join(example1_dir, "invocation.json")]))
+        self.assertFalse(bosh.execute("simulate",
+                                      os.path.join(example1_dir, "example1.json"),
+                                      "-i",
+                                      os.path.join(example1_dir, "invocation.json")))
 
     @pytest.mark.skipif(subprocess.Popen("type docker", shell=True).wait(), reason="Docker not installed")
     def test_example1_exec(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")       
-        self.assertFalse(bosh(["exec", "launch",
-                               os.path.join(example1_dir, "example1.json"),
-                               os.path.join(example1_dir, "invocation.json")])[2])
-        self.assertFalse(bosh(["exec",
-                              "launch",
-                              os.path.join(example1_dir,
-                                           "example1.json"),
-                              "-x",
-                              os.path.join(example1_dir,
-                                           "invocation.json")])[2])
+        self.assertFalse(bosh.execute("launch",
+                                      os.path.join(example1_dir, "example1.json"),
+                                      os.path.join(example1_dir, "invocation.json"))[2])
+        self.assertFalse(bosh.execute("launch",
+                                      os.path.join(example1_dir,
+                                                   "example1.json"),
+                                      "-x",
+                                      os.path.join(example1_dir,
+                                                   "invocation.json"))[2])
 
     @pytest.mark.skipif(subprocess.Popen("type docker", shell=True).wait(), reason="Docker not installed")
     def test_example1_exec_missing_script(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
-        sout, serr, ecode, emsg = bosh(["exec", "launch",
-                                       os.path.join(example1_dir,
-                                                    "example1.json"),
-                                       os.path.join(example1_dir,
-                                                    "invocation_missing_script.json")])
+        sout, serr, ecode, emsg = bosh.execute("launch",
+                                               os.path.join(example1_dir,
+                                                            "example1.json"),
+                                               os.path.join(example1_dir,
+                                                            "invocation_missing_script.json"))
         self.assertTrue('Example Boutiques Tool ERR (2): File does not exist!' in emsg)
 
     def test_example1_no_exec_random(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")       
-        self.assertFalse(bosh(["exec", "simulate",
-                               os.path.join(example1_dir, "example1.json"),
-                               "-r", "3"]))
+        self.assertFalse(bosh.execute("simulate",
+                                      os.path.join(example1_dir, "example1.json"),
+                                      "-r", "3"))

--- a/tools/python/boutiques/tests/test_example2.py
+++ b/tools/python/boutiques/tests/test_example2.py
@@ -3,7 +3,7 @@
 import os, subprocess
 from unittest import TestCase
 from boutiques import __file__ as bfile
-from boutiques import bosh
+import boutiques as bosh
 
 class TestExample2(TestCase):
 
@@ -13,23 +13,23 @@ class TestExample2(TestCase):
 
     def test_example2_no_exec(self):
         example2_dir = os.path.join(self.get_examples_dir(), "example2")       
-        self.assertFalse(bosh(["exec", "simulate",
-                               os.path.join(example2_dir, "example2.json"),
-                               "-i",
-                               os.path.join(example2_dir, "invocation.json")]))
+        self.assertFalse(bosh.execute("simulate",
+                                      os.path.join(example2_dir, "example2.json"),
+                                      "-i",
+                                      os.path.join(example2_dir, "invocation.json")))
 
     def test_example2_exec(self):
         example2_dir = os.path.join(self.get_examples_dir(), "example2")       
-        self.assertFalse(bosh(["exec", "launch",
-                               os.path.join(example2_dir, "example2.json"),
-                               os.path.join(example2_dir, "invocation.json")])[2])
-        self.assertFalse(bosh(["exec", "launch",
-                               os.path.join(example2_dir, "example2.json"),
-                               "-x",
-                               os.path.join(example2_dir, "invocation.json")])[2])
+        self.assertFalse(bosh.execute("launch",
+                                      os.path.join(example2_dir, "example2.json"),
+                                      os.path.join(example2_dir, "invocation.json"))[2])
+        self.assertFalse(bosh.execute("launch",
+                                      os.path.join(example2_dir, "example2.json"),
+                                      "-x",
+                                      os.path.join(example2_dir, "invocation.json"))[2])
 
     def test_example2_no_exec_random(self):
         example2_dir = os.path.join(self.get_examples_dir(), "example2")       
-        self.assertFalse(bosh(["exec", "simulate",
-                               os.path.join(example2_dir, "example2.json"),
-                               "-r", "3"]))
+        self.assertFalse(bosh.execute("simulate",
+                                      os.path.join(example2_dir, "example2.json"),
+                                      "-r", "3"))

--- a/tools/python/boutiques/tests/test_exec.py
+++ b/tools/python/boutiques/tests/test_exec.py
@@ -3,7 +3,7 @@
 import os
 from unittest import TestCase
 from boutiques import __file__ as bfile
-from boutiques.bosh import bosh
+import boutiques as bosh
 
 class TestExec(TestCase):
 
@@ -13,56 +13,56 @@ class TestExec(TestCase):
 
     def test_failing_launch(self):
         example1_dir = os.path.join(self.get_examples_dir(),"example1")       
-        self.assertRaises(SystemExit, bosh, ["exec", "launch",
-                                             os.path.join(example1_dir,
-                                                          "fake.json"),
-                                             os.path.join(example1_dir,
-                                                          "invocation.json")])
-        self.assertRaises(SystemExit, bosh, ["exec", "launch",
-                                             os.path.join(example1_dir,
-                                                          "example1.json"),
-                                             os.path.join(example1_dir,
-                                                          "fake.json")])
-        self.assertRaises(SystemExit, bosh, ["exec", "launch",
-                                             os.path.join(example1_dir,
-                                                          "example1.json"),
-                                             os.path.join(example1_dir,
-                                                          "exampleTool1.py")])
+        self.assertRaises(SystemExit, bosh.execute, ["launch",
+                                                     os.path.join(example1_dir,
+                                                                  "fake.json"),
+                                                     os.path.join(example1_dir,
+                                                                  "invocation.json")])
+        self.assertRaises(SystemExit, bosh.execute, ["launch",
+                                                     os.path.join(example1_dir,
+                                                                  "example1.json"),
+                                                     os.path.join(example1_dir,
+                                                                  "fake.json")])
+        self.assertRaises(SystemExit, bosh.execute, ["launch",
+                                                     os.path.join(example1_dir,
+                                                                  "example1.json"),
+                                                     os.path.join(example1_dir,
+                                                                  "exampleTool1.py")])
 
     def test_failing_simulate(self):
         example1_dir = os.path.join(self.get_examples_dir(),"example1")       
-        self.assertRaises(SystemExit, bosh, ["exec", "simulate",
-                                             os.path.join(example1_dir,
-                                                          "fake.json"),
-                                             "-i",
-                                             os.path.join(example1_dir,
-                                                          "invocation.json")])
-        self.assertRaises(SystemExit, bosh, ["exec", "simulate",
-                                             os.path.join(example1_dir,
-                                                          "example1.json"),
-                                             "-i",
-                                             os.path.join(example1_dir,
-                                                          "fake.json")])
-        self.assertRaises(SystemExit, bosh, ["exec", "simulate",
-                                             os.path.join(example1_dir,
-                                                          "example1.json"),
-                                             "-i",
-                                             os.path.join(example1_dir,
-                                                          "exampleTool1.py")])
-        self.assertRaises(SystemExit, bosh, ["exec", "simulate",
-                                             os.path.join(example1_dir,
-                                                          "example1.json"),
-                                             "-r", "-2"])
-        self.assertFalse(bosh(["exec", "simulate",
-                               os.path.join(example1_dir,"example1.json"),
-                               "-r", "1"]))
-        self.assertRaises(SystemExit, bosh, ["exec", "simulate",
-                                             os.path.join(example1_dir,
-                                                          "example1.json"),
-                                             "-r", "1", "-i",
-                                             os.path.join(example1_dir,
-                                                          "invocation.json")])
-        self.assertRaises(SystemExit, bosh, ["exec", "simulate",
-                                             os.path.join(example1_dir,
-                                                          "example1.json")])
+        self.assertRaises(SystemExit, bosh.execute, ["simulate",
+                                                     os.path.join(example1_dir,
+                                                                  "fake.json"),
+                                                     "-i",
+                                                     os.path.join(example1_dir,
+                                                                  "invocation.json")])
+        self.assertRaises(SystemExit, bosh.execute, ["simulate",
+                                                     os.path.join(example1_dir,
+                                                                  "example1.json"),
+                                                     "-i",
+                                                     os.path.join(example1_dir,
+                                                                  "fake.json")])
+        self.assertRaises(SystemExit, bosh.execute, ["simulate",
+                                                     os.path.join(example1_dir,
+                                                                  "example1.json"),
+                                                     "-i",
+                                                     os.path.join(example1_dir,
+                                                                  "exampleTool1.py")])
+        self.assertRaises(SystemExit, bosh.execute, ["simulate",
+                                                     os.path.join(example1_dir,
+                                                                  "example1.json"),
+                                                     "-r", "-2"])
+        self.assertFalse(bosh.execute("simulate",
+                                      os.path.join(example1_dir,"example1.json"),
+                                      "-r", "1"))
+        self.assertRaises(SystemExit, bosh.execute, ["simulate",
+                                                     os.path.join(example1_dir,
+                                                                  "example1.json"),
+                                                     "-r", "1", "-i",
+                                                     os.path.join(example1_dir,
+                                                                  "invocation.json")])
+        self.assertRaises(SystemExit, bosh.execute, ["simulate",
+                                                     os.path.join(example1_dir,
+                                                                  "example1.json")])
 

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "0.5.6"
+VERSION = "0.5.6.post1"
 DEPS = [
          "simplejson",
          "jsonschema",


### PR DESCRIPTION
- updated `bosh` to return the exit code properly via the CLI
- now supports multiple indices for `container-image` in the context of `singularity`
- will properly download and rename images pulled through `singularity`, and won't download image if there is one in the working directory with the same name

This PR is necessary for `bosh` to work using Singularity on a cluster (tested on Compute Canada, Cedar). Post merging this, given another PR with small modifications, I will release `0.5.6-post1` on pypi.