### PR TITLE
Version consolidation on Zenodo

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -241,6 +241,9 @@ def publish(*params):
                         help="disable interactive input.")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="print information messages.")
+    parser.add_argument("--update", action="store",
+                        help="deposition id of the record to update "
+                        "(e.g. 123456)")
 
     results = parser.parse_args(params)
 
@@ -250,7 +253,10 @@ def publish(*params):
                           results.sandbox,
                           results.no_int,
                           results.zenodo_token)
-    publisher.publish()
+    if results.update:
+        publisher.publish_updated_version(results.update)
+    else:
+        publisher.publish()
     if hasattr(publisher, 'doi'):
         return publisher.doi
 

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -239,9 +239,9 @@ class Publisher():
         }
         keywords = data['metadata']['keywords']
         if self.descriptor.get('tags'):
-            for key, value in self.descriptor.get('tags').iteritems():
+            for key, value in self.descriptor.get('tags').items():
                 # Check if value is a string or a list of strings
-                if isinstance(value, basestring):
+                if isinstance(value, str):
                     keywords.append(key + ":" + value)
                 else:
                     keywords += [key + ":" + item for item in value]

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_updated.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_updated.json
@@ -1,0 +1,167 @@
+{
+    "author": "Test author",
+    "command-line": "exampleTool1.py [CONFIG_FILE] [STRING_INPUT_LIST] [STRING_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [LOG] [INT_LIST_INPUT]",
+    "container-image": {
+        "image": "boutiques/example1:test",
+        "type": "docker",
+        "container-opts": ["-e", "HOME=$PWD"]
+    },
+    "description": "This is an updated version of an existing descriptor",
+    "url": "http://example.com",
+    "descriptor-url": "https://github.com/boutiques/boutiques/blob/master/tools/python/boutiques/schema/examples/example1/example1_docker.json",
+    "tool-doi": "00.0000/example.0000000",
+    "environment-variables": [
+        {
+            "name": "ENVAR",
+            "value": "theValue"
+        }
+    ],
+    "error-codes": [
+        {
+            "code": 2,
+            "description": "File does not exist!"
+        }
+    ],
+    "groups": [
+        {
+            "description": "This group forces us to choose exactly one of the file or the enum input to use.",
+            "id": "an_example_group",
+            "members": [
+                "num_input",
+                "enum_input"
+            ],
+            "mutually-exclusive": true,
+            "name": "Example group 1",
+            "one-is-required": true
+        }
+    ],
+    "inputs": [
+        {
+            "command-line-flag": "-i",
+            "default-value": "aStringValue",
+            "description": "Describe the use and meaning of the parameter",
+            "id": "str_input_list",
+            "list": true,
+            "max-list-entries": 3,
+            "min-list-entries": 1,
+            "name": "A list of string inputs",
+            "type": "String",
+            "value-key": "[STRING_INPUT_LIST]"
+        },
+        {
+            "command-line-flag": "-s",
+            "default-value": "aStringValue",
+            "description": "Describe the use and meaning of the parameter",
+            "id": "str_input",
+            "name": "A string input",
+            "type": "String",
+            "value-key": "[STRING_INPUT]"
+        },
+        {
+            "command-line-flag": "-l",
+            "description": "Describe the use and meaning of the parameter",
+            "id": "list_int_input",
+            "integer": true,
+            "list": true,
+            "min-list-entries": 1,
+            "name": "A list of ints",
+            "type": "Number",
+            "value-key": "[INT_LIST_INPUT]"
+        },
+        {
+            "id": "config_num",
+            "name": "A number put in the configuration file",
+            "type": "Number",
+            "value-choices": [
+                4
+            ],
+            "value-key": "[CONFIG_NUMBER]"
+        },
+        {
+            "command-line-flag": "-n",
+            "command-line-flag-separator": "=",
+            "exclusive-minimum": true,
+            "id": "num_input",
+            "maximum": 1,
+            "minimum": 0,
+            "name": "A number input",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[NUMBER_INPUT]"
+        },
+        {
+            "id": "file_input",
+            "name": "A file input",
+            "optional": true,
+            "type": "File",
+            "value-key": "[FILE_INPUT]"
+        },
+        {
+            "command-line-flag": "-e",
+            "id": "enum_input",
+            "name": "An enum input",
+            "optional": true,
+            "type": "String",
+            "value-choices": [
+                "val1",
+                "val2",
+                "val3"
+            ],
+            "value-key": "[ENUM_INPUT]"
+        },
+        {
+            "command-line-flag": "-f",
+            "disables-inputs": [
+                "num_input"
+            ],
+            "id": "flag_input",
+            "name": "A flag input",
+            "optional": true,
+            "requires-inputs": [
+                "file_input"
+            ],
+            "type": "Flag",
+            "value-key": "[FLAG_INPUT]"
+        }
+    ],
+    "name": "Example Boutiques Tool",
+    "output-files": [
+        {
+            "description": "The output log file from the example tool",
+            "id": "logfile",
+            "name": "Log file",
+            "path-template": "log-[CONFIG_NUMBER]-[STRING_INPUT].txt",
+            "path-template-stripped-extensions": [
+                ".txt",
+                ".csv"
+            ],
+            "value-key": "[LOG]"
+        },
+        {
+            "id": "output_files",
+            "list": true,
+            "name": "outfiles",
+            "optional": true,
+            "path-template": "output/*_exampleOutputTag.resultType"
+        },
+        {
+            "command-line-flag": "-c",
+            "file-template": [
+                "# This is a demo configuration file",
+                "numInput=[CONFIG_NUMBER]",
+                "strInput=[STRING_INPUT]"
+            ],
+            "id": "config_file",
+            "name": "Configuration file",
+            "path-template": "./config.txt",
+            "value-key": "[CONFIG_FILE]"
+        }
+    ],
+    "schema-version": "0.5",
+    "tags": {
+        "domain": "testing",
+        "foo": ["bar1", "bar2"],
+        "programming-language": "Python"
+    },
+    "tool-version": "0.0.2"
+}

--- a/tools/python/boutiques/tests/test_publisher.py
+++ b/tools/python/boutiques/tests/test_publisher.py
@@ -52,6 +52,25 @@ class TestPublisher(TestCase):
                   "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r"])
         self.assertTrue("Desriptor already has a DOI" in str(e.exception))
 
+        # Test publication of an updated version of the descriptor
+        deposition_id = doi.split(".")[-1]
+        example1_desc_new = op.join(example1_dir,
+                                    "example1_docker_updated.json")
+        temp_descriptor_new = tempfile.NamedTemporaryFile(suffix=".json")
+        shutil.copyfile(example1_desc_new, temp_descriptor_new.name)
+
+        new_doi = bosh(["publish",
+                        temp_descriptor_new.name,
+                        "--sandbox", "-y", "-v", "--update", deposition_id,
+                        "--zenodo-token", "hAaW2wSBZMskxpfigTYHcuDrC"
+                        "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r"])
+        assert(new_doi)
+
+        # Updated version of descriptor should have a new DOI
+        with open(temp_descriptor_new.name, 'r') as fhandle:
+            descriptor = json.load(fhandle)
+            assert(descriptor.get('doi') == new_doi)
+
     def test_publisher_auth(self):
         example1_dir = op.join(self.get_examples_dir(), "example1")
 


### PR DESCRIPTION
Issue #299 

Can now publish an updated version of an existing descriptor using the flag `--update <descriptor_id>` on `bosh publish`, where `descriptor_id` is the Zenodo ID of the published record you wish to update.

Example:
![zenodo versions](https://user-images.githubusercontent.com/14361988/47184335-64394f80-d2f8-11e8-85f6-b5954ecea6ec.PNG)