### PR TITLE
CWL importer

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -15,6 +15,7 @@ from boutiques.invocationSchemaHandler import InvocationValidationError
 from boutiques.localExec import ExecutorOutput
 from boutiques.localExec import ExecutorError
 from boutiques.exporter import ExportError
+from boutiques.importer import ImportError
 
 
 def create(*params):
@@ -159,24 +160,34 @@ def execute(*params):
 
 
 def importer(*params):
-    parser = ArgumentParser("Imports old descriptor or BIDS app to spec.")
+    parser = ArgumentParser("Imports old descriptor or BIDS app or CWL "
+                            " descriptor to spec.")
     parser.add_argument("type", help="Type of import we are performing",
-                        choices=["bids", "0.4"])
-    parser.add_argument("descriptor", help="Where the Boutiques"
+                        choices=["bids", "0.4", "cwl"])
+    parser.add_argument("output_descriptor", help="Where the Boutiques"
                         " descriptor will be written.")
-    parser.add_argument("input", help="Input to be convered. For '0.4'"
+    parser.add_argument("input_descriptor", help="Input descriptor to be "
+                        "converted. For '0.4'"
                         ", is JSON descriptor,"
-                        " for 'bids' is base directory of BIDS app.")
+                        " for 'bids' is base directory of BIDS app, "
+                        "for 'cwl' is YAML descriptor.")
+    parser.add_argument("-o", "--output-invocation", help="Where to write "
+                        "the invocation if any.")
+    parser.add_argument("-i", "--input-invocation", help="Input invocation "
+                        " for CWL if any.")
     results = parser.parse_args(params)
 
-    descriptor = results.descriptor
-    inp = results.input
     from boutiques.importer import Importer
-    importer = Importer(descriptor)
+    importer = Importer(results.input_descriptor,
+                        results.output_descriptor,
+                        results.input_invocation,
+                        results.output_invocation)
     if results.type == "0.4":
-        importer.upgrade_04(inp)
+        importer.upgrade_04()
     elif results.type == "bids":
-        importer.import_bids(inp)
+        importer.import_bids()
+    elif results.type == "cwl":
+        importer.import_cwl()
 
 
 def exporter(*params):
@@ -420,6 +431,7 @@ def bosh(args=None):
             InvocationValidationError,
             ValidationError,
             ExportError,
+            ImportError,
             ExecutorError) as e:
         # We don't want to raise an exception when function is called
         # from CLI.'

--- a/tools/python/boutiques/importer.py
+++ b/tools/python/boutiques/importer.py
@@ -133,14 +133,13 @@ class Importer():
         # Read the CWL descriptor
         with open(self.input_descriptor, 'r') as f:
             cwl_desc = yaml.load(f)
-        d_file = self.input_descriptor
 
         # validate yaml descriptor?
 
         bout_desc = {}
         # Command line
         if cwl_desc.get('baseCommand') is None:
-            raise ImportError(d_file + ': Cannot find baseCommand attribute, '
+            raise ImportError('Cannot find baseCommand attribute, '
                               'perhaps you passed a workflow document, '
                               'this is not supported')
         if type(cwl_desc['baseCommand']) is list:
@@ -152,10 +151,9 @@ class Importer():
         if cwl_desc.get('arguments'):
             for i in cwl_desc['arguments']:
                 if type(i) is dict:
-                    raise ImportError(d_file + ': '
-                                      ' Dict arguments not supported.')
+                    raise ImportError('Dict arguments not supported.')
                 if "$(runtime." in i:
-                    raise ImportError(d_file + ': Runtime parameters '
+                    raise ImportError('Runtime parameters '
                                       ' are not supported:'
                                       " "+i)
                 command_line += i+" "
@@ -199,18 +197,18 @@ class Importer():
                 cwl_type = 'string'
             if type(cwl_type) is dict:  # It must be an array
                 if cwl_type['type'] != "array":
-                    raise ImportError(d_file + ": Only 1-level nested "
+                    raise ImportError("Only 1-level nested "
                                       "types of type"
                                       " 'array' are supported (CWL input: {0})".
                                       format(cwl_input))
                 if cwl_type.get('inputBinding') is not None:
-                    raise ImportError(d_file + ": Input bindings of "
+                    raise ImportError("Input bindings of "
                                       "array elements "
                                       "are not supported (CWL input: {0})".
                                       format(cwl_input))
                 cwl_type = cwl_type['items']
-                if type(cwl_type) != string:
-                    raise ImportError(d_file + ": Unknown type:"
+                if type(cwl_type) != str:
+                    raise ImportError("Unknown type:"
                                       " {0}".format(str(cwl_type)))
                 bout_input['list'] = True
             boutiques_type = boutiques_types[cwl_type.replace("[]", "")
@@ -238,7 +236,7 @@ class Importer():
                 bout_input['list'] = True
                 if cwl_input_binding.get("itemSeparator"):
                     if cwl_input_binding['itemSeparator'] != ' ':
-                        raise ImportError(d_file + ': Array separators wont be '
+                        raise ImportError('Array separators wont be '
                                           'supported until #76 is implemented')
 
         # Outputs
@@ -247,12 +245,12 @@ class Importer():
             if not glob.startswith("$"):
                 return glob
             if not glob.startswith("$(inputs."):
-                raise ImportError(d_file + ": Unsupported reference: "+glob)
+                raise ImportError("Unsupported reference: "+glob)
             input_id = glob.replace("$(inputs.", "").replace(")", "")
             for i in boutiques_inputs:
                 if i['id'] == input_id:
                     return i['value-key']
-            raise ImportError(d_file + ": Unresolved reference"
+            raise ImportError("Unresolved reference"
                               " in glob: " + glob)
 
         boutiques_outputs = []
@@ -278,7 +276,7 @@ class Importer():
                        and cwl_out_obj['type']['type'] == 'array'):
                             bout_output['list'] = True
                     else:
-                        raise ImportError(d_file + ': Unsupported output type: '
+                        raise ImportError('Unsupported output type: '
                                           + cwl_output['type'])
                 boutiques_outputs.append(bout_output)
         # Boutiques descriptors have to have at least 1 output file
@@ -333,7 +331,7 @@ class Importer():
                     suggeseted_resources['cpu-cores'] = req['coresMin']
                 bout_desc['suggested-resources'] = suggested_resources
                 return
-            raise ImportError(d_file + ': Unsupported requirement: '+str(req))
+            raise ImportError('Unsupported requirement: '+str(req))
 
         for key in ['requirements', 'hints']:
             if(cwl_desc.get(key)):

--- a/tools/python/boutiques/importer.py
+++ b/tools/python/boutiques/importer.py
@@ -129,16 +129,15 @@ class Importer():
             f.write(template_string)
 
     def import_cwl(self):
-        ''' Known limitations:
-        * CWL complex types are not supported.
-        '''
+
+        # Read the CWL descriptor
         with open(self.input_descriptor, 'r') as f:
             cwl_desc = yaml.load(f)
         d_file = self.input_descriptor
 
         # validate yaml descriptor?
-        bout_desc = {}
 
+        bout_desc = {}
         # Command line
         if cwl_desc.get('baseCommand') is None:
             raise ImportError(d_file + ': Cannot find baseCommand attribute, '
@@ -189,7 +188,7 @@ class Importer():
                 bout_input['name'] = cwl_in_obj['name']
             else:
                 bout_input['name'] = cwl_input
-            value_key = "[{}]".format(cwl_input.upper())
+            value_key = "[{0}]".format(cwl_input.upper())
             command_line += " "+value_key
             bout_input['value-key'] = value_key
 
@@ -202,12 +201,12 @@ class Importer():
                 if cwl_type['type'] != "array":
                     raise ImportError(d_file + ": Only 1-level nested "
                                       "types of type"
-                                      " 'array' are supported (CWL input: {})".
+                                      " 'array' are supported (CWL input: {0})".
                                       format(cwl_input))
                 if cwl_type.get('inputBinding') is not None:
                     raise ImportError(d_file + ": Input bindings of "
                                       "array elements "
-                                      "are not supported (CWL input: {})".
+                                      "are not supported (CWL input: {0})".
                                       format(cwl_input))
                 cwl_type = cwl_type['items']
                 bout_input['list'] = True

--- a/tools/python/boutiques/importer.py
+++ b/tools/python/boutiques/importer.py
@@ -209,6 +209,9 @@ class Importer():
                                       "are not supported (CWL input: {0})".
                                       format(cwl_input))
                 cwl_type = cwl_type['items']
+                if type(cwl_type) != string:
+                    raise ImportError(d_file + ": Unknown type:"
+                                      " {0}".format(str(cwl_type)))
                 bout_input['list'] = True
             boutiques_type = boutiques_types[cwl_type.replace("[]", "")
                                                      .replace("?", "")]

--- a/tools/python/boutiques/importer.py
+++ b/tools/python/boutiques/importer.py
@@ -3,16 +3,27 @@
 from argparse import ArgumentParser
 from jsonschema import ValidationError
 from boutiques.validator import validate_descriptor
+import boutiques
+import yaml
 import json
 import os
+import os.path as op
+
+
+class ImportError(Exception):
+    pass
 
 
 class Importer():
 
-    def __init__(self, output_file):
-        self.output_file = output_file
+    def __init__(self, input_descriptor, output_descriptor,
+                 input_invocation, output_invocation):
+        self.input_descriptor = input_descriptor
+        self.output_descriptor = output_descriptor
+        self.input_invocation = input_invocation
+        self.output_invocation = output_invocation
 
-    def upgrade_04(self, input_file):
+    def upgrade_04(self):
         """
          Differences between 0.4 and current (0.5):
            -schema version (obv)
@@ -43,7 +54,7 @@ class Importer():
           "walltime-estimate": 3600
         },
         """
-        with open(input_file, 'r') as fhandle:
+        with open(self.input_descriptor, 'r') as fhandle:
             descriptor = json.load(fhandle)
 
         descriptor["schema-version"] = "0.5"
@@ -68,13 +79,13 @@ class Importer():
               {"walltime-estimate": descriptor["walltime-estimate"]}
             del descriptor["walltime-estimate"]
 
-        with open(self.output_file, 'w') as fhandle:
+        with open(self.output_descriptor, 'w') as fhandle:
             fhandle.write(json.dumps(descriptor, indent=4, sort_keys=True))
-        validate_descriptor(self.output_file)
+        validate_descriptor(self.output_descriptor)
 
-    def get_entry_point(self, app_dir):
+    def get_entry_point(self, input_descriptor):
         entrypoint = None
-        with open(os.path.join(app_dir, "Dockerfile")) as f:
+        with open(os.path.join(self.input_descriptor, "Dockerfile")) as f:
             content = f.readlines()
         for line in content:
             split = line.split()
@@ -82,7 +93,7 @@ class Importer():
                 entrypoint = split[1].strip("[]\"")
         return entrypoint
 
-    def import_bids(self, app_dir):
+    def import_bids(self):
         path, fil = os.path.split(__file__)
         template_file = os.path.join(path, "templates", "bids-app.json")
 
@@ -90,11 +101,11 @@ class Importer():
             template_string = f.read()
 
         errors = []
-        app_name = os.path.basename(os.path.abspath(app_dir))
-        with open(os.path.join(app_dir, "version"), "r") as f:
+        app_name = os.path.basename(os.path.abspath(self.input_descriptor))
+        with open(os.path.join(self.input_descriptor, "version"), "r") as f:
             version = f.read().strip()
         git_repo = "https://github.com/BIDS-Apps/"+app_name
-        entrypoint = self.get_entry_point(app_dir)
+        entrypoint = self.get_entry_point(self.input_descriptor)
         container_image = "bids/"+app_name
         analysis_types = "participant\", \"group\", \"session"
 
@@ -114,5 +125,245 @@ class Importer():
         template_string = template_string.replace("@@ANALYSIS_TYPES@@",
                                                   analysis_types)
 
-        with open(self.output_file, "w") as f:
+        with open(self.output_descriptor, "w") as f:
             f.write(template_string)
+
+    def import_cwl(self):
+        ''' Known limitations:
+        * CWL complex types are not supported.
+        '''
+        with open(self.input_descriptor, 'r') as f:
+            cwl_desc = yaml.load(f)
+        d_file = self.input_descriptor
+
+        # validate yaml descriptor?
+        bout_desc = {}
+
+        # Command line
+        if cwl_desc.get('baseCommand') is None:
+            raise ImportError(d_file + ': Cannot find baseCommand attribute, '
+                              'perhaps you passed a workflow document, '
+                              'this is not supported')
+        if type(cwl_desc['baseCommand']) is list:
+            command_line = ""
+            for i in cwl_desc['baseCommand']:
+                command_line += i+" "
+        else:
+            command_line = cwl_desc['baseCommand']
+        if cwl_desc.get('arguments'):
+            for i in cwl_desc['arguments']:
+                if type(i) is dict:
+                    raise ImportError(d_file + ': '
+                                      ' Dict arguments not supported.')
+                if "$(runtime." in i:
+                    raise ImportError(d_file + ': Runtime parameters '
+                                      ' are not supported:'
+                                      " "+i)
+                command_line += i+" "
+        boutiques_inputs = []
+
+        # Inputs
+        def position(x):
+            if (type(x) is dict and
+                    x.get('inputBinding') and
+                    x['inputBinding'].get('position')):
+                return x['inputBinding']['position']
+            return 0
+        sorted_inputs = sorted(cwl_desc['inputs'],
+                               key=lambda x: (position(cwl_desc['inputs'][x])))
+        # Mapping between CQL and Boutiques input types
+        boutiques_types = {
+          'string': 'String',
+          'File': 'File',
+          'File?': 'File',
+          'boolean': 'Flag',
+          'int': 'Number'
+          # float type?
+        }
+        for cwl_input in sorted_inputs:
+            bout_input = {}
+            # Easy stuff
+            bout_input['id'] = cwl_input  # perhaps 'idify' that
+            cwl_in_obj = cwl_desc['inputs'][cwl_input]
+            if type(cwl_in_obj) is dict and cwl_in_obj.get('name'):
+                bout_input['name'] = cwl_in_obj['name']
+            else:
+                bout_input['name'] = cwl_input
+            value_key = "[{}]".format(cwl_input.upper())
+            command_line += " "+value_key
+            bout_input['value-key'] = value_key
+
+            # CWL type parsing
+            if type(cwl_in_obj) is dict:
+                cwl_type = cwl_in_obj['type']
+            else:
+                cwl_type = 'string'
+            if type(cwl_type) is dict:  # It must be an array
+                if cwl_type['type'] != "array":
+                    raise ImportError(d_file + ": Only 1-level nested "
+                                      "types of type"
+                                      " 'array' are supported (CWL input: {})".
+                                      format(cwl_input))
+                if cwl_type.get('inputBinding') is not None:
+                    raise ImportError(d_file + ": Input bindings of "
+                                      "array elements "
+                                      "are not supported (CWL input: {})".
+                                      format(cwl_input))
+                cwl_type = cwl_type['items']
+                bout_input['list'] = True
+            boutiques_type = boutiques_types[cwl_type.replace("[]", "")
+                                                     .replace("?", "")]
+            bout_input['type'] = boutiques_type
+            if cwl_type == 'int':
+                bout_input['integer'] = True
+            if '?' in cwl_type or boutiques_type == "Flag":
+                bout_input['optional'] = True
+
+            # CWL input binding
+            if type(cwl_in_obj) is dict:
+                cwl_input_binding = cwl_in_obj['inputBinding']
+            else:
+                cwl_input_binding = {}
+            if cwl_input_binding.get('prefix'):
+                bout_input['command-line-flag'] = cwl_input_binding['prefix']
+                if (not (cwl_input_binding.get('separate') is None) and
+                        cwl_input_binding['separate'] is False):
+                    bout_input['command-line-flag-separator'] = ''
+            boutiques_inputs.append(bout_input)
+
+            # array types
+            if cwl_type.endswith("[]"):
+                bout_input['list'] = True
+                if cwl_input_binding.get("itemSeparator"):
+                    if cwl_input_binding['itemSeparator'] != ' ':
+                        raise ImportError(d_file + ': Array separators wont be '
+                                          'supported until #76 is implemented')
+
+        # Outputs
+
+        def resolve_glob(glob, boutiques_inputs):
+            if not glob.startswith("$"):
+                return glob
+            if not glob.startswith("$(inputs."):
+                raise ImportError(d_file + ": Unsupported reference: "+glob)
+            input_id = glob.replace("$(inputs.", "").replace(")", "")
+            for i in boutiques_inputs:
+                if i['id'] == input_id:
+                    return i['value-key']
+            raise ImportError(d_file + ": Unresolved reference"
+                              " in glob: " + glob)
+
+        boutiques_outputs = []
+        sorted_outputs = sorted(cwl_desc['outputs'],
+                                key=(lambda x: cwl_desc['outputs'][x].
+                                     get('outputBinding')))
+        for cwl_output in sorted_outputs:
+            bout_output = {}
+            bout_output['id'] = cwl_output  # perhaps 'idify' that
+            if cwl_desc['outputs'][cwl_output].get('name'):
+                bout_output['name'] = cwl_desc['outputs'][cwl_output]['name']
+            else:
+                bout_output['name'] = cwl_output
+            cwl_out_binding = (cwl_desc['outputs'][cwl_output].
+                               get('outputBinding'))
+            if cwl_out_binding and cwl_out_binding.get('glob'):
+                glob = cwl_out_binding['glob']
+                bout_output['path-template'] = resolve_glob(glob,
+                                                            boutiques_inputs)
+                cwl_out_obj = cwl_desc['outputs'][cwl_output]
+                if type(cwl_out_obj.get('type')) is dict:
+                    if (cwl_out_obj['type'].get('type')
+                       and cwl_out_obj['type']['type'] == 'array'):
+                            bout_output['list'] = True
+                    else:
+                        raise ImportError(d_file + ': Unsupported output type: '
+                                          + cwl_output['type'])
+                boutiques_outputs.append(bout_output)
+        # Boutiques descriptors have to have at least 1 output file
+        if len(boutiques_outputs) == 0 or cwl_desc.get('stdout'):
+            stdout = cwl_desc.get('stdout') or 'stdout.txt'
+            command_line += " > "+stdout
+            boutiques_outputs.append(
+              {
+                  'id': 'stdout',
+                  'name': 'Standard output',
+                  'path-template': 'stdout.txt'
+              }
+            )
+
+        # Mandatory boutiques fields
+        bout_desc['command-line'] = command_line
+        bout_desc['description'] = (cwl_desc.get("doc") or
+                                    "Tool imported from CWL.")
+        bout_desc['inputs'] = boutiques_inputs
+        # This may not be a great idea but not sure if CWL tools have names
+        bout_desc['name'] = op.splitext(op.basename(self.input_descriptor))[0]
+        bout_desc['output-files'] = boutiques_outputs
+        bout_desc['schema-version'] = '0.5'
+        bout_desc['tool-version'] = "unknown"  # perhaphs there's one in cwl
+
+        # Hints and requirements
+        def parse_req(req, req_type, bout_desc):
+            # We could support InitialWorkDirRequiment, through config files
+            if req_type == 'DockerRequirement':
+                container_image = {}
+                container_image['type'] = 'docker'
+                container_image['index'] = 'index.docker.io'
+                container_image['image'] = req['dockerPull']
+                bout_desc['container-image'] = container_image
+                return
+            if req_type == 'EnvVarRequirement':
+                bout_envars = []
+                for env_var in req['envDef']:
+                    bout_env_var = {}
+                    bout_env_var['name'] = env_var
+                    bout_env_var['value'] = resolve_glob(
+                                              req['envDef'][env_var],
+                                              boutiques_inputs)
+                    bout_envars.append(bout_env_var)
+                    bout_desc['environment-variables'] = bout_envars
+                return
+            if req_type == 'ResourceRequirement':
+                suggested_resources = {}
+                if req.get('ramMin'):
+                    suggested_resources['ram'] = req['ramMin']
+                if req.get('coresMin'):
+                    suggeseted_resources['cpu-cores'] = req['coresMin']
+                bout_desc['suggested-resources'] = suggested_resources
+                return
+            raise ImportError(d_file + ': Unsupported requirement: '+str(req))
+
+        for key in ['requirements', 'hints']:
+            if(cwl_desc.get(key)):
+                for i in cwl_desc[key]:
+                    parse_req(cwl_desc[key][i], i, bout_desc)
+
+        # enum types?
+
+        # Write descriptor
+        with open(self.output_descriptor, 'w') as f:
+            f.write(json.dumps(bout_desc, indent=4, sort_keys=True))
+        validate_descriptor(self.output_descriptor)
+
+        if self.input_invocation is None:
+            return
+
+        # Convert invocation
+        def get_input(descriptor_inputs, input_id):
+            for inp in descriptor_inputs:
+                if inp['id'] == input_id:
+                    return inp
+            return False
+        boutiques_invocation = {}
+        with open(self.input_invocation, 'r') as f:
+            cwl_inputs = yaml.load(f)
+        for input_name in cwl_inputs:
+            if get_input(bout_desc['inputs'], input_name)['type'] != "File":
+                input_value = cwl_inputs[input_name]
+            else:
+                input_value = cwl_inputs[input_name]['path']
+            boutiques_invocation[input_name] = input_value
+        with open(self.output_invocation, 'w') as f:
+            f.write(json.dumps(boutiques_invocation, indent=4, sort_keys=True))
+        boutiques.invocation(self.output_descriptor,
+                             "-i", self.output_invocation)

--- a/tools/python/boutiques/importer.py
+++ b/tools/python/boutiques/importer.py
@@ -212,10 +212,10 @@ class Importer():
                                       "are not supported (CWL input: {0})".
                                       format(cwl_input))
                 cwl_type = cwl_type['items']
-                if type(cwl_type) != str:
+                bout_input['list'] = True
+            if type(cwl_type) != str:
                     raise ImportError("Unknown type:"
                                       " {0}".format(str(cwl_type)))
-                bout_input['list'] = True
             boutiques_type = boutiques_types[cwl_type.replace("[]", "")
                                                      .replace("?", "")]
             bout_input['type'] = boutiques_type

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -790,7 +790,9 @@ class LocalExecutor(object):
                     if useFlags:
                         flag = self.safeGet(paramId, 'command-line-flag') or ''
                         sep = self.safeGet(paramId,
-                                           'command-line-flag-separator') or ' '
+                                           'command-line-flag-separator')
+                        if sep is None:
+                            sep = ' '
                         val = flag + sep + val
                         # special case for flag-type inputs
                         if self.safeGet(paramId, 'type') == 'Flag':

--- a/tools/python/boutiques/tests/cwl/1st-tool/1st-tool.cwl
+++ b/tools/python/boutiques/tests/cwl/1st-tool/1st-tool.cwl
@@ -1,0 +1,9 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+inputs:
+  message:
+    type: string
+    inputBinding:
+      position: 1
+outputs: []

--- a/tools/python/boutiques/tests/cwl/1st-workflow/1st-workflow-job.yml
+++ b/tools/python/boutiques/tests/cwl/1st-workflow/1st-workflow-job.yml
@@ -1,0 +1,4 @@
+inp:
+  class: File
+  path: hello.tar
+ex: Hello.java

--- a/tools/python/boutiques/tests/cwl/1st-workflow/1st-workflow.cwl
+++ b/tools/python/boutiques/tests/cwl/1st-workflow/1st-workflow.cwl
@@ -1,0 +1,24 @@
+cwlVersion: v1.0
+class: Workflow
+inputs:
+  inp: File
+  ex: string
+
+outputs:
+  classout:
+    type: File
+    outputSource: compile/classfile
+
+steps:
+  untar:
+    run: tar-param.cwl
+    in:
+      tarfile: inp
+      extractfile: ex
+    out: [example_out]
+
+  compile:
+    run: arguments.cwl
+    in:
+      src: untar/example_out
+    out: [classfile]

--- a/tools/python/boutiques/tests/cwl/README.md
+++ b/tools/python/boutiques/tests/cwl/README.md
@@ -1,0 +1,1 @@
+Examples copied from https://github.com/common-workflow-language/common-workflow-language/tree/master/v1.0/examples

--- a/tools/python/boutiques/tests/cwl/array-inputs/array-inputs-job.yml
+++ b/tools/python/boutiques/tests/cwl/array-inputs/array-inputs-job.yml
@@ -1,0 +1,3 @@
+filesA: [one, two, three]
+filesB: [four, five, six]
+filesC: [seven, eight, nine]

--- a/tools/python/boutiques/tests/cwl/array-inputs/array-inputs.cwl
+++ b/tools/python/boutiques/tests/cwl/array-inputs/array-inputs.cwl
@@ -1,0 +1,29 @@
+cwlVersion: v1.0
+class: CommandLineTool
+inputs:
+  filesA:
+    type: string[]
+    inputBinding:
+      prefix: -A
+      position: 1
+
+  filesB:
+    type:
+      type: array
+      items: string
+      inputBinding:
+        prefix: -B=
+        separate: false
+    inputBinding:
+      position: 2
+
+  filesC:
+    type: string[]
+    inputBinding:
+      prefix: -C=
+      itemSeparator: ","
+      separate: false
+      position: 4
+
+outputs: []
+baseCommand: echo

--- a/tools/python/boutiques/tests/cwl/array-output/array-outputs-job.yml
+++ b/tools/python/boutiques/tests/cwl/array-output/array-outputs-job.yml
@@ -1,0 +1,4 @@
+touchfiles:
+  - foo.txt
+  - bar.dat
+  - baz.txt

--- a/tools/python/boutiques/tests/cwl/array-output/array-outputs.cwl
+++ b/tools/python/boutiques/tests/cwl/array-output/array-outputs.cwl
@@ -1,0 +1,17 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: touch
+inputs:
+  touchfiles:
+    type:
+      type: array
+      items: string
+    inputBinding:
+      position: 1
+outputs:
+  output:
+    type:
+      type: array
+      items: File
+    outputBinding:
+      glob: "*.txt"

--- a/tools/python/boutiques/tests/cwl/createfile/createfile-job.yml
+++ b/tools/python/boutiques/tests/cwl/createfile/createfile-job.yml
@@ -1,0 +1,1 @@
+conf: hello

--- a/tools/python/boutiques/tests/cwl/createfile/createfile-job.yml
+++ b/tools/python/boutiques/tests/cwl/createfile/createfile-job.yml
@@ -1,1 +1,1 @@
-conf: hello
+message: hello

--- a/tools/python/boutiques/tests/cwl/createfile/createfile.cwl
+++ b/tools/python/boutiques/tests/cwl/createfile/createfile.cwl
@@ -1,0 +1,14 @@
+class: CommandLineTool
+cwlVersion: v1.0
+baseCommand: ["cat", "example.conf"]
+
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - entryname: example.conf
+        entry: |
+          CONFIGVAR=$(inputs.message)
+
+inputs:
+  message: string
+outputs: []

--- a/tools/python/boutiques/tests/cwl/docker/docker-job.yml
+++ b/tools/python/boutiques/tests/cwl/docker/docker-job.yml
@@ -1,0 +1,3 @@
+src:
+  class: File
+  path: hello.js

--- a/tools/python/boutiques/tests/cwl/docker/docker.cwl
+++ b/tools/python/boutiques/tests/cwl/docker/docker.cwl
@@ -1,0 +1,12 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: node
+hints:
+  DockerRequirement:
+    dockerPull: node:slim
+inputs:
+  src:
+    type: File
+    inputBinding:
+      position: 1
+outputs: []

--- a/tools/python/boutiques/tests/cwl/env/env.cwl
+++ b/tools/python/boutiques/tests/cwl/env/env.cwl
@@ -1,0 +1,10 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: env
+requirements:
+  EnvVarRequirement:
+    envDef:
+      HELLO: $(inputs.message)
+inputs:
+  message: string
+outputs: []

--- a/tools/python/boutiques/tests/cwl/expression/expression.cwl
+++ b/tools/python/boutiques/tests/cwl/expression/expression.cwl
@@ -1,0 +1,23 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+
+requirements:
+  - class: InlineJavascriptRequirement
+
+inputs: []
+outputs: []
+arguments:
+  - prefix: -A
+    valueFrom: $(1+1)
+  - prefix: -B
+    valueFrom: $("/foo/bar/baz".split('/').slice(-1)[0])
+  - prefix: -C
+    valueFrom: |
+      ${
+        var r = [];
+        for (var i = 10; i >= 1; i--) {
+          r.push(i);
+        }
+        return r;
+      }

--- a/tools/python/boutiques/tests/cwl/inp/inp-job.yml
+++ b/tools/python/boutiques/tests/cwl/inp/inp-job.yml
@@ -1,0 +1,6 @@
+example_flag: true
+example_string: hello
+example_int: 42
+example_file:
+  class: File
+  path: whale.txt

--- a/tools/python/boutiques/tests/cwl/inp/inp.cwl
+++ b/tools/python/boutiques/tests/cwl/inp/inp.cwl
@@ -1,0 +1,28 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+inputs:
+  example_flag:
+    type: boolean
+    inputBinding:
+      position: 1
+      prefix: -f
+  example_string:
+    type: string
+    inputBinding:
+      position: 3
+      prefix: --example-string
+  example_int:
+    type: int
+    inputBinding:
+      position: 2
+      prefix: -i
+      separate: false
+  example_file:
+    type: File?
+    inputBinding:
+      prefix: --file=
+      separate: false
+      position: 4
+
+outputs: []

--- a/tools/python/boutiques/tests/cwl/nestedworkflows/nestedworkflows.cwl
+++ b/tools/python/boutiques/tests/cwl/nestedworkflows/nestedworkflows.cwl
@@ -1,0 +1,52 @@
+cwlVersion: v1.0
+class: Workflow
+
+inputs: []
+
+outputs:
+  classout:
+    type: File
+    outputSource: compile/classout
+
+requirements:
+  - class: SubworkflowFeatureRequirement
+
+steps:
+  compile:
+    run: 1st-workflow.cwl
+    in:
+      inp:
+        source: create-tar/tar
+      ex:
+        default: "Hello.java"
+    out: [classout]
+
+  create-tar:
+    requirements:
+      - class: InitialWorkDirRequirement
+        listing:
+          - entryname: Hello.java
+            entry: |
+              public class Hello {
+                public static void main(String[] argv) {
+                    System.out.println("Hello from Java");
+                }
+              }
+    in: []
+    out: [tar]
+    run:
+      class: CommandLineTool
+      requirements:
+        - class: ShellCommandRequirement
+      arguments:
+        - shellQuote: false
+          valueFrom: |
+            date
+            tar cf hello.tar Hello.java
+            date
+      inputs: []
+      outputs:
+        tar:
+          type: File
+          outputBinding:
+            glob: "hello.tar"

--- a/tools/python/boutiques/tests/cwl/record/record-job1.yml
+++ b/tools/python/boutiques/tests/cwl/record/record-job1.yml
@@ -1,0 +1,4 @@
+dependent_parameters:
+  itemA: one
+exclusive_parameters:
+  itemC: three

--- a/tools/python/boutiques/tests/cwl/record/record.cwl
+++ b/tools/python/boutiques/tests/cwl/record/record.cwl
@@ -1,0 +1,34 @@
+cwlVersion: v1.0
+class: CommandLineTool
+inputs:
+  dependent_parameters:
+    type:
+      type: record
+      name: dependent_parameters
+      fields:
+        itemA:
+          type: string
+          inputBinding:
+            prefix: -A
+        itemB:
+          type: string
+          inputBinding:
+            prefix: -B
+  exclusive_parameters:
+    type:
+      - type: record
+        name: itemC
+        fields:
+          itemC:
+            type: string
+            inputBinding:
+              prefix: -C
+      - type: record
+        name: itemD
+        fields:
+          itemD:
+            type: string
+            inputBinding:
+              prefix: -D
+outputs: []
+baseCommand: echo

--- a/tools/python/boutiques/tests/cwl/stdout/arguments.cwl
+++ b/tools/python/boutiques/tests/cwl/stdout/arguments.cwl
@@ -1,0 +1,18 @@
+cwlVersion: v1.0
+class: CommandLineTool
+label: Example trivial wrapper for Java 7 compiler
+hints:
+  DockerRequirement:
+    dockerPull: java:7-jdk
+baseCommand: javac
+arguments: ["-d", $(runtime.outdir)]
+inputs:
+  src:
+    type: File
+    inputBinding:
+      position: 1
+outputs:
+  classfile:
+    type: File
+    outputBinding:
+      glob: "*.class"

--- a/tools/python/boutiques/tests/cwl/stdout/stdout.cwl
+++ b/tools/python/boutiques/tests/cwl/stdout/stdout.cwl
@@ -1,0 +1,12 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+stdout: output.txt
+inputs:
+  message:
+    type: string
+    inputBinding:
+      position: 1
+outputs:
+  output:
+    type: stdout

--- a/tools/python/boutiques/tests/cwl/tar-param/tar-param-job.yml
+++ b/tools/python/boutiques/tests/cwl/tar-param/tar-param-job.yml
@@ -1,0 +1,4 @@
+tarfile:
+  class: File
+  path: hello.tar
+extractfile: goodbye.txt

--- a/tools/python/boutiques/tests/cwl/tar-param/tar-param.cwl
+++ b/tools/python/boutiques/tests/cwl/tar-param/tar-param.cwl
@@ -1,0 +1,17 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [tar, xf]
+inputs:
+  tarfile:
+    type: File
+    inputBinding:
+      position: 1
+  extractfile:
+    type: string
+    inputBinding:
+      position: 2
+outputs:
+  example_out:
+    type: File
+    outputBinding:
+      glob: $(inputs.extractfile)

--- a/tools/python/boutiques/tests/cwl/tar/tar-job.yml
+++ b/tools/python/boutiques/tests/cwl/tar/tar-job.yml
@@ -1,0 +1,3 @@
+tarfile:
+  class: File
+  path: hello.tar

--- a/tools/python/boutiques/tests/cwl/tar/tar.cwl
+++ b/tools/python/boutiques/tests/cwl/tar/tar.cwl
@@ -1,0 +1,13 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: [tar, xf]
+inputs:
+  tarfile:
+    type: File
+    inputBinding:
+      position: 1
+outputs:
+  example_out:
+    type: File
+    outputBinding:
+      glob: hello.txt

--- a/tools/python/boutiques/tests/test_import.py
+++ b/tools/python/boutiques/tests/test_import.py
@@ -59,8 +59,7 @@ class TestImport(TestCase):
         ex_dir = opj(op.split(bfile)[0], "tests/cwl")
         # These ones are supposed to crash
         bad_dirs = ["1st-workflow", "record", "array-inputs",
-                    "createfile", "expression", "nestedworkflows",
-                    "arguments"]
+                    "expression", "nestedworkflows", "arguments"]
         for d in os.listdir(ex_dir):
                 if d == "README.md":
                         continue

--- a/tools/python/boutiques/tests/test_import.py
+++ b/tools/python/boutiques/tests/test_import.py
@@ -59,8 +59,12 @@ class TestImport(TestCase):
     def test_import_cwl_valid(self):
         ex_dir = opj(op.split(bfile)[0], "tests/cwl")
         # These ones are supposed to crash
-        bad_dirs = ["1st-workflow", "record", "array-inputs",
-                    "expression", "nestedworkflows", "arguments"]
+        bad_dirs = ["1st-workflow",  # workflow
+                    "record",  # complex type
+                    "array-inputs",  # input bindings specific to array element
+                    "expression",  # Javascript expression
+                    "nestedworkflows"  # workflow
+                    ]
         for d in os.listdir(ex_dir):
                 if d == "README.md":
                         continue

--- a/tools/python/boutiques/tests/test_import.py
+++ b/tools/python/boutiques/tests/test_import.py
@@ -8,6 +8,8 @@ import json
 import os
 import os.path as op
 from os.path import join as opj
+import pytest
+from boutiques.importer import ImportError
 
 
 class TestImport(TestCase):
@@ -50,3 +52,42 @@ class TestImport(TestCase):
         assert(result == open(ref_file, "r").read().strip() or
                result == open(ref_file_p2, "r").read().strip())
         os.remove(fout)
+
+    def test_import_cwl(self):
+        ex_dir = opj(op.split(bfile)[0], "tests/cwl")
+        # These ones are supposed to crash
+        bad_dirs = ["1st-workflow", "record", "array-inputs",
+                    "createfile", "expression", "nestedworkflows",
+                    "arguments"]
+        for d in os.listdir(ex_dir):
+                if d == "README.md":
+                        continue
+                files = os.listdir(opj(ex_dir, d))
+                cwl_descriptor = None
+                cwl_invocation = None
+                for f in files:
+                        if op.basename(f).endswith(".cwl"):
+                                cwl_descriptor = op.abspath(opj(ex_dir, d, f))
+                        if op.basename(f).endswith(".yml"):
+                                cwl_invocation = op.abspath(opj(ex_dir, d, f))
+                assert(cwl_descriptor is not None)
+                print(d)  # to help with debugging
+                out_desc = "./cwl_out.json"
+                out_inv = "./cwl_inv_out.json"
+                if cwl_invocation is not None:
+                        args = ["import",
+                                "cwl",
+                                out_desc,
+                                cwl_descriptor,
+                                "-i", cwl_invocation,
+                                "-o", out_inv]
+                else:
+                        args = ["import",
+                                "cwl",
+                                out_desc,
+                                cwl_descriptor]
+                if d in bad_dirs:
+                        with pytest.raises(ImportError):
+                                bosh(args)
+                else:
+                        self.assertFalse(bosh(args))

--- a/tools/python/boutiques/tests/test_import.py
+++ b/tools/python/boutiques/tests/test_import.py
@@ -12,6 +12,7 @@ import pytest
 from boutiques.importer import ImportError
 import boutiques
 import tarfile
+from contextlib import closing
 
 
 class TestImport(TestCase):
@@ -99,7 +100,9 @@ class TestImport(TestCase):
                                         f.write("'hello'")
                                 with open('goodbye.txt', 'w') as f:
                                         f.write("goodbye")
-                                with tarfile.open('hello.tar', "w") as tar:
+                                # closing required for Python 2.6...
+                                with closing(tarfile.open('hello.tar',
+                                                          "w")) as tar:
                                         tar.add('goodbye.txt')
                                 ret = boutiques.execute(
                                         "launch",

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -68,12 +68,19 @@ def validate_descriptor(json_file, **kwargs):
 
     cmdline = descriptor["command-line"]
 
-    # Verify that all command-line key appear in the command-line
-    msg_template = "   KeyError: \"{0}\" not in command-line or file template"
+    # Verify that all command-line key appear in the command-line, in
+    # a file template or in an environment variable value
+    msg_template = ("   KeyError: \"{0}\" not in command-line or file template"
+                    " or environment variables")
+    envValues = ""
+    if descriptor.get('environment-variables'):
+        for env in descriptor.get('environment-variables'):
+            envValues += "||"+env['value']
     errors += [msg_template.format(k)
                for k in clkeys
-               if (cmdline.count(k) +
-                   " ".join(configFileTemplates).count(k)) < 1]
+               if ((cmdline +
+                    ".".join(configFileTemplates) +
+                    envValues).count(k)) < 1]
 
     # Verify that no key contains another key
     msg_template = "   KeyError: \"{0}\" contains \"{1}\""

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -7,7 +7,8 @@ DEPS = [
          "simplejson",
          "requests",
          "pytest",
-         "termcolor"
+         "termcolor",
+         "pyyaml"
        ]
 
 # jsonschema 2.6 doesn't support Python 2.6


### PR DESCRIPTION
This adds CWL support to `bosh import`. 

Unsupported CWL features:
* CWL workflows (only tools can be imported).
* CWL arguments with Javascript expressions, e.g., `valueFrom: $("/foo/bar/baz".split('/').slice(-1)[0])`.
* CWL records and complex types
* Array inputs with specific bindings for array elements (regular array inputs are supported).

Other bug fixes:
* Validator now doesn't crash if value keys are present only in environment variable values.
* Command-line flag separators can now be empty.

Partially addresses #1.