### PR TITLE
Descriptor publication on Zenodo

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -198,66 +198,29 @@ def publish(*params):
 
     parser = ArgumentParser("Boutiques publisher",
                             description="A publisher of Boutiques tools"
-                            " in Neurolinks"
-                            "(https://brainhack101.github.io/neurolinks)."
-                            " Crawls a Git"
-                            "repository for valid Boutiques descriptors"
-                            " and imports them"
-                            "in Neurolinks format. Uses your GitHub"
-                            " account to fork the "
-                            "Neurolinks repository and commit new tools"
-                            " in it. Requires "
-                            "that your GitHub ssh key is configured"
-                            " and usable without"
-                            "password.")
-    parser.add_argument("boutiques_repo", action="store",
-                        help="Local path to a Git repository containing"
-                        " Boutiques descriptors to publish.")
-    parser.add_argument("author_name", action="store",
-                        help="Default author name.")
-    parser.add_argument("tool_url", action="store",
-                        help="Default tool URL.")
-    parser.add_argument("--neurolinks-repo", "-n", action="store",
-                        default=get_neurolinks_default(),
-                        help="Local path to a Git clone of {0}. Remotes:"
-                        " 'origin' should point to a writable fork from"
-                        " which a PR will be initiated; 'base' will be"
-                        " pulled before any update, should point to"
-                        " {0}. If a URL is provided, will attempt to"
-                        " fork it on GitHub and clone it to {1}.".
-                        format(neurolinks_github_repo_url,
-                               neurolinks_dest_path))
-    parser.add_argument("--boutiques-remote", "-r", action="store",
-                        default='origin',
-                        help="Name of Boutiques Git repo remote used to"
-                        " get URLs of Boutiques descriptor.")
-    parser.add_argument("--no-github", action="store_true",
-                        help="Do not interact with GitHub at all"
-                        " (useful for tests).")
-    parser.add_argument("--github-login", "-u", action="store",
-                        help="GitHub login used to fork, clone and PR"
-                        " to {}. Defaults to value in $HOME/.pygithub."
-                        " Saved in $HOME/.pygithub if "
-                        "specified.".format(neurolinks_github_repo_url))
-    parser.add_argument("--github-password", "-p", action="store",
-                        help="GitHub password used to fork, clone and"
-                        " PR to {}. Defaults to value in $HOME/.pygithub."
-                        " Saved in $HOME/.pygithub if specified."
-                        .format(neurolinks_github_repo_url))
-    parser.add_argument("--inter", "-i", action="store_true",
-                        default=False,
-                        help="Interactive mode. Does not use default "
-                        "values everywhere, "
-                        "checks if URLs are correct or accessible.")
+                            " in Zenodo (http://zenodo.org). Requires "
+                            "a Zenodo access token, see "
+                            "http://developers.zenodo.org/#authentication.")
+    parser.add_argument("boutiques_descriptor", action="store",
+                        help="Local path to a "
+                        " Boutiques descriptor to publish.")
+    parser.add_argument("creator", action="store",
+                        help="Creator to use in Zenodo metadata.")
+    parser.add_argument("affiliation", action="store",
+                        help="Affiliation to use in Zenodo metadata.")
+    parser.add_argument("--sandbox", action="store_true",
+                        help="Publishes to Zenodo's sandbox'.")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Prints information messages.")
 
     results = parser.parse_args(params)
 
     from boutiques.publisher import Publisher
-    publisher = Publisher(results.boutiques_repo, results.boutiques_remote,
-                          results.author_name, results.tool_url, results.inter,
-                          results.neurolinks_repo, neurolinks_dest_path,
-                          results.github_login, results.github_password,
-                          results.no_github).publish()
+    publisher = Publisher(results.boutiques_descriptor,
+                          results.creator,
+                          results.affiliation,
+                          results.verbose,
+                          results.sandbox).publish()
 
 
 def invocation(*params):

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -203,22 +203,23 @@ def publish(*params):
                             "a Zenodo access token, see "
                             "http://developers.zenodo.org/#authentication.")
     parser.add_argument("boutiques_descriptor", action="store",
-                        help="Local path to a "
+                        help="local path of the "
                         " Boutiques descriptor to publish.")
     parser.add_argument("creator", action="store",
-                        help="Creator to use in Zenodo metadata.")
+                        help="creator to use in Zenodo metadata.")
     parser.add_argument("affiliation", action="store",
-                        help="Affiliation to use in Zenodo metadata.")
+                        help="affiliation to use in Zenodo metadata.")
     parser.add_argument("--sandbox", action="store_true",
-                        help="Publishes to Zenodo's sandbox.")
+                        help="publish to Zenodo's sandbox instead of "
+                        "production server. Recommended for tests.")
     parser.add_argument("--zenodo-token", action="store",
-                        help="Zenodo API token to use for authentication."
+                        help="Zenodo API token to use for authentication. "
                         "If not used, token will be read from configuration "
                         "file or requested interactively.")
     parser.add_argument("--no-int", '-y', action="store_true",
-                        help="Disables interactive input.")
+                        help="disable interactive input.")
     parser.add_argument("-v", "--verbose", action="store_true",
-                        help="Prints information messages.")
+                        help="print information messages.")
 
     results = parser.parse_args(params)
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -211,6 +211,10 @@ def publish(*params):
                         help="Affiliation to use in Zenodo metadata.")
     parser.add_argument("--sandbox", action="store_true",
                         help="Publishes to Zenodo's sandbox.")
+    parser.add_argument("--zenodo-token", action="store",
+                        help="Zenodo API token to use for authentication."
+                        "If not used, token will be read from configuration "
+                        "file or requested interactively.")
     parser.add_argument("--no-int", '-y', action="store_true",
                         help="Disables interactive input.")
     parser.add_argument("-v", "--verbose", action="store_true",
@@ -224,7 +228,8 @@ def publish(*params):
                           results.affiliation,
                           results.verbose,
                           results.sandbox,
-                          results.no_int).publish()
+                          results.no_int,
+                          results.zenodo_token).publish()
 
 
 def invocation(*params):

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -33,6 +33,7 @@ import os
 class ZenodoError(Exception):
     pass
 
+
 class Publisher():
 
     def __init__(self, descriptor_file_name,
@@ -58,7 +59,8 @@ class Publisher():
         self.zenodo_endpoint = "https://sandbox.zenodo.org" if\
             self.sandbox else "https://zenodo.org"
         if(self.verbose):
-            print("[ INFO ] Using Zenodo endpoint {}".format(self.zenodo_endpoint))
+            print("[ INFO ] Using Zenodo endpoint {}".
+                  format(self.zenodo_endpoint))
 
     def get_zenodo_access_token(self):
         json_creds = self.read_credentials()
@@ -79,7 +81,8 @@ class Publisher():
         with open(self.config_file, 'w') as f:
             f.write(json.dumps(json_creds, indent=4, sort_keys=True))
         if(self.verbose):
-            print("[ INFO ] Zenodo access token saved in {}".format(self.config_file))
+            print("[ INFO ] Zenodo access token saved in {}".
+                  format(self.config_file))
 
     def config_token_property_name(self):
         if self.sandbox:
@@ -122,24 +125,28 @@ class Publisher():
                 'creators': [{'name': self.creator,
                               'affiliation': self.affiliation}],
                 'version': self.descriptor['tool-version'],
-                'keywords': ['Boutiques', 'schema-version:{}'.format(self.descriptor['schema-version'])]
+                'keywords': ['Boutiques',
+                             'schema-version:{}'.
+                             format(self.descriptor['schema-version'])]
             }
         }
+        keywords = data['metadata']['keywords']
         for tag in self.descriptor.get('tags'):
-            data['metadata']['keywords'].append(tag+":"+self.descriptor['tags'][tag])
+            keywords.append(tag + ":" + self.descriptor['tags'][tag])
         if self.descriptor.get('container-image'):
-            data['metadata']['keywords'].append(self.descriptor['container-image']['type'])
-            
+            keywords.append(self.descriptor['container-image']['type'])
+
         r = requests.post(self.zenodo_endpoint+'/api/deposit/depositions',
                           params={'access_token': self.zenodo_access_token},
                           json={},
-                          data = json.dumps(data),
+                          data=json.dumps(data),
                           headers=headers)
         if(r.status_code != 201):
             self.raise_zenodo_error("Deposition failed", r)
         zid = r.json()['id']
         if(self.verbose):
-            self.print_zenodo_info("Deposition succeeded, id is {}".format(zid), r)
+            self.print_zenodo_info("Deposition succeeded, id is {}".
+                                   format(zid), r)
         return zid
 
     def zenodo_upload_descriptor(self, deposition_id):
@@ -152,7 +159,7 @@ class Publisher():
                           data=data,
                           files=files)
         # Status code is inconsistent with Zenodo documentation
-        
+
         if(r.status_code != 201):
             self.raise_zenodo_error("Cannot upload descriptor", r)
         if(self.verbose):
@@ -166,17 +173,20 @@ class Publisher():
         if(r.status_code != 202):
             self.raise_zenodo_error("Cannot publish descriptor", r)
         if(self.verbose):
-            self.print_zenodo_info("Descriptor published to Zenodo, doi is {}".format(r.json()['doi']), r)
+            self.print_zenodo_info("Descriptor published to Zenodo, doi is {}"
+                                   .format(r.json()['doi']), r)
 
     def raise_zenodo_error(self, message, r):
-        raise ZenodoError("Zenodo error ({0}): {1}. {2}".format(r.status_code, message, r.json()))
-    
+        raise ZenodoError("Zenodo error ({0}): {1}. {2}"
+                          .format(r.status_code, message, r.json()))
+
     def print_zenodo_info(self, message, r):
         print("[ INFO ({1}) ] {0}".format(message, r.status_code))
 
     def publish(self):
         if(not self.no_int):
-            prompt = "The descriptor will be published to Zenodo, this cannot be undone. Are you sure? (Y/n) "
+            prompt = ("The descriptor will be published to Zenodo, "
+                      "this cannot be undone. Are you sure? (Y/n) ")
             try:
                 ret = raw_input(prompt)  # Python 2
             except NameError:

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -37,7 +37,8 @@ class ZenodoError(Exception):
 class Publisher():
 
     def __init__(self, descriptor_file_name,
-                 creator, affiliation, verbose, sandbox, no_int):
+                 creator, affiliation, verbose, sandbox, no_int,
+                 auth_token):
         # Straightforward assignments
         self.verbose = verbose
         self.sandbox = sandbox
@@ -45,15 +46,17 @@ class Publisher():
         self.creator = creator
         self.affiliation = affiliation
         self.no_int = no_int
+        self.zenodo_access_token = auth_token
 
         # Validate and load descriptor
         validate_descriptor(descriptor_file_name)
         self.descriptor = json.loads(open(self.descriptor_file_name).read())
 
         # Fix Zenodo access token
-        self.config_file = os.path.join(os.getenv("HOME"), ".boutiques")
-        self.zenodo_access_token = self.get_zenodo_access_token()
-        self.save_zenodo_access_token()
+        if self.zenodo_access_token is None:
+            self.config_file = os.path.join(os.getenv("HOME"), ".boutiques")
+            self.zenodo_access_token = self.get_zenodo_access_token()
+            self.save_zenodo_access_token()
 
         # Set Zenodo endpoint
         self.zenodo_endpoint = "https://sandbox.zenodo.org" if\
@@ -177,8 +180,8 @@ class Publisher():
                                    .format(r.json()['doi']), r)
 
     def raise_zenodo_error(self, message, r):
-        raise ZenodoError("Zenodo error ({0}): {1}. {2}"
-                          .format(r.status_code, message, r.json()))
+        raise ZenodoError("Zenodo error ({0}): {1}."
+                          .format(r.status_code, message))
 
     def print_zenodo_info(self, message, r):
         print("[ INFO ({1}) ] {0}".format(message, r.status_code))

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env pythonprint
+#!/usr/bin/env python
 
 # Copyright 2015 - 2017:
 #   The Royal Institution for the Advancement of Learning McGill University,

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -24,356 +24,155 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
-from jsonschema import ValidationError
 from boutiques.validator import validate_descriptor
-from git import Repo
-from github import Github
-import git
 import json
+import requests
 import os
-import sys
-try:
-    # For Python 3.0 and later
-    from urllib.request import urlopen, URLError
-except ImportError:
-    # Fall back to Python 2's urllib2
-    from urllib2 import urlopen, URLError
 
 
 class Publisher():
 
-    def __init__(self, boutiques_dir, remote_name, tool_author, tool_url, inter,
-                 neurolinks_repo_url, neurolinks_dest_path,
-                 github_user, github_password, no_github):
-        self.boutiques_dir = os.path.abspath(boutiques_dir)
-        self.remote_name = remote_name if remote_name else 'origin'
+    def __init__(self, descriptor_file_name,
+                 creator, affiliation, verbose, sandbox=False):
+        # Straightforward assignments
+        self.verbose = verbose
+        self.sandbox = sandbox
+        self.descriptor_file_name = descriptor_file_name
+        self.creator = creator
+        self.affiliation = affiliation
+
+        # Validate and load descriptor
+        validate_descriptor(descriptor_file_name)
+        self.descriptor = json.loads(open(self.descriptor_file_name).read())
+
+        # Fix Zenodo access token
+        self.config_file = os.path.join(os.getenv("HOME"), ".boutiques")
+        self.zenodo_access_token = self.get_zenodo_access_token()
+        if(self.verbose):
+            print("Zenodo access token is {}".format(self.zenodo_access_token))
+        self.save_zenodo_access_token()
+
+        # Set Zenodo endpoint
+        self.zenodo_endpoint = "http://sandbox.zenodo.org" if\
+            self.sandbox else "http://sandbox.zenodo.org."
+        if(self.verbose):
+            print("Using Zenodo endpoint {}".format(self.zenodo_endpoint))
+
+    def get_zenodo_access_token(self):
+        json_creds = self.read_credentials()
+        if json_creds.get(self.config_token_property_name()):
+            return json_creds.get(self.config_token_property_name())
+        prompt = ("Please enter your Zenodo access token (it will be "
+                  "saved in {} for future use): ".format(self.config_file))
         try:
-            self.boutiques_repo = Repo(self.boutiques_dir)
-        except git.exc.InvalidGitRepositoryError as e:
-            # We won't publish a descriptor which is not in a Git repo!
-            sys.stderr.write('error: %s is not a Git repository.\n'
-                             % self.boutiques_dir)
-            sys.exit(1)
+            return raw_input(prompt)  # Python 2
+        except NameError:
+            return input(prompt)  # Python 3
 
-        for remote in self.boutiques_repo.remotes:
-            if remote.name == self.remote_name:
-                self.boutiques_remote = remote
+    def save_zenodo_access_token(self):
+        json_creds = self.read_credentials()
+        json_creds[self.config_token_property_name()] = self.zenodo_access_token
+        with open(self.config_file, 'w') as f:
+            f.write(json.dumps(json_creds, indent=4, sort_keys=True))
+        if(self.verbose):
+            print("Zenodo access token saved in {}".format(self.config_file))
 
-        url = self.boutiques_remote.url
-        # If remote URL is on Github, try to guess the URL
-        # of the Boutiques descriptor
-        if "github.com" in url:
-            url = url.replace(".git", "").replace("git@github.com:",
-                                                  "https://github.com/")
-            url = url.replace("https://github.com/",
-                              "https://raw.githubusercontent.com/")
-            url = url.replace("http://github.com/",
-                              "https://raw.githubusercontent.com/")
-            url += "master"
-        self.base_url = url
+    def config_token_property_name(self):
+        if self.sandbox:
+            return "zenodo-access-token-test"
+        return "zenodo-access-token"
 
-        # Try to guess the tool author
-        self.tool_author = tool_author
-
-        self.tool_url = tool_url if tool_url else "http://example.com"
-        self.inter = inter
-        self.no_github = no_github
-
-        if self.no_github:
-            return
-
-        # Set github credentials
-        self.github_user = github_user
-        self.github_password = github_password
-        self.fix_github_credentials()
-        # Fork and clone the neurolinks repo
-        if neurolinks_repo_url.startswith("http"):
-            # won't do anything if fork already exists
-            fork_url = self.fork_repo(neurolinks_repo_url)
-            neurolinks_local_url = self.clone_repo(fork_url,
-                                                   neurolinks_dest_path)
-            # Add base neurolinks repo as remote and pull from it, in case
-            # fork already existed and is outdated
-            self.neurolinks_repo = Repo(neurolinks_local_url)
-            base = self.neurolinks_repo.create_remote('base',
-                                                      neurolinks_repo_url)
-            neurolinks_repo_url = neurolinks_local_url
-        else:
-            self.neurolinks_repo = Repo(neurolinks_repo_url)
-        self.neurolinks_repo.remotes.base.pull('master')
-
-        self.tools_file = os.path.abspath(os.path.join(neurolinks_repo_url,
-                                                       'jsons', 'tool.json'))
-        if not os.path.isfile(self.tools_file):
-            print("error: cannot find {0} (check "
-                  "neurolinks repo).".format(self.tools_file))
-            sys.exit(1)
-
-    def fix_github_credentials(self):
-        pygithub_file = os.path.join(os.getenv("HOME"), ".pygithub")
-        # Read saved credentials
+    def read_credentials(self):
         try:
-            with open(pygithub_file, "r") as f:
+            with open(self.config_file, "r") as f:
                 json_creds = json.load(f)
         except IOError:
             json_creds = {}
         except ValueError:
             json_creds = {}
-        # Credentials passed as parameters have precedence.
-        # Ask credentials if none
-        # can be found
-        username = self.github_user
-        if username is None:
-            username = json_creds.get('user')
-        if not username:
-            username = self.get_from_stdin("GitHub login")
-        password = self.github_password
-        if password is None:
-            password = json_creds.get('password')
-        if not password:
-            password = self.get_from_stdin("GitHub password "
-                                           "(user: {0})".format(username))
-        # Save credentials
-        self.github_username = username
-        self.github_password = password
-        json_creds['user'] = self.github_username
-        json_creds['password'] = self.github_password
-        with open(pygithub_file, "w") as f:
-            f.write(json.dumps(json_creds, indent=4, sort_keys=True))
+        return json_creds
 
-    def find_json_files(self, directory):
-        json_files = []
-        for root, dirs, files in os.walk(directory):
-            for file in files:
-                if file.endswith(".json"):
-                    json_files.append(os.path.join(root, file))
-        return json_files
+    def zenodo_test_api(self):
+        r = requests.get(self.zenodo_endpoint+'/api/deposit/depositions')
+        assert(r.status_code == 401), "Cannot access Zenodo API."
+        if(self.verbose):
+            print("Zenodo API is accessible.")
+        r = requests.get(self.zenodo_endpoint+'/api/deposit/depositions',
+                         params={'access_token': self.zenodo_access_token})
+        message = "Cannot authenticate to Zenodo API, check you access token"
+        assert(r.status_code == 200), message
+        if(self.verbose):
+            print("Can authenticate to Zenodo API.")
 
-    def get_json_string(self, identifier, label, description,
-                        tool_author, tool_url, boutiques_url,
-                        docker_container, singularity_container):
+    def zenodo_deposit(self):
+        headers = {"Content-Type": "application/json"}
+        r = requests.post(self.zenodo_endpoint+'/api/deposit/depositions',
+                          params={'access_token': self.zenodo_access_token},
+                          json={},
+                          headers=headers)
+        assert(r.status_code == 200),\
+            self.print_zenodo_error("Cannot create deposit:")
+        # Not sure why [0] is required, this is inconsistend with API docs
+        zid = r.json()[0]['id']
+        if(self.verbose):
+            print("Descriptor deposited on Zenodo, id is {}.".format(zid))
+        return zid
 
-        path, fil = os.path.split(__file__)
-        template_file = os.path.join(path, "neurolinks-template", "tool.json")
+    def zenodo_upload_descriptor(self, deposition_id):
+        data = {'filename': self.descriptor_file_name}
+        files = {'file': open(self.descriptor_file_name, 'rb')}
+        r = requests.post(self.zenodo_endpoint +
+                          '/api/deposit/depositions/%s/files'
+                          % deposition_id,
+                          params={'access_token': self.zenodo_access_token},
+                          data=data,
+                          files=files)
+        # Status code is inconsistent with Zenodo documentation
+        assert(r.status_code == 200),\
+            self.print_zenodo_error("Cannot upload descriptor")
+        if(self.verbose):
+            print("Descriptor uploaded to Zenodo.")
 
-        with open(template_file) as f:
-            template_string = f.read()
+    def zenodo_add_metadata(self, deposition_id):
+        headers = {"Content-Type": "application/json"}
+        data = {
+            'metadata': {
+                'title': self.descriptor['name'],
+                'upload_type': 'software',
+                'description': self.descriptor['description'] or "Boutiques "
+                               "descriptor for {}".format(
+                                                    self.descriptor['name']),
+                'creators': [{'name': self.creator,
+                              'affiliation': self.affiliation}],
+                'keywords': ["Boutiques descriptor"]
+            }
+        }
+        r = requests.put(self.zenodo_endpoint+'/api/deposit/depositions/%s'
+                         % deposition_id,
+                         params={'access_token': self.zenodo_access_token},
+                         data=json.dumps(data),
+                         headers=headers)
+        assert(r.status_code == 200),\
+            self.print_zenodo_error("Cannot add metadata to descriptor", r)
+        if(self.verbose):
+            print("Zenodo metadata added to descriptor.")
 
-        template_string = template_string.replace("@@__ID__@@", identifier)
-        template_string = template_string.replace("@@__LABEL__@@", label)
-        template_string = template_string.replace("@@__DESCRIPTION__@@",
-                                                  description)
-        template_string = template_string.replace("@@__TOOL_AUTHOR__@@",
-                                                  tool_author)
-        template_string = template_string.replace("@@__TOOL_URL__@@",
-                                                  tool_url)
-        template_string = template_string.replace("@@__BOUTIQUES_URL__@@",
-                                                  boutiques_url)
+    def zenodo_publish(self, deposition_id):
+        r = requests.post(self.zenodo_endpoint +
+                          '/api/deposit/depositions/%s/actions/publish'
+                          % deposition_id,
+                          params={'access_token': self.zenodo_access_token})
+        assert(r.status_code == 202),\
+            self.print_zenodo_error("Cannot publish descriptor")
+        if(self.verbose):
+            print("Descriptor published to Zenodo.")
 
-        json_string = json.loads(template_string)
-        if docker_container:
-            json_string['dockercontainer'] = docker_container
-        if singularity_container:
-            json_string['singularitycontainer'] = singularity_container
-
-        return json_string
-
-    def is_boutiques_descriptor(self, json_file):
-        try:
-            validate_descriptor(json_file)
-            return True
-        except Exception:
-            return False
-
-    def get_from_stdin(self, question, default_value=None, input_type=None):
-        if not self.inter:
-            return default_value
-        prompt = question + ": "
-        if default_value:
-            prompt = question+" ("+default_value+"): "
-        try:
-            answer = raw_input(prompt)  # Python 2
-        except NameError:
-            answer = input(prompt)  # Python 3
-        answer = answer if answer else default_value
-        if input_type == "URL":
-            while not self.check_url(answer):
-                answer = self.get_from_stdin(question,
-                                             default_value, input_type)
-        return answer
-
-    def check_url(self, url):
-        try:
-            code = urlopen(url).getcode()
-        except ValueError as e:
-            print("error: {0}".format(e.message))
-            return False
-        except URLError as e:
-            print("error: {0}".format(e.message))
-            return False
-        if code != 200:
-            print("warning: URL is not accessible (status: {0})".format(code))
-            return False
-        else:
-            print("  ... URL is accessible.")
-            return True
-
-    def print_banner(self, descriptor):
-        name = descriptor['name']
-        text = "Found Boutiques tool {0}".format(name, "")
-        line = ""
-        for i in range(0, len(text)):
-            line = line + "="
-        print("")
-        print(line)
-        print(text)
-        print(line)
-
-    def get_descriptors(self):
-        json_strings = []
-        json_files = self.find_json_files(self.boutiques_dir)
-        descriptors = [x for x in json_files if self.is_boutiques_descriptor(x)]
-        return descriptors
-
-    def get_neurolinks_json(self, descriptor_file_name, tools):
-        entities = tools.get('entities')
-        with open(descriptor_file_name, "r") as f:
-            descriptor = json.load(f)
-        self.print_banner(descriptor)
-        if self.inter:
-            if(self.get_from_stdin("Publish Y/n?", "Y") != "Y"):
-                return None
-        if(self.contains(descriptor['name'], entities)):
-            if not self.inter:
-                print('Not overwriting existing entry - '
-                      'use interactive mode to override')
-                return None
-            if(self.get_from_stdin("{0} is already published,"
-                                   " overwrite Y/n?".format(
-                    descriptor['name']), "n") != "Y"):
-                return None
-            tools['entities'] = self.remove(descriptor['name'], entities)
-        label = descriptor['name']
-        description = descriptor.get('description')
-        docker_container = None
-        singularity_container = None
-        container_image = descriptor.get('container-image')
-        if container_image:
-            if container_image.get('type') == "docker":
-                index = container_image.get('index') or 'http://index.docker.io'
-                if "index.docker.io" in index:
-                    index = "https://hub.docker.com/r/"
-                elif "quay.io" in index:
-                    index = "https://quay.io/repository"
-                docker_container = os.path.join(index,
-                                                container_image.
-                                                get("image").split(':')[0])
-            if container_image.get('type') == "singularity":
-                index = container_image.get('index') or 'shub://'
-                if index == "docker://":
-                    singularity_container = os.path.join(
-                                               "https://hub.docker.com",
-                                               container_image.get("image").
-                                               split(':')[0])
-                else:
-                    singularity_container = os.path.join(
-                                                index,
-                                                container_image.get("image"))
-        identifier = label.replace(" ", "_")
-        boutiques_url = self.get_url(descriptor_file_name)
-        if self.inter:
-            self.tool_author = self.get_from_stdin("Tool author",
-                                                   self.tool_author)
-            self.tool_url = self.get_from_stdin("Tool URL",
-                                                self.tool_url,
-                                                "URL")
-            boutiques_url = self.get_from_stdin("Boutiques descriptor URL",
-                                                boutiques_url, "URL")
-        return self.get_json_string(identifier, label, description,
-                                    self.tool_author, self.tool_url,
-                                    boutiques_url, docker_container,
-                                    singularity_container)
-
-    def get_url(self, file_path):
-        file_path = file_path.replace(self.boutiques_dir, "")
-        url = self.base_url + file_path
-        return url
-
-    def contains(self, label, tools):
-        if not tools:
-            return
-        for tool in tools:
-            if tool['label'] == label:
-                return True
-        return False
-
-    def remove(self, label, tools):
-        new_tools = [x for x in tools if x['label'] != label]
-        return new_tools
+    def print_zenodo_error(self, message, r):
+        print("{0}: {1}".format(message, r.json()))
 
     def publish(self):
-        json_tools = []
-        existing_tools = {}
-        if not self.no_github:
-            # Load existing tools
-            with open(self.tools_file, "r") as json_file:
-                existing_tools = json.load(json_file)
-        # Get new tools from boutiques repo
-        descriptors = self.get_descriptors()
-        for descriptor_file_name in descriptors:
-            # Build neurolinks string
-            neurolinks_json = self.get_neurolinks_json(
-                                          descriptor_file_name,
-                                          existing_tools)
-            # Have user review before commit
-            if not self.inter and neurolinks_json:
-                print("Tool summary:")
-                print(json.dumps(neurolinks_json, indent=4, sort_keys=True))
-                if(self.get_from_stdin("Publish Y/n?", "n") != "Y"):
-                    neurolinks_json = None
-            # Publish json string unless user didn't want to
-            if neurolinks_json:
-                json_tools.append(neurolinks_json)
-        if len(json_tools) == 0:
-            print("Nothing to publish, bye!")
-            return
-        if self.no_github:
-            for tool in json_tools:
-                print(json.dumps(tool, indent=4, sort_keys=True))
-            return
-        # Add new tools to existing tools
-        for tool in json_tools:
-            existing_tools['entities'].append(tool)
-        # Write updated tools
-        json_file = open(self.tools_file, "w")
-        json_file.write(json.dumps(existing_tools, indent=4, sort_keys=True))
-        json_file.close()
-        # Commit tools file
-        self.neurolinks_repo.index.add([self.tools_file])
-        self.neurolinks_repo.index.commit("Added tool {0} with "
-                                          "bosh-publish".format(
-                                                        tool['label']))
-        # Push to fork
-        self.neurolinks_repo.remotes.origin.push()
-        # Make PR
-        self.pr(self.neurolinks_repo.remotes.origin.url,
-                self.neurolinks_repo.remotes.base.url)
-
-    def clone_repo(self, repo_url, dest_path):
-        print("Cloning {0} to {1}...".format(repo_url, dest_path))
-        Repo.clone_from(repo_url, dest_path)
-        return os.path.abspath(dest_path)
-
-    def fork_repo(self, repo_url):
-        print("Forking {0} to {1}...".format(repo_url, self.github_username))
-        g = Github(self.github_username, self.github_password)
-        github_user = g.get_user()
-        repo = g.get_repo("brainhack101/neurolinks")
-        myfork = github_user.create_fork(repo)
-        return myfork.ssh_url
-
-    def pr(self, fork_url, base_url):
-        print("Create a pull request from {0} to {1} to finalize"
-              " publication. This cannot be done automatically.".
-              format(fork_url, base_url))
+        self.zenodo_test_api()
+        deposition_id = self.zenodo_deposit()
+        self.zenodo_upload_descriptor(deposition_id)
+        self.zenodo_add_metadata(deposition_id)
+        self.zenodo_publish(deposition_id)

--- a/tools/python/boutiques/tests/test_publisher.py
+++ b/tools/python/boutiques/tests/test_publisher.py
@@ -12,7 +12,10 @@ class TestPublisher(TestCase):
 
     def test_publisher(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        print(os.path.join(example1_dir,"example1.json"))
         self.assertFalse(bosh(["publish",
                                os.path.join(example1_dir,"example1.json"),
                                "Test author", "Test affiliation",
-                               "--sandbox", "-y", "-v"]))
+                               "--sandbox", "-y", "-v",
+                               "--zenodo-token", "hAaW2wSBZMskxpfigTYHcuDrC"
+                               "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r"]))

--- a/tools/python/boutiques/tests/test_publisher.py
+++ b/tools/python/boutiques/tests/test_publisher.py
@@ -6,9 +6,13 @@ import os
 
 class TestPublisher(TestCase):
 
-    def get_boutiques_dir(self):
-        return os.path.join(os.path.split(bfile)[0], "..", "..", "..")
+    def get_examples_dir(self):
+        return os.path.join(os.path.dirname(bfile),
+                            "schema", "examples")
 
     def test_publisher(self):
-        self.assertFalse(bosh(["publish", self.get_boutiques_dir(),
-                               "test author", "example.com", "--no-github"]))
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        self.assertFalse(bosh(["publish",
+                               os.path.join(example1_dir,"example1.json"),
+                               "Test author", "Test affiliation",
+                               "--sandbox", "-y", "-v"]))

--- a/tools/python/boutiques/tests/test_publisher.py
+++ b/tools/python/boutiques/tests/test_publisher.py
@@ -12,9 +12,9 @@ class TestPublisher(TestCase):
 
     def test_publisher(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
-        print(os.path.join(example1_dir,"example1.json"))
+        print(os.path.join(example1_dir, "example1.json"))
         self.assertFalse(bosh(["publish",
-                               os.path.join(example1_dir,"example1.json"),
+                               os.path.join(example1_dir, "example1.json"),
                                "Test author", "Test affiliation",
                                "--sandbox", "-y", "-v",
                                "--zenodo-token", "hAaW2wSBZMskxpfigTYHcuDrC"

--- a/tools/python/requirements.txt
+++ b/tools/python/requirements.txt
@@ -1,4 +1,3 @@
 simplejson
 jsonschema
-gitpython
-PyGithub
+requests

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -4,8 +4,7 @@ VERSION = "0.5.7"
 DEPS = [
          "simplejson",
          "jsonschema",
-         "gitpython",
-         "PyGithub",
+         "requests",
          "pytest",
        ]
 


### PR DESCRIPTION
Rewrote `bosh publish` to publish tools to Zenodo instead of Neurolinks, as discussed in #205 and #34.

Example of tool published: https://zenodo.org/record/1219701 Note the keywords, extracted from the descriptor tags, schema-version and container image type. Hopefully searching from keywords will be available in the coming Zenodo search API. Tool version (Zenodo's "version") is also extracted from the descriptor, as well as name (Zenodo's "title"). Creator and affiliation are passed on the CLI.

Option `--sandbox` publishes to https://sandbox.zenodo.org instead of https://zenodo.org

Auth token is asked interactively if not passed on the CLI or found in $HOME.boutiques. It is always stored in $HOME/.boutiques once available. In the test, authentication token is passed on the CLI. This is not very clean but I thought it was ok since it's a token for the sandbox service.

By default, publisher interactively asks user for confirmation before publishing, as publications cannot be deleted. Option `-y` disables interactive input for use in tests or Python API. 

@camarasu, you may also want to look at this.