### PR TITLE
Small fixes

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -12,6 +12,7 @@ from jsonschema import ValidationError
 from boutiques.validator import DescriptorValidationError
 from boutiques.publisher import ZenodoError
 from boutiques.invocationSchemaHandler import InvocationValidationError
+from boutiques.localExec import ToolOutputNotFoundError
 
 
 def validate(*params):
@@ -391,10 +392,11 @@ def bosh(args=None):
 
     except (ZenodoError,
             DescriptorValidationError,
-            InvocationValidationError) as e:
+            InvocationValidationError,
+            ToolOutputNotFoundError) as e:
         # We don't want to raise an exception when function is called
         # from CLI.'
         if runs_as_cli():
             print(e)
-            return 1
+            return 99  # Problem: this conflicts with tool error codes.
         raise e

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -398,5 +398,5 @@ def bosh(args=None):
         # from CLI.'
         if runs_as_cli():
             print(e)
-            return 99  # Problem: this conflicts with tool error codes.
+            return 99  # Note: this conflicts with tool error codes.
         raise e

--- a/tools/python/boutiques/invocationSchemaHandler.py
+++ b/tools/python/boutiques/invocationSchemaHandler.py
@@ -171,7 +171,7 @@ def validateSchema(s, d=None, **kwargs):
                 try:
                         jsonschema.validate(d, s)
                 except ValidationError as e:
-                        raise InvocationValidationError(e.message)
+                        raise InvocationValidationError(e)
                 if kwargs.get("verbose"):
                         print("Invocation Schema validation OK")
 

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -14,6 +14,10 @@ import pwd
 import os.path as op
 
 
+class ToolOutputNotFoundError(Exception):
+    pass
+
+
 # Executor class
 class LocalExecutor(object):
     """
@@ -247,12 +251,12 @@ class LocalExecutor(object):
                 isOptional = False
             s1 = 'Optional' if isOptional else 'Required'
             s2 = '' if exists else 'not '
-            err = ''
+            message = (s1 + " output file \'" + outfile['name'] +
+                       "\' was " + s2 + "found at " + outFileName)
             if (not isOptional and not exists):
-                err = "Error! "
-            # Add error warning when required file is missing
-            print("\t" + err + s1 + " output file \'" + outfile['name'] +
-                  "\' was " + s2 + "found at " + outFileName)
+                raise ToolOutputNotFoundError(message)
+            else:
+                print("\t {0}".format(message))
         desc_err = ''
         if 'error-codes' in list(self.desc_dict.keys()):
             for err_elem in self.desc_dict['error-codes']:

--- a/tools/python/boutiques/schema/examples/invalid_json.json
+++ b/tools/python/boutiques/schema/examples/invalid_json.json
@@ -1,0 +1,26 @@
+{
+    "name": "output",
+    "tool-version": "1.0",
+    "description": "A simple script to test output files",
+    "command-line": "output.sh [INPUT_FILE] [OUTPUT_FILE]",
+    "schema-version": "0.5",
+    "container-image": {
+	"type": "docker"
+	"image": "boutiques/examples"
+    },
+    "inputs": [{
+	"id": "input_file",
+	"name": "Input file",
+        "command-line-key": "[INPUT_FILE]",
+	"type": "File",
+	"optional": false
+    }],
+    "output-files": [{
+	"id": "output_file",
+	"name": "Output file",
+        "command-line-key": "[OUTPUT_FILE]",
+	"path-template": "[INPUT_FILE]-processed.log",
+	"path-template-striped-extensions": [".txt",".mnc",".cpp",".m",".j"]
+    }]
+
+}

--- a/tools/python/boutiques/schema/examples/no_container.json
+++ b/tools/python/boutiques/schema/examples/no_container.json
@@ -1,0 +1,22 @@
+{
+    "command-line": "echo [INPUT] > file.txt", 
+    "description": "a tool with no container image", 
+    "inputs": [
+        {
+            "id": "param", 
+            "name": "param", 
+            "type": "String", 
+            "value-key": "[INPUT]"
+        }
+    ],
+    "name": "cat", 
+    "output-files": [
+        {
+            "id": "output_file", 
+            "name": "output file", 
+            "path-template": "file.txt"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "tool-version": "0.1"
+}

--- a/tools/python/boutiques/schema/examples/no_container_invocation.json
+++ b/tools/python/boutiques/schema/examples/no_container_invocation.json
@@ -1,0 +1,3 @@
+{
+  "param": "hello"
+}

--- a/tools/python/boutiques/tests/test_no_container.py
+++ b/tools/python/boutiques/tests/test_no_container.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import pytest
+from unittest import TestCase
+from boutiques import __file__ as bfile
+import boutiques as bosh
+
+
+class TestExample1(TestCase):
+
+    def get_examples_dir(self):
+        return os.path.join(os.path.dirname(bfile),
+                            "schema", "examples")
+
+    def test_no_container(self):
+        self.assertFalse(bosh.execute("launch",
+                                      os.path.join(self.get_examples_dir(),
+                                                   "no_container.json"),
+                                      os.path.join(self.get_examples_dir(),
+                                                   "no_container_invocation."
+                                                   + "json"))[2])

--- a/tools/python/boutiques/tests/test_validator.py
+++ b/tools/python/boutiques/tests/test_validator.py
@@ -23,8 +23,12 @@ class TestValidator(TestCase):
         fil = op.join(op.split(bfile)[0], 'schema/examples/bad.json')
         self.assertRaises(DescriptorValidationError, bosh, ['validate', fil])
 
-    def test_invalid(self):
+    def test_invalid_boutiques(self):
         fil = op.join(op.split(bfile)[0], 'schema/examples/invalid.json')
+        self.assertRaises(DescriptorValidationError, bosh, ['validate', fil])
+
+    def test_invalid_json(self):
+        fil = op.join(op.split(bfile)[0], 'schema/examples/invalid_json.json')
         self.assertRaises(DescriptorValidationError, bosh, ['validate', fil])
 
     def test_invalid_cli(self):

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -50,7 +50,10 @@ def validate_descriptor(json_file, **kwargs):
 
     # Load descriptor
     with open(json_file) as fhandle:
-        descriptor = simplejson.load(fhandle)
+        try:
+            descriptor = simplejson.load(fhandle)
+        except simplejson.errors.JSONDecodeError as e:
+            raise DescriptorValidationError(e.message)
 
     # Validate basic JSON schema compliance for descriptor
     # Note: if it fails basic schema compliance we don"t do more checks

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -53,14 +53,14 @@ def validate_descriptor(json_file, **kwargs):
         try:
             descriptor = simplejson.load(fhandle)
         except simplejson.errors.JSONDecodeError as e:
-            raise DescriptorValidationError(e.message)
+            raise DescriptorValidationError(e)
 
     # Validate basic JSON schema compliance for descriptor
     # Note: if it fails basic schema compliance we don"t do more checks
     try:
         validate(descriptor, schema)
     except ValidationError as e:
-        raise DescriptorValidationError(e.message)
+        raise DescriptorValidationError(e)
 
     # Helper get functions
     def safeGet(desc, sec, targ):


### PR DESCRIPTION
* Added a test for tools with no container image (#172)
* `bosh` CLI now returns `99` in case an exception occurs, to reduce potential conflict with tool exit code.
* Added a test for invalid JSON descriptors and caught the exception in validator.
* Raised an exception when mandatory output file is not found (was just printing a message).