### PR TITLE
Bug fixes in simulator

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -668,10 +668,7 @@ class LocalExecutor(object):
                 print("Input: " + str(self.in_dict))
             # Check results (as much as possible)
             try:
-                print(self.in_dict)
-                # TODO: fix validateDict to not reset in_dict
                 self._validateDict()
-                print(self.in_dict)
             # If an error occurs, print out the problems already
             # encountered before blowing up
             except Exception:  # Avoid catching BaseExceptions like SystemExit
@@ -979,7 +976,7 @@ class LocalExecutor(object):
                     launchDir = os.getcwd()
                     if self.launchDir is not None:
                         launchDir = self.launchDir
-                    for ftarg in (str(val).split() if isList else [val]):
+                    for ftarg in (val if isList else [val]):
                         # Special case 1: launchdir is specified and we
                         # want to use absolute path
                         # Note: in this case, the pwd is mounted as the
@@ -999,6 +996,8 @@ class LocalExecutor(object):
                         # the path with its absolute version
                         elif targ.get('uses-absolute-path') is True:
                             replacementFiles.append(os.path.abspath(ftarg))
+                        else:
+                            replacementFiles.append(ftarg)
                     # Replace old val with the new one
                     self.in_dict[key] = " ".join(replacementFiles)
             # List length constraints are satisfied

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -938,7 +938,7 @@ class LocalExecutor(object):
             if targ["type"] == "Number":
                 # Number type and constraints are not violated
                 # (note the lambda safety checks)
-                for v in (str(val).split() if isList else [val]):
+                for v in (val if isList else [val]):
                     check('minimum', lambda x, y: float(x) >= targ[y],
                           "violates minimum value", v)
                     check('exclusive-minimum',

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -489,9 +489,9 @@ class LocalExecutor(object):
                 minv, maxv = float(minv), float(maxv)
             # Apply exclusive boundary constraints, if any
             if self.safeGet(param_id, 'exclusive-minimum'):
-                minv += (1 if isInt else 0.0001)
+                minv += 1 if isInt else 0.001
             if self.safeGet(param_id, 'exclusive-maximum'):
-                maxv -= (1 if isInt else 0.0001)
+                maxv -= 1 if isInt else 0.001
             # Returns a random int or a random float, depending on the type of p
             return (rnd.randint(minv, maxv)
                     if isInt else round(rnd.uniform(minv, maxv), nd))
@@ -519,8 +519,7 @@ class LocalExecutor(object):
             mx = self.safeGet(prm['id'], 'max-list-entries') or nl
             isList = self.safeGet(prm['id'], 'list') or False
             return [str(paramSingle(prm)) for _ in
-                    range(rnd.randint(mn, mx))
-                   ] if isList else paramSingle(prm)
+                    range(rnd.randint(mn, mx))] if isList else paramSingle(prm)
 
         # Returns a list of the ids of parameters that
         # disable the input parameter
@@ -671,12 +670,12 @@ class LocalExecutor(object):
                 self._validateDict()
             # If an error occurs, print out the problems already
             # encountered before blowing up
-            except Exception:  # Avoid catching BaseExceptions like SystemExit
+            except Exception as e:  # Avoid BaseExceptions like SystemExit
                 sys.stderr.write("An error occurred in validation\n"
                                  "Previously saved issues\n")
                 for err in self.errs:
                     sys.stderr.write("\t" + str(err) + "\n")
-                raise # Pass on (throw) the caught exception
+                raise e  # Pass on (throw) the caught exception
             # Add new command line
             self.cmdLine.append(self._generateCmdLineFromInDict())
 
@@ -952,9 +951,9 @@ class LocalExecutor(object):
             elif self.safeGet(targ['id'], 'value-choices'):
                 # Value is in the list of allowed values
                 if isinstance(val, list):
-                    fn = lambda x, y: all([x1 in targ[y] for x1 in x])
+                    fn = (lambda x, y: all([x1 in targ[y] for x1 in x]))
                 else:
-                    fn = lambda x, y: x in targ[y]
+                    fn = (lambda x, y: x in targ[y])
                 check('value-choices', fn,
                       "is not a valid enum choice", val)
             elif targ["type"] == "Flag":

--- a/tools/python/cleanup_tests.sh
+++ b/tools/python/cleanup_tests.sh
@@ -5,7 +5,10 @@
 # and have not yet committed them!
 #
 
-rm -r temp-*.sh log*.txt config*.txt file.txt creator_output.json test-created-argparse-descriptor.json .pytest_cache/
+rm -r temp-*.sh log*.txt config*.txt file.txt creator_output.json \
+      test-created-argparse-descriptor.json .pytest_cache/ bar.dat \
+      baz.txt cwl_inv_out.json cwl_out.json example.conf foo.txt \
+      goodbye.txt hello.js hello.tar stdout.txt
 git checkout boutiques/schema/examples/good.json
 git checkout boutiques/schema/examples/example1/example1_docker.json
 git checkout boutiques/schema/examples/example1/example1_sing.json


### PR DESCRIPTION
(please excuse the incorrect branch name - I thought the errors were with validation at first!)

**Work in Progress**

Fixes addressed:
- [x] Allows for simulation for inputs of type `list` with `value-choices`

- [x] Fixes overwriting of filenames in generated command-lines

Previously, running the simulator on a descriptor with inputs would give a value like:
```
ndmg_pipeline  ''  ''  ''  ''  /ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz  /ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz  str_outdir_Fp  /ndmg_atlases/labels/DS01876.nii.gz  -c
```

Now we have the following, as expected:
```
ndmg_pipeline  f_dti_file_64.nii.gz  f_bval_file_35.cpp  f_bvec_file_88.mnc  f_mprage_file_63.csv  /ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz  /ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz  str_outdir_Om  /ndmg_atlases/labels/DS00833.nii.gz /ndmg_atlases/labels/DS00108.nii.gz /ndmg_atlases/labels/DS00833.nii.gz
```
Note, that values were still being set for the files but they were discarded in the simulated-invocation-validation stage, but an erroneously missing `else` in validating file inputs meant that the original value often wouldn't get passed along after validation.