### PR TITLE
Support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 - docker
 
 python:
+- 2.6
 - 2.7
 - 3.5
 - 3.5-dev

--- a/tools/python/boutiques/conftest.py
+++ b/tools/python/boutiques/conftest.py
@@ -47,7 +47,7 @@ def pytest_generate_tests(metafunc):
     # Generate the test ids for each of the test cases.
     # An id is created by concatenaning the name of the descriptor
     # with the name of the test case.
-    names = ["{}_{}".format(op.basename(descriptor_filename),
+    names = ["{0}_{1}".format(op.basename(descriptor_filename),
              params[1]["name"].replace(' ', '-')) for params in tests]
 
     metafunc.parametrize("descriptor, test, invocation", tests, ids=names)

--- a/tools/python/boutiques/evaluate.py
+++ b/tools/python/boutiques/evaluate.py
@@ -64,11 +64,12 @@ def evaluateEngine(executor, query):
                     # print(obj)
                     query_result[obj["id"]] = executor.in_dict.get(obj["id"])
                 elif "groups" in layers:
-                    query_result[obj["id"]] = {mem: executor.in_dict.get(mem)
-                                               for mem in obj['members']}
+                    query_result[obj["id"]] = {}
+                    for mem in obj['members']:
+                        query_result[obj["id"]][mem] = executor.in_dict.get(mem)
 
         return query_result
 
     except Exception:
-        print("Invalid query ({}). See --help.".format(query))
+        print("Invalid query ({0}). See --help.".format(query))
         return {}

--- a/tools/python/boutiques/invocationSchemaHandler.py
+++ b/tools/python/boutiques/invocationSchemaHandler.py
@@ -109,7 +109,10 @@ def generateInvocationSchema(toolDesc, oname=None, validateWrtMetaSchema=True):
                 disbs.append(m)
         # Handle requires-inputs (flags have to be true to satisfy it)
         if reqs:
-            reqMap = {r: {"enum": [True]} for r in reqs if isFlag(r)}
+            reqMap = {}
+            for r in reqs:
+                if isFlag(r):
+                    reqMap[r] = {"enum": [True]}
             if isFlag(id):
                 h[id] = {}
                 h[id]['anyOf'] = [

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -62,7 +62,7 @@ class Publisher():
         self.zenodo_endpoint = "https://sandbox.zenodo.org" if\
             self.sandbox else "https://zenodo.org"
         if(self.verbose):
-            print("[ INFO ] Using Zenodo endpoint {}".
+            print("[ INFO ] Using Zenodo endpoint {0}".
                   format(self.zenodo_endpoint))
 
     def get_zenodo_access_token(self):
@@ -72,7 +72,7 @@ class Publisher():
         if(self.no_int):
             raise ZenodoError("Cannot find Zenodo credentials.")
         prompt = ("Please enter your Zenodo access token (it will be "
-                  "saved in {} for future use): ".format(self.config_file))
+                  "saved in {0} for future use): ".format(self.config_file))
         try:
             return raw_input(prompt)  # Python 2
         except NameError:
@@ -84,7 +84,7 @@ class Publisher():
         with open(self.config_file, 'w') as f:
             f.write(json.dumps(json_creds, indent=4, sort_keys=True))
         if(self.verbose):
-            print("[ INFO ] Zenodo access token saved in {}".
+            print("[ INFO ] Zenodo access token saved in {0}".
                   format(self.config_file))
 
     def config_token_property_name(self):
@@ -123,13 +123,13 @@ class Publisher():
                 'title': self.descriptor['name'],
                 'upload_type': 'software',
                 'description': self.descriptor['description'] or "Boutiques "
-                               "descriptor for {}".format(
+                               "descriptor for {0}".format(
                                                    self.descriptor['name']),
                 'creators': [{'name': self.creator,
                               'affiliation': self.affiliation}],
                 'version': self.descriptor['tool-version'],
                 'keywords': ['Boutiques',
-                             'schema-version:{}'.
+                             'schema-version:{0}'.
                              format(self.descriptor['schema-version'])]
             }
         }
@@ -148,7 +148,7 @@ class Publisher():
             self.raise_zenodo_error("Deposition failed", r)
         zid = r.json()['id']
         if(self.verbose):
-            self.print_zenodo_info("Deposition succeeded, id is {}".
+            self.print_zenodo_info("Deposition succeeded, id is {0}".
                                    format(zid), r)
         return zid
 
@@ -176,7 +176,7 @@ class Publisher():
         if(r.status_code != 202):
             self.raise_zenodo_error("Cannot publish descriptor", r)
         if(self.verbose):
-            self.print_zenodo_info("Descriptor published to Zenodo, doi is {}"
+            self.print_zenodo_info("Descriptor published to Zenodo, doi is {0}"
                                    .format(r.json()['doi']), r)
 
     def raise_zenodo_error(self, message, r):

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -1,305 +1,455 @@
 {
-    "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN] [EXTRA1] [EXTRA2]",
+    "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN] [EXTRA1] [EXTRA2]", 
     "container-image": {
-        "entrypoint": false,
-        "image": "neurodata/ndmg:v0.0.41-1",
-        "index": "index.docker.io",
+        "entrypoint": false, 
+        "image": "neurodata/ndmg:v0.0.41-1", 
+        "index": "index.docker.io", 
         "type": "docker"
-    },
-    "description": "dwi connectome estimation pipeline",
+    }, 
+    "description": "dwi connectome estimation pipeline", 
+    "error-codes": [
+        {
+            "code": 1, 
+            "description": "crashed"
+        }, 
+        {
+            "code": 12, 
+            "description": "crashed badly"
+        }
+    ], 
     "groups": [
         {
-            "all-or-none": true,
-            "id": "together_group",
+            "all-or-none": true, 
+            "id": "together_group", 
             "members": [
-                "extra1",
+                "extra1", 
                 "extra2"
-            ],
+            ], 
             "name": "these guys have to be toggled together"
-        },
+        }, 
         {
-            "id": "dti_group",
+            "id": "dti_group", 
             "members": [
-                "dti_file",
+                "dti_file", 
                 "dti_file_minc"
-            ],
-            "mutually-exclusive": true,
-            "name": "Group of two possible dti input files",
+            ], 
+            "mutually-exclusive": true, 
+            "name": "Group of two possible dti input files", 
             "one-is-required": true
-        },
+        }, 
         {
-            "id": "parcellation_group",
+            "id": "parcellation_group", 
             "members": [
-                "desikan",
-                "jhu",
-                "talairach",
-                "aal",
-                "harvardoxford",
+                "desikan", 
+                "jhu", 
+                "talairach", 
+                "aal", 
+                "harvardoxford", 
                 "cpac200"
-            ],
-            "name": "Group of all used parcellations",
+            ], 
+            "name": "Group of all used parcellations", 
             "one-is-required": true
         }
-    ],
+    ], 
     "inputs": [
         {
-            "id": "dti_file",
-            "name": "Diffusion Tensor Image",
-            "optional": true,
-            "type": "File",
+            "id": "dti_file", 
+            "name": "Diffusion Tensor Image", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[DTI]"
-        },
+        }, 
         {
-            "id": "extra1",
-            "name": "optional thing at the end",
-            "optional": true,
-            "type": "File",
+            "id": "extra1", 
+            "name": "optional thing at the end", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[EXTRA1]"
-        },
+        }, 
         {
-            "id": "extra2",
-            "name": "optional thing at the end",
-            "optional": true,
-            "type": "File",
+            "id": "extra2", 
+            "name": "optional thing at the end", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[EXTRA2]"
-        },
+        }, 
         {
-            "id": "dti_file_minc",
-            "name": "Diffusion Tensor Image",
-            "optional": true,
-            "type": "File",
+            "id": "dti_file_minc", 
+            "name": "Diffusion Tensor Image", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[DTI]"
-        },
+        }, 
         {
-            "id": "bval_file",
-            "name": "B-values file",
-            "optional": false,
-            "type": "File",
+            "id": "bval_file", 
+            "name": "B-values file", 
+            "optional": false, 
+            "type": "File", 
             "value-key": "[BVAL]"
-        },
+        }, 
         {
-            "id": "bvec_file",
-            "name": "Gradient vectors file",
-            "optional": false,
-            "type": "File",
+            "id": "bvec_file", 
+            "name": "Gradient vectors file", 
+            "optional": false, 
+            "type": "File", 
             "value-key": "[BVEC]"
-        },
+        }, 
         {
-            "id": "mprage_file",
-            "name": "Structural scan file",
-            "optional": false,
-            "type": "File",
+            "id": "mprage_file", 
+            "name": "Structural scan file", 
+            "optional": false, 
+            "type": "File", 
             "value-key": "[MPRAGE]"
-        },
+        }, 
         {
-            "id": "atlas",
-            "name": "Atlas image (MNI152)",
-            "optional": false,
-            "type": "String",
+            "id": "atlas", 
+            "name": "Atlas image (MNI152)", 
+            "optional": false, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
-            ],
+            ], 
             "value-key": "[ATLAS]"
-        },
+        }, 
         {
-            "id": "mask",
-            "name": "Atlas brain mask",
-            "optional": false,
-            "type": "String",
+            "id": "mask", 
+            "name": "Atlas brain mask", 
+            "optional": false, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
-            ],
+            ], 
             "value-key": "[MASK]"
-        },
+        }, 
         {
-            "id": "outdir",
-            "name": "Output directory",
-            "optional": false,
-            "type": "String",
+            "id": "outdir", 
+            "name": "Output directory", 
+            "optional": false, 
+            "type": "String", 
             "value-key": "[OUTDIR]"
-        },
+        }, 
         {
-            "id": "desikan",
-            "name": "Desikan parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "desikan", 
+            "name": "Desikan parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/desikan.nii.gz"
-            ],
+            ], 
             "value-key": "[DESIKAN]"
-        },
+        }, 
         {
-            "id": "jhu",
-            "name": "JHU parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "jhu", 
+            "name": "JHU parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/JHU.nii.gz"
-            ],
+            ], 
             "value-key": "[JHU]"
-        },
+        }, 
         {
-            "id": "talairach",
-            "name": "Talairach parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "talairach", 
+            "name": "Talairach parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/Talairach.nii.gz"
-            ],
+            ], 
             "value-key": "[TALAIRACH]"
-        },
+        }, 
         {
-            "id": "aal",
-            "name": "AAL parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "aal", 
+            "name": "AAL parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/AAL.nii.gz"
-            ],
+            ], 
             "value-key": "[AAL]"
-        },
+        }, 
         {
-            "id": "harvardoxford",
-            "name": "Harvard-Oxford parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "harvardoxford", 
+            "name": "Harvard-Oxford parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/HarvardOxford.nii.gz"
-            ],
+            ], 
             "value-key": "[HARVARDOXFORD]"
-        },
+        }, 
         {
-            "id": "cpac200",
-            "name": "CPAC200 parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "cpac200", 
+            "name": "CPAC200 parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/CPAC200.nii.gz"
-            ],
+            ], 
             "value-key": "[CPAC200]"
-        },
+        }, 
         {
-            "command-line-flag": "-c",
-            "id": "clean",
-            "name": "Clean-up flag",
-            "optional": true,
-            "type": "Flag",
+            "command-line-flag": "-c", 
+            "id": "clean", 
+            "name": "Clean-up flag", 
+            "optional": true, 
+            "type": "Flag", 
             "value-key": "[CLEAN]"
         }
-    ],
-    "name": "ndmg",
+    ], 
+    "invocation-schema": {
+        "$schema": "http://json-schema.org/draft-04/schema#", 
+        "additionalProperties": false, 
+        "allOf": [
+            {
+                "anyOf": [
+                    {
+                        "required": [
+                            "dti_file"
+                        ]
+                    }, 
+                    {
+                        "required": [
+                            "dti_file_minc"
+                        ]
+                    }
+                ]
+            }, 
+            {
+                "anyOf": [
+                    {
+                        "required": [
+                            "desikan"
+                        ]
+                    }, 
+                    {
+                        "required": [
+                            "jhu"
+                        ]
+                    }, 
+                    {
+                        "required": [
+                            "talairach"
+                        ]
+                    }, 
+                    {
+                        "required": [
+                            "aal"
+                        ]
+                    }, 
+                    {
+                        "required": [
+                            "harvardoxford"
+                        ]
+                    }, 
+                    {
+                        "required": [
+                            "cpac200"
+                        ]
+                    }
+                ]
+            }
+        ], 
+        "dependencies": {
+            "dti_file": {
+                "properties": {
+                    "dti_file_minc": {
+                        "not": {}
+                    }
+                }
+            }, 
+            "dti_file_minc": {
+                "properties": {
+                    "dti_file": {
+                        "not": {}
+                    }
+                }
+            }
+        }, 
+        "description": "Invocation schema for ndmg.", 
+        "properties": {
+            "aal": {
+                "enum": [
+                    "/ndmg_atlases/labels/AAL.nii.gz"
+                ]
+            }, 
+            "atlas": {
+                "enum": [
+                    "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
+                ]
+            }, 
+            "bval_file": {
+                "type": "string"
+            }, 
+            "bvec_file": {
+                "type": "string"
+            }, 
+            "clean": {
+                "type": "boolean"
+            }, 
+            "cpac200": {
+                "enum": [
+                    "/ndmg_atlases/labels/CPAC200.nii.gz"
+                ]
+            }, 
+            "desikan": {
+                "enum": [
+                    "/ndmg_atlases/labels/desikan.nii.gz"
+                ]
+            }, 
+            "dti_file": {
+                "type": "string"
+            }, 
+            "dti_file_minc": {
+                "type": "string"
+            }, 
+            "extra1": {
+                "type": "string"
+            }, 
+            "extra2": {
+                "type": "string"
+            }, 
+            "harvardoxford": {
+                "enum": [
+                    "/ndmg_atlases/labels/HarvardOxford.nii.gz"
+                ]
+            }, 
+            "jhu": {
+                "enum": [
+                    "/ndmg_atlases/labels/JHU.nii.gz"
+                ]
+            }, 
+            "mask": {
+                "enum": [
+                    "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
+                ]
+            }, 
+            "mprage_file": {
+                "type": "string"
+            }, 
+            "outdir": {
+                "type": "string"
+            }, 
+            "talairach": {
+                "enum": [
+                    "/ndmg_atlases/labels/Talairach.nii.gz"
+                ]
+            }
+        }, 
+        "required": [
+            "bval_file", 
+            "bvec_file", 
+            "mprage_file", 
+            "atlas", 
+            "mask", 
+            "outdir"
+        ], 
+        "title": "ndmg.invocationSchema", 
+        "type": "object"
+    }, 
+    "name": "ndmg", 
     "output-files": [
         {
-            "id": "aligned_dti",
-            "name": "Aligned DTI volume",
-            "optional": true,
-            "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz",
+            "id": "aligned_dti", 
+            "name": "Aligned DTI volume", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "tensors",
-            "name": "Tensor maps",
-            "optional": true,
-            "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz",
+            "id": "tensors", 
+            "name": "Tensor maps", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "fibers",
-            "name": "Fiber streamlines",
-            "optional": true,
-            "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz",
+            "id": "fibers", 
+            "name": "Fiber streamlines", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "desikan_graph",
-            "name": "Desikan graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle",
+            "id": "desikan_graph", 
+            "name": "Desikan graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "jhu_graph",
-            "name": "JHU graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle",
+            "id": "jhu_graph", 
+            "name": "JHU graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "talairach_graph",
-            "name": "Talairach graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle",
+            "id": "talairach_graph", 
+            "name": "Talairach graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "aal_graph",
-            "name": "AAL graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle",
+            "id": "aal_graph", 
+            "name": "AAL graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "harvardoxford_graph",
-            "name": "Harvard-Oxford graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle",
+            "id": "harvardoxford_graph", 
+            "name": "Harvard-Oxford graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "cpac200_graph",
-            "name": "CPAC200 graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle",
+            "id": "cpac200_graph", 
+            "name": "CPAC200 graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
         }
-    ],
-    "schema-version": "0.5",
+    ], 
+    "schema-version": "0.5", 
     "suggested-resources": {
-        "cpu-cores": 1,
-        "ram": 12,
+        "cpu-cores": 1, 
+        "ram": 12, 
         "walltime-estimate": 3600
-    },
+    }, 
     "tags": {
-	"domain": "testing",
-	"status": "experimental",
-	"foo": "bar"	
-    },
-    "error-codes": [
-	    {
-		"code": 1,
-		"description": "crashed"
-	    },
-	    {
-		"code": 12,
-		"description": "crashed badly"
-	    }
-    ],
+        "domain": "testing", 
+        "foo": "bar", 
+        "status": "experimental"
+    }, 
     "tool-version": "v0.0.41-1"
 }

--- a/tools/python/boutiques/tests/test_publisher.py
+++ b/tools/python/boutiques/tests/test_publisher.py
@@ -1,9 +1,13 @@
-from unittest import TestCase
 from boutiques import __file__ as bfile
 from boutiques.publisher import ZenodoError
 from boutiques.bosh import bosh
 import subprocess
 import os
+import sys
+if sys.version_info < (2, 7):
+    from unittest2 import TestCase
+else:
+    from unittest import TestCase
 
 
 class TestPublisher(TestCase):

--- a/tools/python/boutiques/tests/test_test.py
+++ b/tools/python/boutiques/tests/test_test.py
@@ -3,10 +3,14 @@
 import subprocess
 import pytest
 import os.path as op
-from unittest import TestCase
 from boutiques import __file__ as bfile
 from boutiques import bosh
 from jsonschema.exceptions import ValidationError
+import sys
+if sys.version_info < (2, 7):
+    from unittest2 import TestCase
+else:
+    from unittest import TestCase
 
 
 class TestTest(TestCase):

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -88,14 +88,14 @@ def validate_descriptor(json_file, **kwargs):
     cmdline = descriptor["command-line"]
 
     # Verify that all command-line key appear in the command-line
-    msg_template = "   KeyError: \"{}\" not in command-line or file template"
+    msg_template = "   KeyError: \"{0}\" not in command-line or file template"
     errors += [msg_template.format(k)
                for k in clkeys
                if (cmdline.count(k) +
                    " ".join(configFileTemplates).count(k)) < 1]
 
     # Verify that no key contains another key
-    msg_template = "   KeyError: \"{}\" contains \"{}\""
+    msg_template = "   KeyError: \"{0}\" contains \"{1}\""
     errors += [msg_template.format(key, clkeys[jdx])
                for idx, key in enumerate(clkeys)
                for jdx in range(0, len(clkeys))
@@ -105,7 +105,7 @@ def validate_descriptor(json_file, **kwargs):
     inIds, outIds = inputGet("id"), outputGet("id")
     grpIds = groupGet("id") if "groups" in descriptor.keys() else []
     allIds = inIds + outIds + grpIds
-    msg_template = "    IdError: \"{}\" is non-unique"
+    msg_template = "    IdError: \"{0}\" is non-unique"
     for idx, s1 in enumerate(allIds):
         for jdx, s2 in enumerate(allIds):
             if s1 == s2 and idx < jdx:
@@ -114,7 +114,7 @@ def validate_descriptor(json_file, **kwargs):
                 errors += []
 
     # Verify that identical keys only exist if they are both in mutex groups
-    msg_template = " MutExError: \"{}\" belongs to 2+ non exclusive IDs"
+    msg_template = " MutExError: \"{0}\" belongs to 2+ non exclusive IDs"
     for idx, key in enumerate(clkeys):
         for jdx in range(idx+1, len(clkeys)):
             if clkeys[jdx] == key:
@@ -126,7 +126,8 @@ def validate_descriptor(json_file, **kwargs):
                         errors += [msg_template.format(key)]
 
     # Verify that output files have unique path-templates
-    msg_template = "OutputError: \"{}\" and \"{}\" have the same path-template"
+    msg_template = ("OutputError: \"{0}\" and \"{1}\" have the same "
+                    "path-template")
     for idx, out1 in enumerate(descriptor["output-files"]):
         for jdx, out2 in enumerate(descriptor["output-files"]):
             if out1["path-template"] == out2["path-template"] and jdx > idx:
@@ -144,13 +145,13 @@ def validate_descriptor(json_file, **kwargs):
 
         # Verify flag-type inputs (have flags, not required, cannot be lists)
         if inp["type"] == "Flag":
-            msg_template = " InputError: \"{}\" must have a command-line flag"
+            msg_template = " InputError: \"{0}\" must have a command-line flag"
             if "command-line-flag" not in inp.keys():
                 errors += [msg_template.format(inp["id"])]
             else:
                 errors += []
 
-            msg_template = " InputError: \"{}\" is of type Flag,"\
+            msg_template = " InputError: \"{0}\" is of type Flag,"\
                            " it has to be optional"
             if inp["optional"] is False:
                 errors += [msg_template.format(inp["id"])]
@@ -159,8 +160,8 @@ def validate_descriptor(json_file, **kwargs):
 
         # Verify number-type inputs min/max are sensible
         elif inp["type"] == "Number":
-            msg_template = " InputError: \"{}\" cannot have greater"\
-                           " min ({}) than max ({})"
+            msg_template = (" InputError: \"{0}\" cannot have greater"
+                            " min ({1}) than max ({2})")
             minn = inp["minimum"] if "minimum" in inp.keys() else -float("Inf")
             maxx = inp["maximum"] if "maximum" in inp.keys() else float("Inf")
             if minn > maxx:
@@ -170,14 +171,14 @@ def validate_descriptor(json_file, **kwargs):
 
         # Verify enum-type inputs (at least 1 option, default in set)
         elif "value-choices" in inp.keys():
-            msg_template = " InputError: \"{}\" must have at least"\
-                           " one value choice"
+            msg_template = (" InputError: \"{0}\" must have at least"
+                            " one value choice")
             if len(inp["value-choices"]) < 1:
                 errors += [msg_template.format(inp["id"])]
             else:
                 errors += []
 
-            msg_template = " InputError: \"{}\" cannot have default"\
+            msg_template = " InputError: \"{0}\" cannot have default"\
                            " value outside its choices"
             if ("default-value" in inp.keys()
                and inp["default-value"] not in inp["value-choices"]):
@@ -188,8 +189,8 @@ def validate_descriptor(json_file, **kwargs):
         # Verify list-type inputs (min entries less than max,
         # no negative entries (both on min and max)
         if "list" in inp.keys():
-            msg_template = " InputError: \"{}\" cannot have greater min"\
-                           " entries ({}) than max entries ({})"
+            msg_template = (" InputError: \"{0}\" cannot have greater min"
+                            " entries ({1}) than max entries ({2})")
             minn = inp.get("min-list-entries") or 0
             maxx = inp.get("max-list-entries") or float("Inf")
             if minn > maxx:
@@ -197,19 +198,19 @@ def validate_descriptor(json_file, **kwargs):
             else:
                 errors += []
 
-            msg_template = " InputError: \"{}\" cannot have negative min"\
-                           " entries ({})"
+            msg_template = (" InputError: \"{0}\" cannot have negative min"
+                            " entries ({1})")
             errors += [msg_template.format(inp["id"], minn)] if minn < 0 else []
 
-            msg_template = " InputError: \"{}\" cannot have non-positive"\
-                           " max entries ({})"
+            msg_template = (" InputError: \"{0}\" cannot have non-positive"
+                            " max entries ({1})")
             if maxx <= 0:
                 errors += [msg_template.format(inp["id"], maxx)]
             else:
                 errors += []
 
         # Verify requires- and disables-inputs (present ids, non-overlapping)
-        msg_template = " InputError: \"{}\" {}d id \"{}\" not found"
+        msg_template = " InputError: \"{0}\" {1}d id \"{2}\" not found"
         for param in ["require", "disable"]:
             if param+"s-inputs" in inp.keys():
                 errors += [msg_template.format(inp["id"], param, ids)
@@ -217,7 +218,7 @@ def validate_descriptor(json_file, **kwargs):
                            if ids not in inIds]
 
         if "requires-inputs" in inp.keys() and "disables-inputs" in inp.keys():
-            msg_template = " InputError: \"{}\" requires and disables \"{}\""
+            msg_template = " InputError: \"{0}\" requires and disables \"{1}\""
             errors += [msg_template.format(inp["id"], ids1)
                        for ids1 in inp["requires-inputs"]
                        for ids2 in inp["disables-inputs"]
@@ -225,8 +226,8 @@ def validate_descriptor(json_file, **kwargs):
 
         # Verify required inputs cannot require or disable other parameters
         if "requires-inputs" in inp.keys() or "disables-inputs" in inp.keys():
-            msg_template = " InputError: \"{}\" cannot require or"\
-                           " disable other inputs"
+            msg_template = (" InputError: \"{0}\" cannot require or"
+                            " disable other inputs")
             if not inp["optional"]:
                 errors += [msg_template.format(inp["id"])]
 
@@ -235,18 +236,18 @@ def validate_descriptor(json_file, **kwargs):
         grp = descriptor['groups'][idx]
         # Verify group members must (exist in inputs, show up
         # once, only belong to single group)
-        msg_template = " GroupError: \"{}\" member \"{}\" does not exist"
+        msg_template = " GroupError: \"{0}\" member \"{1}\" does not exist"
         errors += [msg_template.format(grp["id"], member)
                    for member in grp["members"] if member not in inIds]
 
-        msg_template = " GroupError: \"{}\" member \"{}\" appears twice"
+        msg_template = " GroupError: \"{0}\" member \"{1}\" appears twice"
         errors += [msg_template.format(grp["id"], member)
                    for member in set(grp["members"])
                    if grp["members"].count(member) > 1]
 
         for jdx, grp2 in enumerate(descriptor["groups"]):
-            msg_template = " GroupError: \"{}\" and \"{}\" both contain"\
-                           " member \"{}\""
+            msg_template = (" GroupError: \"{0}\" and \"{1}\" both contain"
+                            " member \"{2}\"")
             errors += [msg_template.format(grp["id"], grp2["id"], m1)
                        for m1 in grp["members"]
                        for m2 in grp2["members"]
@@ -255,15 +256,16 @@ def validate_descriptor(json_file, **kwargs):
         # Verify mutually exclusive groups cannot have required members
         # nor requiring members
         if "mutually-exclusive" in grp.keys():
-            msg_template = " GroupError: \"{}\" is mutually-exclusive"\
-                           " and cannot have required members, such as \"{}\""
+            msg_template = (" GroupError: \"{0}\" is mutually-exclusive"
+                            " and cannot have required members, "
+                            "such as \"{1}\"")
             errors += [msg_template.format(grp["id"], member)
                        for member in set(grp["members"])
                        if not inById(member)["optional"]]
 
-            msg_template = " GroupError: \"{}\" is mutually-exclusive"\
-                           " and cannot have members require one another,"\
-                           " such as \"{}\" and \"{}\""
+            msg_template = (" GroupError: \"{0}\" is mutually-exclusive"
+                            " and cannot have members require one another,"
+                            " such as \"{1}\" and \"{2}\"")
             for member in set(grp["members"]):
                 if "requires-inputs" in inById(member).keys():
                     errors += [msg_template.format(grp["id"], member, req)
@@ -272,23 +274,23 @@ def validate_descriptor(json_file, **kwargs):
 
         # Verify one-is-required groups should never have required members
         if "one-is-required" in grp.keys():
-            msg_template = " GroupError: \"{}\" is a one-is-required"\
-                           " group and contains a required member, \"{}\""
+            msg_template = (" GroupError: \"{0}\" is a one-is-required"
+                            " group and contains a required member, \"{1}\"")
             errors += [msg_template.format(grp["id"], member)
                        for member in set(grp["members"])
                        if member in inIds and not inById(member)["optional"]]
 
         # Verify one-is-required groups should never have required members
         if "all-or-none" in grp.keys():
-            msg_template = " GroupError: \"{}\" is an all-or-none group"\
-                           " and cannot be paired with one-is-required"\
-                           " or mutually-exclusive groups"
+            msg_template = (" GroupError: \"{0}\" is an all-or-none group"
+                            " and cannot be paired with one-is-required"
+                            " or mutually-exclusive groups")
             if ("one-is-required" in grp.keys()
                or "mutually-exclusive" in grp.keys()):
                     errors += [msg_template.format(grp["id"])]
 
-            msg_template = " GroupError: \"{}\" is an all-or-none"
-            " group and contains a required member, \"{}\""
+            msg_template = (" GroupError: \"{0}\" is an all-or-none"
+                            " group and contains a required member, \"{1}\"")
             errors += [msg_template.format(grp["id"], member)
                        for member in set(grp["members"])
                        if member in inIds and not inById(member)["optional"]]
@@ -304,23 +306,23 @@ def validate_descriptor(json_file, **kwargs):
                                           "output-files", "id")
 
                 # Verify if output reference ids are valid
-                msg_template = "TestError: \"{}\" output id"\
-                               " not found, in test \"{}\""
+                msg_template = ("TestError: \"{0}\" output id"
+                                " not found, in test \"{1}\"")
                 errors += [msg_template.format(output_id, test["name"])
                            for output_id in test_output_ids
                            if (output_id not in outIds)]
 
                 # Verify that we do not have multiple output
                 # references refering to the same id
-                msg_template = "TestError: \"{}\" output id"\
-                               " cannot appear more than once within"\
-                               " same test, in test \"{}\""
+                msg_template = ("TestError: \"{0}\" output id"
+                                " cannot appear more than once within"
+                                " same test, in test \"{1}\"")
                 errors += [msg_template.format(output_id, test["name"])
                            for output_id in set(test_output_ids)
                            if (test_output_ids.count(output_id) > 1)]
 
         # Verify that all the defined tests have unique names
-        msg_template = "TestError: \"{}\" test name is non-unique"
+        msg_template = "TestError: \"{0}\" test name is non-unique"
         errors += [msg_template.format(test_name)
                    for test_name in set(tests_names)
                    if (tests_names.count(test_name) > 1)]

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -1,23 +1,33 @@
+import sys
 from setuptools import setup
+import sys
 
 VERSION = "0.5.7"
 DEPS = [
          "simplejson",
-         "jsonschema",
          "requests",
          "pytest",
        ]
+
+# jsonschema 2.6 doesn't support Python 2.6
+# and unittest2 is a backport of Python 2.7's 'unittest to 2.6
+if sys.version_info < (2, 7):
+    DEPS.append("unittest2")
+    DEPS.append("jsonschema==2.5.1")
+else:
+    DEPS.append("jsonschema")
 
 setup(name="boutiques",
       version=VERSION,
       description="Schema for describing bash command-line tools",
       url="http://github.com/boutiques/boutiques",
       author="Tristan Glatard, Gregory Kiar",
-      author_email="tristan.glatard@gmail.com, gkiar07@gmail.com",
+      author_email="tristan.glatard@concordia.ca, gkiar07@gmail.com",
       classifiers=[
                 "Programming Language :: Python",
                 "Programming Language :: Python :: 2",
                 "Programming Language :: Python :: 3",
+                "Programming Language :: Python :: 2.6",
                 "Programming Language :: Python :: 2.7",
                 "Programming Language :: Python :: 3.5",
                 "Programming Language :: Python :: 3.6",
@@ -35,7 +45,7 @@ setup(name="boutiques",
       tests_require=["pytest"],
       setup_requires=DEPS,
       install_requires=DEPS,
-      entry_points = {
+      entry_points=  {
         "console_scripts": [
             "bosh=boutiques.bosh:bosh",
         ]


### PR DESCRIPTION
* Replaced `{}` with `{<int>}` in string formats
* Removed dictionary comprehensions
* In `setup.py`, required `jsonschema==2.5.1` for Python 2.6 (jsonschema dropped Python 2.6 support from version 2.6)
* Imported `TestCase` from `unittest2` instead of `unittest` when Python 2.6 is used. `unittest2` is a backport of Python 2.7's unittest.
* Not sure what to do with `requirements.txt` so left it as is.

Fixes #167 and #166.