### PR TITLE
Validator can now reformat descriptors

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -35,10 +35,14 @@ def validate(*params):
                         help="The Boutiques descriptor.")
     parser.add_argument("--bids", "-b", action="store_true",
                         help="Flag indicating if descriptor is a BIDS app")
+    parser.add_argument("--format", "-f", action="store_true",
+                        help="If descriptor is valid, rewrite it with sorted"
+                        " keys.")
     results = parser.parse_args(params)
 
     from boutiques.validator import validate_descriptor
-    descriptor = validate_descriptor(results.descriptor)
+    descriptor = validate_descriptor(results.descriptor,
+                                     results.format)
     if results.bids:
         from boutiques.bids import validate_bids
         validate_bids(descriptor, valid=True)

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -42,7 +42,7 @@ def validate(*params):
 
     from boutiques.validator import validate_descriptor
     descriptor = validate_descriptor(results.descriptor,
-                                     results.format)
+                                     format_output=results.format)
     if results.bids:
         from boutiques.bids import validate_bids
         validate_bids(descriptor, valid=True)

--- a/tools/python/boutiques/tests/test_validator.py
+++ b/tools/python/boutiques/tests/test_validator.py
@@ -13,7 +13,7 @@ class TestValidator(TestCase):
 
     def test_success(self):
         fil = op.join(op.split(bfile)[0], 'schema/examples/good.json')
-        assert bosh(['validate', fil]) is None
+        assert bosh(['validate', '--format', fil]) is None
 
     def test_success_cli(self):
         fil = op.join(op.split(bfile)[0], 'schema/examples/good.json')

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -14,7 +14,7 @@ class DescriptorValidationError(ValidationError):
 
 
 # Main validation module
-def validate_descriptor(json_file, format_output=False):
+def validate_descriptor(json_file, **kwargs):
     """
     Validates the Boutiques descriptor against the schema.
     """
@@ -353,7 +353,7 @@ def validate_descriptor(json_file, format_output=False):
 
     errors = None if errors == [] else errors
     if errors is None:
-        if format_output:
+        if kwargs.get('format_output'):
             with open(json_file, 'w') as fhandle:
                 fhandle.write(json.dumps(descriptor, indent=4, sort_keys=True))
         return descriptor

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -2,6 +2,7 @@
 
 import simplejson
 import os.path as op
+import json
 from jsonschema import validate, ValidationError
 from argparse import ArgumentParser
 from boutiques import __file__ as bfile
@@ -13,7 +14,7 @@ class DescriptorValidationError(ValidationError):
 
 
 # Main validation module
-def validate_descriptor(json_file, **kwargs):
+def validate_descriptor(json_file, format_output):
     """
     Validates the Boutiques descriptor against the schema.
     """
@@ -352,8 +353,10 @@ def validate_descriptor(json_file, **kwargs):
 
     errors = None if errors == [] else errors
     if errors is None:
-        if kwargs.get("verbose"):
-            print("Boutiques validation OK")
+        print("Boutiques validation OK")
+        if format_output:
+            with open(json_file, 'w') as fhandle:
+                fhandle.write(json.dumps(descriptor, indent=4, sort_keys=True))
         return descriptor
     else:
         raise DescriptorValidationError("\n".join(errors))

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -14,7 +14,7 @@ class DescriptorValidationError(ValidationError):
 
 
 # Main validation module
-def validate_descriptor(json_file, format_output):
+def validate_descriptor(json_file, format_output=False):
     """
     Validates the Boutiques descriptor against the schema.
     """

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -353,7 +353,6 @@ def validate_descriptor(json_file, format_output=False):
 
     errors = None if errors == [] else errors
     if errors is None:
-        print("Boutiques validation OK")
         if format_output:
             with open(json_file, 'w') as fhandle:
                 fhandle.write(json.dumps(descriptor, indent=4, sort_keys=True))


### PR DESCRIPTION
Option '--format' of the validator now rewrites the descriptor with alphabetically ordered properties.

This follows the discussion in https://github.com/aces/cbrain-plugins-experimental/pull/23