### PR TITLE
Identifiers in CARMIN exports

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -169,11 +169,11 @@ def importer(*params):
 
 def exporter(*params):
     parser = ArgumentParser("Export Boutiques descriptor to other formats.")
-    parser.add_argument("type", help="Type of export we are performing."
-                        " For carmin, pipeline id is set to the output"
-                        " file name.",
+    parser.add_argument("type", help="Type of export we are performing.",
                         choices=["carmin"])
     parser.add_argument("descriptor", help="Boutiques descriptor to export.")
+    parser.add_argument("identifier", help="Identifier to use in"
+                                           "CARMIN export.")
     parser.add_argument("output", help="Output file where to write the"
                         " converted descriptor.")
     results = parser.parse_args(params)
@@ -184,7 +184,7 @@ def exporter(*params):
     bosh(["validate", results.descriptor])
 
     from boutiques.exporter import Exporter
-    exporter = Exporter(descriptor)
+    exporter = Exporter(descriptor, results.identifier)
     if results.type == "carmin":
         exporter.carmin(output)
 

--- a/tools/python/boutiques/exporter.py
+++ b/tools/python/boutiques/exporter.py
@@ -63,12 +63,12 @@ class Exporter():
             param['description'] = input_or_output.get('description')
         return param
 
-    def carmin(self, output_file):
+    def carmin(self, identifier, output_file):
         carmin_desc = {}
         with open(self.descriptor, 'r') as fhandle:
             descriptor = json.load(fhandle)
 
-        carmin_desc['identifier'] = str(uuid.uuid4())
+        carmin_desc['identifier'] = identifier
         carmin_desc['name'] = descriptor.get('name')
         carmin_desc['version'] = descriptor.get('tool-version')
         carmin_desc['description'] = descriptor.get('description')

--- a/tools/python/boutiques/exporter.py
+++ b/tools/python/boutiques/exporter.py
@@ -31,8 +31,9 @@ import uuid
 
 class Exporter():
 
-    def __init__(self, descriptor):
+    def __init__(self, descriptor, identifier):
         self.descriptor = descriptor
+        self.identifier = identifier
 
     def convert_type(self, boutiques_type, is_integer=False, is_list=False):
         if is_list:
@@ -63,12 +64,12 @@ class Exporter():
             param['description'] = input_or_output.get('description')
         return param
 
-    def carmin(self, identifier, output_file):
+    def carmin(self, output_file):
         carmin_desc = {}
         with open(self.descriptor, 'r') as fhandle:
             descriptor = json.load(fhandle)
 
-        carmin_desc['identifier'] = identifier
+        carmin_desc['identifier'] = self.identifier
         carmin_desc['name'] = descriptor.get('name')
         carmin_desc['version'] = descriptor.get('tool-version')
         carmin_desc['description'] = descriptor.get('description')

--- a/tools/python/boutiques/tests/test_export.py
+++ b/tools/python/boutiques/tests/test_export.py
@@ -15,5 +15,5 @@ class TestImport(TestCase):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
         example1_desc = os.path.join(example1_dir, "example1_docker.json")
         fout = "test-example1-carmin.json"
-        self.assertFalse(bosh(["export", "carmin", example1_desc, fout]))
+        self.assertFalse(bosh(["export", "carmin", example1_desc, "123", fout]))
         os.remove(fout)


### PR DESCRIPTION
This fixes #256. I realize that we may want to have a discussion on what should be a pipeline identifier but @simon-dube and @louis-ver need this a.s.a.p to complete the CARMIN server. This PR provides a flexible solution where the identifier is set by the user. 