### PR TITLE
Changes to be compliant with the schema v0.5

### DIFF
--- a/examples/custom-properties/custom.json
+++ b/examples/custom-properties/custom.json
@@ -3,7 +3,7 @@
     "tool-version": "1.0",
     "description": "A simple script to test output files",
     "command-line": "output.sh [INPUT_FILE] [OUTPUT_FILE]",
-    "schema-version": "0.4",
+    "schema-version": "0.5",
     "container-image": {
 	"type": "docker",
 	"image": "boutiques/examples"
@@ -11,14 +11,14 @@
     "inputs": [{
 	"id": "input_file",
 	"name": "Input file",
-        "command-line-key": "[INPUT_FILE]",
+        "value-key": "[INPUT_FILE]",
 	"type": "File",
 	"optional": false
     }],
     "output-files": [{
 	"id": "output_file",
 	"name": "Output file",
-        "command-line-key": "[OUTPUT_FILE]",
+        "value-key": "[OUTPUT_FILE]",
 	"path-template": "[INPUT_FILE]-processed.log",
 	"path-template-stripped-extensions": [".txt",".mnc",".cpp",".m",".j"]
     }],


### PR DESCRIPTION
Changes to be compliant with the boutiques schema version 0.5.

We were using this example and realized that it wasn't compliant with the last version of the boutiques schema. We then made the changes so that future people testing boutiques with the github examples don't have errors when validating them. 