### PR TITLE
Docker image inspection in creator

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -21,10 +21,17 @@ def create(*params):
     parser = ArgumentParser("Boutiques descriptor creator")
     parser.add_argument("descriptor", action="store",
                         help="Output file to store descriptor in.")
+    parser.add_argument("--docker-image", '-d', action="store",
+                        help="Name of Docker image on DockerHub.")
+    parser.add_argument("--use-singularity", '-u', action="store_true",
+                        help="When --docker-image is used. Specify to "
+                             "use singularity to run it.")
     results = parser.parse_args(params)
 
     from boutiques.creator import CreateDescriptor
-    new = CreateDescriptor()
+    new = CreateDescriptor(parser=None,
+                           docker_image=results.docker_image,
+                           use_singularity=results.use_singularity)
     new.save(results.descriptor)
     return None
 

--- a/tools/python/boutiques/creator.py
+++ b/tools/python/boutiques/creator.py
@@ -57,7 +57,22 @@ class CreateDescriptor(object):
             cont_image['image'] = image_name
 
         # Properties found in the image metadata
+
+        # Set default logging handler to avoid "No handler found" error
+        # when importing docker in Python 2.6
+        # Thanks https://stackoverflow.com/questions/33175763/how-to-use-
+        # logging-nullhandler-in-python-2-6, goddammit 2.6
+        import logging
+        try:
+            from logging import NullHandler
+        except ImportError:
+            class NullHandler(logging.Handler):
+                def emit(self, record):
+                    pass
+        logging.getLogger(__name__).addHandler(NullHandler())
+        logging.NullHandler = NullHandler
         import docker
+
         client = docker.from_env()
         try:
             image = client.images.get(image_name)

--- a/tools/python/boutiques/creator.py
+++ b/tools/python/boutiques/creator.py
@@ -73,7 +73,7 @@ class CreateDescriptor(object):
             raise CreatorError("Cannot inspect Docker image {0}: {1} "
                                "{2} {3}".format(image_name, stdout,
                                                 os.linesep, stderr))
-        image_attrs = json.loads(stdout)[0]
+        image_attrs = json.loads(stdout.decode("utf-8"))[0]
         if (image_attrs.get('ContainerConfig')):
             container_config = image_attrs['ContainerConfig']
             entrypoint = container_config.get('Entrypoint')

--- a/tools/python/boutiques/tests/test_creator.py
+++ b/tools/python/boutiques/tests/test_creator.py
@@ -8,6 +8,7 @@ import boutiques.creator as bc
 import subprocess
 import os.path as op
 import os
+import pytest
 
 from boutiques.creator import CreatorError
 
@@ -29,6 +30,8 @@ class TestCreator(TestCase):
         descriptor = bosh(['create', '-d', 'mysql:latest', '-u', fil])
         assert bosh(['validate', fil]) is None
 
+    @pytest.mark.skipif(subprocess.Popen("type docker", shell=True).wait(),
+                        reason="Docker not installed")
     def test_fail_image_(self):
         fil = 'creator_output.json'
         self.assertRaises(CreatorError,

--- a/tools/python/boutiques/tests/test_creator.py
+++ b/tools/python/boutiques/tests/test_creator.py
@@ -24,6 +24,11 @@ class TestCreator(TestCase):
         descriptor = bosh(['create', '-d', 'mysql:latest', fil])
         assert bosh(['validate', fil]) is None
 
+    def test_success_docker_sing_import(self):
+        fil = 'creator_output.json'
+        descriptor = bosh(['create', '-d', 'mysql:latest', '-u', fil])
+        assert bosh(['validate', fil]) is None
+
     def test_fail_image_(self):
         fil = 'creator_output.json'
         self.assertRaises(CreatorError,

--- a/tools/python/boutiques/tests/test_creator.py
+++ b/tools/python/boutiques/tests/test_creator.py
@@ -19,6 +19,18 @@ class TestCreator(TestCase):
         descriptor = bosh(['create', fil])
         assert bosh(['validate', fil]) is None
 
+    def test_success_docker(self):
+        fil = 'creator_output.json'
+        descriptor = bosh(['create', '-d', 'mysql:latest', fil])
+        assert bosh(['validate', fil]) is None
+
+    def test_fail_image_(self):
+        fil = 'creator_output.json'
+        self.assertRaises(CreatorError,
+                          bosh,
+                          ['create', '-d', 'ihopethisdoesntexists', fil]
+                          )
+
     def test_not_an_argparser(self):
         self.assertRaises(CreatorError, bc.CreateDescriptor, "notaparser")
 

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -7,8 +7,7 @@ DEPS = [
          "simplejson",
          "requests",
          "pytest",
-         "termcolor",
-         "docker"
+         "termcolor"
        ]
 
 # jsonschema 2.6 doesn't support Python 2.6

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -7,7 +7,8 @@ DEPS = [
          "simplejson",
          "requests",
          "pytest",
-         "termcolor"
+         "termcolor",
+         "docker"
        ]
 
 # jsonschema 2.6 doesn't support Python 2.6


### PR DESCRIPTION
Creator can now inspect a Docker image to fill some properties. In particular:
* If there is an entrypoint, it will be added to the command line
* Tool version is set from the image tag
* Author and description are set from the corresponding properties of the image

It also sets the container-image properties correctly, including when Docker images have to be booted through Singularity (`--use-singularity` option). 