### PR TITLE
Fix for bug in simulate

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -127,6 +127,7 @@ def execute(*params):
         else:
             executor.readInput(inp)
             executor.printCmdLine()
+        return "", "", 0, "" # for consistency with execute (stdout, stderr, exit_code, err_msg)
 
 def importer(*params):
     parser = ArgumentParser("Imports old descriptor or BIDS app to spec.")

--- a/tools/python/boutiques/tests/test_example1.py
+++ b/tools/python/boutiques/tests/test_example1.py
@@ -16,7 +16,7 @@ class TestExample1(TestCase):
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(example1_dir, "example1.json"),
                                       "-i",
-                                      os.path.join(example1_dir, "invocation.json")))
+                                      os.path.join(example1_dir, "invocation.json"))[2])
 
     @pytest.mark.skipif(subprocess.Popen("type docker", shell=True).wait(), reason="Docker not installed")
     def test_example1_exec(self):
@@ -45,4 +45,4 @@ class TestExample1(TestCase):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")       
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(example1_dir, "example1.json"),
-                                      "-r", "3"))
+                                      "-r", "3")[2])

--- a/tools/python/boutiques/tests/test_example2.py
+++ b/tools/python/boutiques/tests/test_example2.py
@@ -16,7 +16,7 @@ class TestExample2(TestCase):
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(example2_dir, "example2.json"),
                                       "-i",
-                                      os.path.join(example2_dir, "invocation.json")))
+                                      os.path.join(example2_dir, "invocation.json"))[2])
 
     def test_example2_exec(self):
         example2_dir = os.path.join(self.get_examples_dir(), "example2")       
@@ -32,4 +32,4 @@ class TestExample2(TestCase):
         example2_dir = os.path.join(self.get_examples_dir(), "example2")       
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(example2_dir, "example2.json"),
-                                      "-r", "3"))
+                                      "-r", "3")[2])

--- a/tools/python/boutiques/tests/test_exec.py
+++ b/tools/python/boutiques/tests/test_exec.py
@@ -55,7 +55,7 @@ class TestExec(TestCase):
                                                      "-r", "-2"])
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(example1_dir,"example1.json"),
-                                      "-r", "1"))
+                                      "-r", "1")[2])
         self.assertRaises(SystemExit, bosh.execute, ["simulate",
                                                      os.path.join(example1_dir,
                                                                   "example1.json"),


### PR DESCRIPTION
bosh simulate now returns a (fake) stdout, stderr, exit_code, err_msg tuple for consistency with execute.