### PR TITLE
Implemented bosh search and bosh pull, added ability to run directly from zenodo

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -376,6 +376,22 @@ def search(*params):
     return searcher.search()
 
 
+def pull(*params):
+    parser = ArgumentParser("Download a descriptor from Zenodo.")
+
+    parser.add_argument("zid", action="store", help="Zenodo ID")
+
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Print information messages")
+
+    result = parser.parse_args(params)
+
+    from boutiques.puller import Puller
+    puller = Puller(result.zid, result.verbose)
+
+    return puller.pull()
+
+
 def bosh(args=None):
     parser = ArgumentParser(description="Driver for Bosh functions",
                             add_help=False)
@@ -394,10 +410,11 @@ def bosh(args=None):
                         "given descriptor. Eval: given an invocation and a "
                         "descriptor, queries execution properties. "
                         "Test: run pytest on a descriptor detailing tests. "
-                        "Search: search Zenodo for descriptors.",
+                        "Search: search Zenodo for descriptors. "
+                        "Pull: download a descriptor from Zenodo.",
                         choices=["create", "validate", "exec", "import",
                                  "export", "publish", "invocation", "evaluate",
-                                 "test", "search"])
+                                 "test", "search", "pull"])
 
     parser.add_argument("--help", "-h", action="store_true",
                         help="show this help message and exit")
@@ -457,6 +474,9 @@ def bosh(args=None):
             return bosh_return(out)
         elif func == "search":
             out = search(*params)
+            return bosh_return(out)
+        elif func == "pull":
+            out = pull(*params)
             return bosh_return(out)
         else:
             parser.print_help()

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -99,16 +99,12 @@ def execute(*params):
         parser.add_argument("-s", "--stream", action="store_true",
                             help="Streams stdout and stderr in real time "
                             "during execution.")
-        parser.add_argument("-z", "--zenodo", action="store_true",
-                            help="Download and use a descriptor published "
-                            "on Zenodo.")
         results = parser.parse_args(params)
         descriptor = results.descriptor
         inp = results.invocation
 
         # Validate invocation and descriptor
-        if not results.zenodo:
-            valid = invocation(descriptor, '-i', inp)
+        valid = invocation(descriptor, '-i', inp)
 
         # Generate object that will perform the commands
         from boutiques.localExec import LocalExecutor
@@ -116,8 +112,7 @@ def execute(*params):
                                  {"forcePathType": True,
                                   "debug": results.debug,
                                   "changeUser": results.user,
-                                  "stream": results.stream,
-                                  "zenodo": results.zenodo})
+                                  "stream": results.stream})
         # Execute it
         return executor.execute(results.volumes)
 
@@ -384,8 +379,9 @@ def search(*params):
 def pull(*params):
     parser = ArgumentParser("Download a descriptor from Zenodo.")
 
-    parser.add_argument("identifier", action="store", help="Zenodo ID or "
-                        "filename of the descriptor to pull")
+    parser.add_argument("identifier", action="store", help="Zenodo ID "
+                        "of the descriptor to pull, prefixed by "
+                        "'zenodo', e.g. zenodo.123456")
 
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print information messages")

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -395,7 +395,7 @@ def pull(*params):
     from boutiques.puller import Puller
     puller = Puller(result.identifier, result.verbose, True)
 
-    return puller.pull()
+    puller.pull()
 
 
 def bosh(args=None):

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -396,7 +396,7 @@ def pull(*params):
     result = parser.parse_args(params)
 
     from boutiques.puller import Puller
-    puller = Puller(result.identifier, result.verbose, True)
+    puller = Puller(result.zid, result.verbose, True)
 
     puller.pull()
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -144,9 +144,6 @@ def execute(*params):
             raise SystemExit("Input file {} does not exist.".format(inp))
         if inp and not inp.endswith(".json"):
             raise SystemExit("Input file {} must end in 'json'.".format(inp))
-        # if not os.path.isfile(descriptor):
-        #     raise SystemExit("JSON descriptor {} does not seem to exist."
-        #                      .format(descriptor))
         if not rand and not inp:
             raise SystemExit("The default mode requires an input (-i).")
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -358,27 +358,46 @@ def test(*params):
     return pytest.main([test_path, "--descriptor", result.descriptor])
 
 
+def search(*params):
+    parser = ArgumentParser("Search Zenodo for Boutiques descriptors. "
+                            "When no term is supplied, will search for "
+                            "all descriptors.")
+
+    parser.add_argument("-q", "--query", action="store", help="Search query")
+
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Print information messages")
+
+    result = parser.parse_args(params)
+
+    from boutiques.searcher import Searcher
+    searcher = Searcher(result.query, result.verbose)
+
+    return searcher.search()
+
+
 def bosh(args=None):
     parser = ArgumentParser(description="Driver for Bosh functions",
                             add_help=False)
     parser.add_argument("function", action="store", nargs="?",
                         help="The tool within boutiques/bosh you wish to run. "
-                        "Create: creates an Boutiques descriptor from scratch."
-                        "Validate: validates an existing boutiques descriptor."
+                        "Create: creates an Boutiques descriptor from scratch. "
+                        "Validate: validates an existing boutiques descriptor. "
                         "Exec: launches or simulates an execution given a "
                         "descriptor and a set of inputs. Import: creates a "
                         "descriptor for a BIDS app or updates a descriptor "
                         "from an older version of the schema. Export: exports a"
                         "descriptor to other formats. Publish: creates"
                         "an entry in Zenodo for the descriptor and "
-                        "adds the DOI created by Zenodo to the descriptor."
+                        "adds the DOI created by Zenodo to the descriptor. "
                         "Invocation: generates the invocation schema for a "
                         "given descriptor. Eval: given an invocation and a "
-                        "descriptor, queries execution properties."
-                        "Test: run pytest on a descriptor detailing tests",
+                        "descriptor, queries execution properties. "
+                        "Test: run pytest on a descriptor detailing tests. "
+                        "Search: search Zenodo for descriptors.",
                         choices=["create", "validate", "exec", "import",
                                  "export", "publish", "invocation", "evaluate",
-                                 "test"])
+                                 "test", "search"])
 
     parser.add_argument("--help", "-h", action="store_true",
                         help="show this help message and exit")
@@ -435,6 +454,9 @@ def bosh(args=None):
             return bosh_return(out)
         elif func == "test":
             out = test(*params)
+            return bosh_return(out)
+        elif func == "search":
+            out = search(*params)
             return bosh_return(out)
         else:
             parser.print_help()

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -17,6 +17,7 @@ from boutiques.localExec import ExecutorError
 from boutiques.exporter import ExportError
 from boutiques.importer import ImportError
 from boutiques.localExec import loadJson
+from tabulate import tabulate
 
 
 def create(*params):
@@ -395,7 +396,7 @@ def pull(*params):
     from boutiques.puller import Puller
     puller = Puller(result.zid, result.verbose, True)
 
-    puller.pull()
+    return puller.pull()
 
 
 def bosh(args=None):
@@ -433,12 +434,15 @@ def bosh(args=None):
     def runs_as_cli():
         return os.path.basename(sys.argv[0]) == "bosh"
 
-    def bosh_return(val, code=0, hide=False):
+    def bosh_return(val, code=0, hide=False, formatted=None):
         if runs_as_cli():
             if hide:
                 return code
             if val is not None:
-                print(val)
+                if formatted is not None:
+                    print(formatted)
+                else:
+                    print(val)
             else:
                 if code == 0:
                     print("OK")
@@ -480,10 +484,11 @@ def bosh(args=None):
             return bosh_return(out)
         elif func == "search":
             out = search(*params)
-            return bosh_return(out)
+            return bosh_return(out, formatted=tabulate(out, headers='keys',
+                                                       tablefmt='plain'))
         elif func == "pull":
             out = pull(*params)
-            return bosh_return(out)
+            return bosh_return(out, hide=True)
         else:
             parser.print_help()
             raise SystemExit

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -41,7 +41,8 @@ def create(*params):
 def validate(*params):
     parser = ArgumentParser("Boutiques descriptor validator")
     parser.add_argument("descriptor", action="store",
-                        help="The Boutiques descriptor.")
+                        help="The Boutiques descriptor as a JSON file, JSON "
+                             "string or Zenodo ID (prefixed by 'zenodo.').")
     parser.add_argument("--bids", "-b", action="store_true",
                         help="Flag indicating if descriptor is a BIDS app")
     parser.add_argument("--format", "-f", action="store_true",
@@ -81,7 +82,8 @@ def execute(*params):
     if mode == "launch":
         parser = ArgumentParser("Launches an invocation.")
         parser.add_argument("descriptor", action="store",
-                            help="The Boutiques descriptor.")
+                            help="The Boutiques descriptor as a JSON file, "
+                            "JSON string or Zenodo ID (prefixed by 'zenodo.').")
         parser.add_argument("invocation", action="store",
                             help="Input JSON complying to invocation.")
         parser.add_argument("-v", "--volumes", action="store", type=str,
@@ -119,7 +121,8 @@ def execute(*params):
     if mode == "simulate":
         parser = ArgumentParser("Simulates an invocation.")
         parser.add_argument("descriptor", action="store",
-                            help="The Boutiques descriptor.")
+                            help="The Boutiques descriptor as a JSON file, "
+                            "JSON string or Zenodo ID (prefixed by 'zenodo.').")
         parser.add_argument("-i", "--input", action="store",
                             help="Input JSON complying to invocation.")
         parser.add_argument("-r", "--random", action="store", type=int,
@@ -141,9 +144,9 @@ def execute(*params):
             raise SystemExit("Input file {} does not exist.".format(inp))
         if inp and not inp.endswith(".json"):
             raise SystemExit("Input file {} must end in 'json'.".format(inp))
-        if not os.path.isfile(descriptor):
-            raise SystemExit("JSON descriptor {} does not seem to exist."
-                             .format(descriptor))
+        # if not os.path.isfile(descriptor):
+        #     raise SystemExit("JSON descriptor {} does not seem to exist."
+        #                      .format(descriptor))
         if not rand and not inp:
             raise SystemExit("The default mode requires an input (-i).")
 
@@ -260,7 +263,8 @@ def invocation(*params):
                             " invocations. Uses descriptor's invocation"
                             " schema if it exists, otherwise creates one.")
     parser.add_argument("descriptor", action="store",
-                        help="The Boutiques descriptor.")
+                        help="The Boutiques descriptor as a JSON file, JSON "
+                             "string or Zenodo ID (prefixed by 'zenodo.').")
     parser.add_argument("-i", "--invocation", action="store",
                         help="Input values in a JSON file or as a JSON "
                         "object to be validated against "
@@ -293,7 +297,8 @@ def evaluate(*params):
     parser = ArgumentParser("Evaluates parameter values for a descriptor"
                             " and invocation")
     parser.add_argument("descriptor", action="store",
-                        help="The Boutiques descriptor.")
+                        help="The Boutiques descriptor as a JSON file, JSON "
+                             "string or Zenodo ID (prefixed by 'zenodo.').")
     parser.add_argument("invocation", action="store",
                         help="Input JSON complying to invocation.")
     parser.add_argument("query", action="store", nargs="*",
@@ -324,8 +329,9 @@ def test(*params):
 
     parser = ArgumentParser("Perform all the tests defined within the"
                             " given descriptor")
-    parser.add_argument("descriptor", action="store", help="The Boutiques"
-                        " descriptor.")
+    parser.add_argument("descriptor", action="store",
+                        help="The Boutiques descriptor as a JSON file, JSON "
+                             "string or Zenodo ID (prefixed by 'zenodo.').")
     result = parser.parse_args(params)
 
     # Generation of the invocation schema (and descriptor validation).
@@ -363,7 +369,8 @@ def search(*params):
                             "When no term is supplied, will search for "
                             "all descriptors.")
 
-    parser.add_argument("-q", "--query", action="store", help="Search query")
+    parser.add_argument("query", nargs="?", default="boutiques",
+                        action="store", help="Search query")
 
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print information messages")
@@ -379,9 +386,9 @@ def search(*params):
 def pull(*params):
     parser = ArgumentParser("Download a descriptor from Zenodo.")
 
-    parser.add_argument("identifier", action="store", help="Zenodo ID "
+    parser.add_argument("zid", action="store", help="Zenodo ID "
                         "of the descriptor to pull, prefixed by "
-                        "'zenodo', e.g. zenodo.123456")
+                        "'zenodo.', e.g. zenodo.123456")
 
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print information messages")

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -99,12 +99,16 @@ def execute(*params):
         parser.add_argument("-s", "--stream", action="store_true",
                             help="Streams stdout and stderr in real time "
                             "during execution.")
+        parser.add_argument("-z", "--zenodo", action="store_true",
+                            help="Download and use a descriptor published "
+                            "on Zenodo.")
         results = parser.parse_args(params)
         descriptor = results.descriptor
         inp = results.invocation
 
         # Validate invocation and descriptor
-        valid = invocation(descriptor, '-i', inp)
+        if not results.zenodo:
+            valid = invocation(descriptor, '-i', inp)
 
         # Generate object that will perform the commands
         from boutiques.localExec import LocalExecutor
@@ -112,7 +116,8 @@ def execute(*params):
                                  {"forcePathType": True,
                                   "debug": results.debug,
                                   "changeUser": results.user,
-                                  "stream": results.stream})
+                                  "stream": results.stream,
+                                  "zenodo": results.zenodo})
         # Execute it
         return executor.execute(results.volumes)
 
@@ -379,7 +384,8 @@ def search(*params):
 def pull(*params):
     parser = ArgumentParser("Download a descriptor from Zenodo.")
 
-    parser.add_argument("zid", action="store", help="Zenodo ID")
+    parser.add_argument("identifier", action="store", help="Zenodo ID or "
+                        "filename of the descriptor to pull")
 
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Print information messages")
@@ -387,7 +393,7 @@ def pull(*params):
     result = parser.parse_args(params)
 
     from boutiques.puller import Puller
-    puller = Puller(result.zid, result.verbose)
+    puller = Puller(result.identifier, result.verbose, True)
 
     return puller.pull()
 

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -132,8 +132,20 @@ class LocalExecutor(object):
         self.desc_path = desc    # Save descriptor path
         self.errs = []        # Empty errors holder
         self.invocation = invocation
-        # Parse JSON descriptor
-        self.desc_dict = loadJson(desc)
+
+        # Extra Options
+        # Include: forcePathType and debug
+        self.debug = False
+        for option in list(options.keys()):
+            setattr(self, option, options.get(option))
+
+        if self.zenodo:
+            from boutiques.puller import Puller
+            puller = Puller(desc, self.debug, False)
+            self.desc_dict = json.loads(puller.pull().read())
+        else:
+            # Parse JSON descriptor
+            self.desc_dict = loadJson(desc)
 
         # Set the shell
         self.shell = self.desc_dict.get("shell")
@@ -154,11 +166,6 @@ class LocalExecutor(object):
         if self.con is not None:
             self.con.get('working-directory')
 
-        # Extra Options
-        # Include: forcePathType and debug
-        self.debug = False
-        for option in list(options.keys()):
-            setattr(self, option, options.get(option))
         # Container Implementation check
         conEngines = ['docker', 'singularity']
         if (self.con is not None) and self.con['type'] not in conEngines:

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -136,6 +136,7 @@ class LocalExecutor(object):
         # Extra Options
         # Include: forcePathType and debug
         self.debug = False
+        self.zenodo = False
         for option in list(options.keys()):
             setattr(self, option, options.get(option))
 
@@ -728,7 +729,6 @@ class LocalExecutor(object):
         self.in_dict = loadJson(infile)
 
         # Input dictionary
-        print(self.in_dict)
         if self.debug:
             print("Input: " + str(self.in_dict))
         # Fix special flag case: flags given the false value

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1090,7 +1090,7 @@ def loadJson(userInput):
     elif userInput.split(".")[0].lower() == "zenodo":
         from boutiques.puller import Puller
         puller = Puller(userInput, False, False)
-        return json.loads(puller.pull().read())
+        return json.loads(puller.pull().read().decode('utf-8'))
     # JSON object
     else:
         try:

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -132,14 +132,6 @@ class LocalExecutor(object):
         self.desc_path = desc    # Save descriptor path
         self.errs = []        # Empty errors holder
         self.invocation = invocation
-
-        # Extra Options
-        # Include: forcePathType and debug
-        self.debug = False
-        self.zenodo = False
-        for option in list(options.keys()):
-            setattr(self, option, options.get(option))
-
         # Parse JSON descriptor
         self.desc_dict = loadJson(desc)
 
@@ -162,6 +154,11 @@ class LocalExecutor(object):
         if self.con is not None:
             self.con.get('working-directory')
 
+        # Extra Options
+        # Include: forcePathType and debug
+        self.debug = False
+        for option in list(options.keys()):
+            setattr(self, option, options.get(option))
         # Container Implementation check
         conEngines = ['docker', 'singularity']
         if (self.con is not None) and self.con['type'] not in conEngines:

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1091,9 +1091,13 @@ def loadJson(userInput):
         from boutiques.puller import Puller
         puller = Puller(userInput, False, False)
         return json.loads(puller.pull().read().decode('utf-8'))
-    # JSON object
-    else:
-        try:
-            return json.loads(userInput)
-        except ValueError:
-            raise ExecutorError("Unable to decode JSON object")
+    # Try to parse JSON object
+    e = ExecutorError("Cannot parse input {}: file not found, "
+                      "invalid Zenodo ID, or invalid JSON object"
+                      .format(userInput))
+    if userInput.isdigit():
+        raise e
+    try:
+        return json.loads(userInput)
+    except ValueError:
+        raise e

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -43,10 +43,7 @@ class Publisher():
                               " from the descriptor before publishing it again."
                               " A new DOI will be generated.")
 
-        self.cache_dir = os.path.join(os.path.expanduser('~'), ".boutiques")
-        if not os.path.exists(self.cache_dir):
-            os.makedirs(self.cache_dir)
-        self.config_file = os.path.join(self.cache_dir, ".config")
+        self.config_file = os.path.join(os.path.expanduser('~'), ".boutiques")
 
         # Fix Zenodo access token
         if self.zenodo_access_token is None:

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -43,7 +43,11 @@ class Publisher():
                               " from the descriptor before publishing it again."
                               " A new DOI will be generated.")
 
-        self.config_file = os.path.join(os.getenv("HOME"), ".boutiques")
+        self.cache_dir = os.path.join(os.path.expanduser('~'), ".boutiques")
+        if not os.path.exists(self.cache_dir):
+            os.makedirs(self.cache_dir)
+        self.config_file = os.path.join(self.cache_dir, ".config")
+
         # Fix Zenodo access token
         if self.zenodo_access_token is None:
             self.zenodo_access_token = self.get_zenodo_access_token()

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -26,6 +26,9 @@ class Puller():
                               "'zenodo', e.g. zenodo.123456")
         self.verbose = verbose
         self.download = download
+        self.cache_dir = os.path.join(os.path.expanduser('~'), ".boutiques")
+        if not os.path.exists(self.cache_dir):
+            os.makedirs(self.cache_dir)
 
     def pull(self):
         from boutiques.searcher import Searcher
@@ -37,14 +40,10 @@ class Puller():
             file_name = file_path.split("/")[-1]
             if hit["id"] == int(self.zid):
                 if self.download:
-                    cache_dir = os.path.join(os.getenv("HOME"), ".cache",
-                                             "boutiques")
-                    if not os.path.exists(cache_dir):
-                        os.makedirs(cache_dir)
                     if(self.verbose):
                         self.print_zenodo_info("Downloading descriptor %s"
                                                % file_name, r)
-                    return urlretrieve(file_path, os.path.join(cache_dir,
+                    return urlretrieve(file_path, os.path.join(self.cache_dir,
                                        file_name))
                 if(self.verbose):
                     self.print_zenodo_info("Opening descriptor %s"

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -48,7 +48,7 @@ class Puller():
                                            % file_name, r)
                 return urlopen(file_path)
 
-        raise IOError("Descriptor not found")
+        raise ZenodoError("Descriptor not found")
 
     def print_zenodo_info(self, message, r):
         print("[ INFO ({1}) ] {0}".format(message, r.status_code))

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -34,11 +34,10 @@ class Puller():
             file_name = file_path.split("/")[-1]
             if hit["id"] == int(zid):
                 if self.download:
-                    urllib.urlretrieve(file_path, file_name)
                     if(self.verbose):
-                        self.print_zenodo_info("Downloaded descriptor %s"
+                        self.print_zenodo_info("Downloading descriptor %s"
                                                % file_name, r)
-                    return
+                    return urllib.urlretrieve(file_path, file_name)
                 if(self.verbose):
                     self.print_zenodo_info("Opening descriptor %s"
                                            % file_name, r)
@@ -52,11 +51,10 @@ class Puller():
             file_name = file_path.split("/")[-1]
             if file_name == filename:
                 if self.download:
-                    urllib.urlretrieve(file_path, file_name)
                     if(self.verbose):
-                        self.print_zenodo_info("Downloaded descriptor %s"
+                        self.print_zenodo_info("Downloading descriptor %s"
                                                % file_name, r)
-                    return
+                    return urllib.urlretrieve(file_path, file_name)
                 if(self.verbose):
                     self.print_zenodo_info("Opening descriptor %s"
                                            % file_name, r)

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -26,9 +26,6 @@ class Puller():
                               "'zenodo', e.g. zenodo.123456")
         self.verbose = verbose
         self.download = download
-        self.cache_dir = os.path.join(os.path.expanduser('~'), ".boutiques")
-        if not os.path.exists(self.cache_dir):
-            os.makedirs(self.cache_dir)
 
     def pull(self):
         from boutiques.searcher import Searcher
@@ -40,10 +37,14 @@ class Puller():
             file_name = file_path.split(os.sep)[-1]
             if hit["id"] == int(self.zid):
                 if self.download:
+                    cache_dir = os.path.join(os.path.expanduser('~'), ".cache",
+                                             "boutiques")
+                    if not os.path.exists(cache_dir):
+                        os.makedirs(cache_dir)
                     if(self.verbose):
                         self.print_zenodo_info("Downloading descriptor %s"
                                                % file_name, r)
-                    return urlretrieve(file_path, os.path.join(self.cache_dir,
+                    return urlretrieve(file_path, os.path.join(cache_dir,
                                        file_name))
                 if(self.verbose):
                     self.print_zenodo_info("Opening descriptor %s"

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -1,0 +1,40 @@
+import requests
+import urllib
+
+
+class ZenodoError(Exception):
+    pass
+
+
+class Puller():
+
+    def __init__(self, zid, verbose):
+        self.zid = zid
+        self.verbose = verbose
+
+    def pull(self):
+        r = requests.get('https://zenodo.org/api/records/?q=boutiques&'
+                         'keywords=boutiques&keywords=schema&'
+                         'keywords=version&file_type=json&type=software')
+
+        if(r.status_code != 200):
+            self.raise_zenodo_error("Error searching Zenodo", r)
+
+        for hit in r.json()["hits"]["hits"]:
+            if hit["id"] == int(self.zid):
+                file_path = hit["files"][0]["links"]["self"]
+                file_name = file_path.split("/")[-1]
+                urllib.urlretrieve(file_path, file_name)
+                if(self.verbose):
+                    self.print_zenodo_info("Downloaded descriptor %s"
+                                           % file_name, r)
+                return
+
+        return "Descriptor not found"
+
+    def print_zenodo_info(self, message, r):
+        print("[ INFO ({1}) ] {0}".format(message, r.status_code))
+
+    def raise_zenodo_error(self, message, r):
+        raise ZenodoError("Zenodo error ({0}): {1}."
+                          .format(r.status_code, message))

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -28,12 +28,9 @@ class Puller():
         self.download = download
 
     def pull(self):
-        r = requests.get('https://zenodo.org/api/records/?q=boutiques&'
-                         'keywords=boutiques&keywords=schema&'
-                         'keywords=version&file_type=json&type=software')
-
-        if(r.status_code != 200):
-            self.raise_zenodo_error("Error searching Zenodo", r)
+        from boutiques.searcher import Searcher
+        searcher = Searcher(None, self.verbose)
+        r = searcher.zenodo_search()
 
         for hit in r.json()["hits"]["hits"]:
             file_path = hit["files"][0]["links"]["self"]

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -1,6 +1,13 @@
 import requests
 import urllib
-import urllib2
+try:
+    # Python 3
+    from urllib.request import urlopen
+    from urllib.request import urlretrieve
+except ImportError:
+    # Python 2
+    from urllib2 import urlopen
+    from urllib import urlretrieve
 
 
 class ZenodoError(Exception):
@@ -37,11 +44,11 @@ class Puller():
                     if(self.verbose):
                         self.print_zenodo_info("Downloading descriptor %s"
                                                % file_name, r)
-                    return urllib.urlretrieve(file_path, file_name)
+                    return urlretrieve(file_path, file_name)
                 if(self.verbose):
                     self.print_zenodo_info("Opening descriptor %s"
                                            % file_name, r)
-                return urllib2.urlopen(file_path)
+                return urlopen(file_path)
 
         raise IOError("Descriptor not found")
 
@@ -54,11 +61,11 @@ class Puller():
                     if(self.verbose):
                         self.print_zenodo_info("Downloading descriptor %s"
                                                % file_name, r)
-                    return urllib.urlretrieve(file_path, file_name)
+                    return urlretrieve(file_path, file_name)
                 if(self.verbose):
                     self.print_zenodo_info("Opening descriptor %s"
                                            % file_name, r)
-                return urllib2.urlopen(file_path)
+                return urlopen(file_path)
 
         raise IOError("Descriptor not found")
 

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -1,5 +1,6 @@
 import requests
 import urllib
+import os
 try:
     # Python 3
     from urllib.request import urlopen
@@ -39,10 +40,15 @@ class Puller():
             file_name = file_path.split("/")[-1]
             if hit["id"] == int(self.zid):
                 if self.download:
+                    cache_dir = os.path.join(os.getenv("HOME"), ".cache",
+                                             "boutiques")
+                    if not os.path.exists(cache_dir):
+                        os.makedirs(cache_dir)
                     if(self.verbose):
                         self.print_zenodo_info("Downloading descriptor %s"
                                                % file_name, r)
-                    return urlretrieve(file_path, file_name)
+                    return urlretrieve(file_path, os.path.join(cache_dir,
+                                       file_name))
                 if(self.verbose):
                     self.print_zenodo_info("Opening descriptor %s"
                                            % file_name, r)

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -37,7 +37,7 @@ class Puller():
 
         for hit in r.json()["hits"]["hits"]:
             file_path = hit["files"][0]["links"]["self"]
-            file_name = file_path.split("/")[-1]
+            file_name = file_path.split(os.sep)[-1]
             if hit["id"] == int(self.zid):
                 if self.download:
                     if(self.verbose):

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -1,205 +1,205 @@
 {
-    "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN] [EXTRA1] [EXTRA2]", 
+    "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN] [EXTRA1] [EXTRA2]",
     "container-image": {
-        "entrypoint": false, 
-        "image": "neurodata/ndmg:v0.0.41-1", 
-        "index": "index.docker.io", 
+        "entrypoint": false,
+        "image": "neurodata/ndmg:v0.0.41-1",
+        "index": "index.docker.io",
         "type": "docker"
-    }, 
-    "description": "dwi connectome estimation pipeline", 
+    },
+    "description": "dwi connectome estimation pipeline",
     "error-codes": [
         {
-            "code": 1, 
+            "code": 1,
             "description": "crashed"
-        }, 
+        },
         {
-            "code": 12, 
+            "code": 12,
             "description": "crashed badly"
         }
-    ], 
+    ],
     "groups": [
         {
-            "all-or-none": true, 
-            "id": "together_group", 
+            "all-or-none": true,
+            "id": "together_group",
             "members": [
-                "extra1", 
+                "extra1",
                 "extra2"
-            ], 
+            ],
             "name": "these guys have to be toggled together"
-        }, 
+        },
         {
-            "id": "dti_group", 
+            "id": "dti_group",
             "members": [
-                "dti_file", 
+                "dti_file",
                 "dti_file_minc"
-            ], 
-            "mutually-exclusive": true, 
-            "name": "Group of two possible dti input files", 
+            ],
+            "mutually-exclusive": true,
+            "name": "Group of two possible dti input files",
             "one-is-required": true
-        }, 
+        },
         {
-            "id": "parcellation_group", 
+            "id": "parcellation_group",
             "members": [
-                "desikan", 
-                "jhu", 
-                "talairach", 
-                "aal", 
-                "harvardoxford", 
+                "desikan",
+                "jhu",
+                "talairach",
+                "aal",
+                "harvardoxford",
                 "cpac200"
-            ], 
-            "name": "Group of all used parcellations", 
+            ],
+            "name": "Group of all used parcellations",
             "one-is-required": true
         }
-    ], 
+    ],
     "inputs": [
         {
-            "id": "dti_file", 
-            "name": "Diffusion Tensor Image", 
-            "optional": true, 
-            "type": "File", 
+            "id": "dti_file",
+            "name": "Diffusion Tensor Image",
+            "optional": true,
+            "type": "File",
             "value-key": "[DTI]"
-        }, 
+        },
         {
-            "id": "extra1", 
-            "name": "optional thing at the end", 
-            "optional": true, 
-            "type": "File", 
+            "id": "extra1",
+            "name": "optional thing at the end",
+            "optional": true,
+            "type": "File",
             "value-key": "[EXTRA1]"
-        }, 
+        },
         {
-            "id": "extra2", 
-            "name": "optional thing at the end", 
-            "optional": true, 
-            "type": "File", 
+            "id": "extra2",
+            "name": "optional thing at the end",
+            "optional": true,
+            "type": "File",
             "value-key": "[EXTRA2]"
-        }, 
+        },
         {
-            "id": "dti_file_minc", 
-            "name": "Diffusion Tensor Image", 
-            "optional": true, 
-            "type": "File", 
+            "id": "dti_file_minc",
+            "name": "Diffusion Tensor Image",
+            "optional": true,
+            "type": "File",
             "value-key": "[DTI]"
-        }, 
+        },
         {
-            "id": "bval_file", 
-            "name": "B-values file", 
-            "optional": false, 
-            "type": "File", 
+            "id": "bval_file",
+            "name": "B-values file",
+            "optional": false,
+            "type": "File",
             "value-key": "[BVAL]"
-        }, 
+        },
         {
-            "id": "bvec_file", 
-            "name": "Gradient vectors file", 
-            "optional": false, 
-            "type": "File", 
+            "id": "bvec_file",
+            "name": "Gradient vectors file",
+            "optional": false,
+            "type": "File",
             "value-key": "[BVEC]"
-        }, 
+        },
         {
-            "id": "mprage_file", 
-            "name": "Structural scan file", 
-            "optional": false, 
-            "type": "File", 
+            "id": "mprage_file",
+            "name": "Structural scan file",
+            "optional": false,
+            "type": "File",
             "value-key": "[MPRAGE]"
-        }, 
+        },
         {
-            "id": "atlas", 
-            "name": "Atlas image (MNI152)", 
-            "optional": false, 
-            "type": "String", 
+            "id": "atlas",
+            "name": "Atlas image (MNI152)",
+            "optional": false,
+            "type": "String",
             "value-choices": [
                 "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
-            ], 
+            ],
             "value-key": "[ATLAS]"
-        }, 
+        },
         {
-            "id": "mask", 
-            "name": "Atlas brain mask", 
-            "optional": false, 
-            "type": "String", 
+            "id": "mask",
+            "name": "Atlas brain mask",
+            "optional": false,
+            "type": "String",
             "value-choices": [
                 "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
-            ], 
+            ],
             "value-key": "[MASK]"
-        }, 
+        },
         {
-            "id": "outdir", 
-            "name": "Output directory", 
-            "optional": false, 
-            "type": "String", 
+            "id": "outdir",
+            "name": "Output directory",
+            "optional": false,
+            "type": "String",
             "value-key": "[OUTDIR]"
-        }, 
+        },
         {
-            "id": "desikan", 
-            "name": "Desikan parcellation", 
-            "optional": true, 
-            "type": "String", 
+            "id": "desikan",
+            "name": "Desikan parcellation",
+            "optional": true,
+            "type": "String",
             "value-choices": [
                 "/ndmg_atlases/labels/desikan.nii.gz"
-            ], 
+            ],
             "value-key": "[DESIKAN]"
-        }, 
+        },
         {
-            "id": "jhu", 
-            "name": "JHU parcellation", 
-            "optional": true, 
-            "type": "String", 
+            "id": "jhu",
+            "name": "JHU parcellation",
+            "optional": true,
+            "type": "String",
             "value-choices": [
                 "/ndmg_atlases/labels/JHU.nii.gz"
-            ], 
+            ],
             "value-key": "[JHU]"
-        }, 
+        },
         {
-            "id": "talairach", 
-            "name": "Talairach parcellation", 
-            "optional": true, 
-            "type": "String", 
+            "id": "talairach",
+            "name": "Talairach parcellation",
+            "optional": true,
+            "type": "String",
             "value-choices": [
                 "/ndmg_atlases/labels/Talairach.nii.gz"
-            ], 
+            ],
             "value-key": "[TALAIRACH]"
-        }, 
+        },
         {
-            "id": "aal", 
-            "name": "AAL parcellation", 
-            "optional": true, 
-            "type": "String", 
+            "id": "aal",
+            "name": "AAL parcellation",
+            "optional": true,
+            "type": "String",
             "value-choices": [
                 "/ndmg_atlases/labels/AAL.nii.gz"
-            ], 
+            ],
             "value-key": "[AAL]"
-        }, 
+        },
         {
-            "id": "harvardoxford", 
-            "name": "Harvard-Oxford parcellation", 
-            "optional": true, 
-            "type": "String", 
+            "id": "harvardoxford",
+            "name": "Harvard-Oxford parcellation",
+            "optional": true,
+            "type": "String",
             "value-choices": [
                 "/ndmg_atlases/labels/HarvardOxford.nii.gz"
-            ], 
+            ],
             "value-key": "[HARVARDOXFORD]"
-        }, 
+        },
         {
-            "id": "cpac200", 
-            "name": "CPAC200 parcellation", 
-            "optional": true, 
-            "type": "String", 
+            "id": "cpac200",
+            "name": "CPAC200 parcellation",
+            "optional": true,
+            "type": "String",
             "value-choices": [
                 "/ndmg_atlases/labels/CPAC200.nii.gz"
-            ], 
+            ],
             "value-key": "[CPAC200]"
-        }, 
+        },
         {
-            "command-line-flag": "-c", 
-            "id": "clean", 
-            "name": "Clean-up flag", 
-            "optional": true, 
-            "type": "Flag", 
+            "command-line-flag": "-c",
+            "id": "clean",
+            "name": "Clean-up flag",
+            "optional": true,
+            "type": "Flag",
             "value-key": "[CLEAN]"
         }
-    ], 
+    ],
     "invocation-schema": {
-        "$schema": "http://json-schema.org/draft-04/schema#", 
-        "additionalProperties": false, 
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "additionalProperties": false,
         "allOf": [
             {
                 "anyOf": [
@@ -207,41 +207,41 @@
                         "required": [
                             "dti_file"
                         ]
-                    }, 
+                    },
                     {
                         "required": [
                             "dti_file_minc"
                         ]
                     }
                 ]
-            }, 
+            },
             {
                 "anyOf": [
                     {
                         "required": [
                             "desikan"
                         ]
-                    }, 
+                    },
                     {
                         "required": [
                             "jhu"
                         ]
-                    }, 
+                    },
                     {
                         "required": [
                             "talairach"
                         ]
-                    }, 
+                    },
                     {
                         "required": [
                             "aal"
                         ]
-                    }, 
+                    },
                     {
                         "required": [
                             "harvardoxford"
                         ]
-                    }, 
+                    },
                     {
                         "required": [
                             "cpac200"
@@ -249,7 +249,7 @@
                     }
                 ]
             }
-        ], 
+        ],
         "dependencies": {
             "dti_file": {
                 "properties": {
@@ -257,7 +257,7 @@
                         "not": {}
                     }
                 }
-            }, 
+            },
             "dti_file_minc": {
                 "properties": {
                     "dti_file": {
@@ -265,191 +265,191 @@
                     }
                 }
             }
-        }, 
-        "description": "Invocation schema for ndmg.", 
+        },
+        "description": "Invocation schema for ndmg.",
         "properties": {
             "aal": {
                 "enum": [
                     "/ndmg_atlases/labels/AAL.nii.gz"
                 ]
-            }, 
+            },
             "atlas": {
                 "enum": [
                     "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
                 ]
-            }, 
+            },
             "bval_file": {
                 "type": "string"
-            }, 
+            },
             "bvec_file": {
                 "type": "string"
-            }, 
+            },
             "clean": {
                 "type": "boolean"
-            }, 
+            },
             "cpac200": {
                 "enum": [
                     "/ndmg_atlases/labels/CPAC200.nii.gz"
                 ]
-            }, 
+            },
             "desikan": {
                 "enum": [
                     "/ndmg_atlases/labels/desikan.nii.gz"
                 ]
-            }, 
+            },
             "dti_file": {
                 "type": "string"
-            }, 
+            },
             "dti_file_minc": {
                 "type": "string"
-            }, 
+            },
             "extra1": {
                 "type": "string"
-            }, 
+            },
             "extra2": {
                 "type": "string"
-            }, 
+            },
             "harvardoxford": {
                 "enum": [
                     "/ndmg_atlases/labels/HarvardOxford.nii.gz"
                 ]
-            }, 
+            },
             "jhu": {
                 "enum": [
                     "/ndmg_atlases/labels/JHU.nii.gz"
                 ]
-            }, 
+            },
             "mask": {
                 "enum": [
                     "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
                 ]
-            }, 
+            },
             "mprage_file": {
                 "type": "string"
-            }, 
+            },
             "outdir": {
                 "type": "string"
-            }, 
+            },
             "talairach": {
                 "enum": [
                     "/ndmg_atlases/labels/Talairach.nii.gz"
                 ]
             }
-        }, 
+        },
         "required": [
-            "bval_file", 
-            "bvec_file", 
-            "mprage_file", 
-            "atlas", 
-            "mask", 
+            "bval_file",
+            "bvec_file",
+            "mprage_file",
+            "atlas",
+            "mask",
             "outdir"
-        ], 
-        "title": "ndmg.invocationSchema", 
+        ],
+        "title": "ndmg.invocationSchema",
         "type": "object"
-    }, 
-    "name": "ndmg", 
+    },
+    "name": "ndmg",
     "output-files": [
         {
-            "id": "aligned_dti", 
-            "name": "Aligned DTI volume", 
-            "optional": true, 
-            "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz", 
+            "id": "aligned_dti",
+            "name": "Aligned DTI volume",
+            "optional": true,
+            "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz",
             "path-template-stripped-extensions": [
-                ".nii", 
+                ".nii",
                 ".nii.gz"
             ]
-        }, 
+        },
         {
-            "id": "tensors", 
-            "name": "Tensor maps", 
-            "optional": true, 
-            "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz", 
+            "id": "tensors",
+            "name": "Tensor maps",
+            "optional": true,
+            "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz",
             "path-template-stripped-extensions": [
-                ".nii", 
+                ".nii",
                 ".nii.gz"
             ]
-        }, 
+        },
         {
-            "id": "fibers", 
-            "name": "Fiber streamlines", 
-            "optional": true, 
-            "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz", 
+            "id": "fibers",
+            "name": "Fiber streamlines",
+            "optional": true,
+            "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz",
             "path-template-stripped-extensions": [
-                ".nii", 
+                ".nii",
                 ".nii.gz"
             ]
-        }, 
+        },
         {
-            "id": "desikan_graph", 
-            "name": "Desikan graph", 
-            "optional": true, 
-            "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle", 
+            "id": "desikan_graph",
+            "name": "Desikan graph",
+            "optional": true,
+            "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle",
             "path-template-stripped-extensions": [
-                ".nii", 
+                ".nii",
                 ".nii.gz"
             ]
-        }, 
+        },
         {
-            "id": "jhu_graph", 
-            "name": "JHU graph", 
-            "optional": true, 
-            "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle", 
+            "id": "jhu_graph",
+            "name": "JHU graph",
+            "optional": true,
+            "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle",
             "path-template-stripped-extensions": [
-                ".nii", 
+                ".nii",
                 ".nii.gz"
             ]
-        }, 
+        },
         {
-            "id": "talairach_graph", 
-            "name": "Talairach graph", 
-            "optional": true, 
-            "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle", 
+            "id": "talairach_graph",
+            "name": "Talairach graph",
+            "optional": true,
+            "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle",
             "path-template-stripped-extensions": [
-                ".nii", 
+                ".nii",
                 ".nii.gz"
             ]
-        }, 
+        },
         {
-            "id": "aal_graph", 
-            "name": "AAL graph", 
-            "optional": true, 
-            "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle", 
+            "id": "aal_graph",
+            "name": "AAL graph",
+            "optional": true,
+            "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle",
             "path-template-stripped-extensions": [
-                ".nii", 
+                ".nii",
                 ".nii.gz"
             ]
-        }, 
+        },
         {
-            "id": "harvardoxford_graph", 
-            "name": "Harvard-Oxford graph", 
-            "optional": true, 
-            "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle", 
+            "id": "harvardoxford_graph",
+            "name": "Harvard-Oxford graph",
+            "optional": true,
+            "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle",
             "path-template-stripped-extensions": [
-                ".nii", 
+                ".nii",
                 ".nii.gz"
             ]
-        }, 
+        },
         {
-            "id": "cpac200_graph", 
-            "name": "CPAC200 graph", 
-            "optional": true, 
-            "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle", 
+            "id": "cpac200_graph",
+            "name": "CPAC200 graph",
+            "optional": true,
+            "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle",
             "path-template-stripped-extensions": [
-                ".nii", 
+                ".nii",
                 ".nii.gz"
             ]
         }
-    ], 
-    "schema-version": "0.5", 
+    ],
+    "schema-version": "0.5",
     "suggested-resources": {
-        "cpu-cores": 1, 
-        "ram": 12, 
+        "cpu-cores": 1,
+        "ram": 12,
         "walltime-estimate": 3600
-    }, 
+    },
     "tags": {
-        "domain": "testing", 
-        "foo": "bar", 
+        "domain": "testing",
+        "foo": "bar",
         "status": "experimental"
-    }, 
+    },
     "tool-version": "v0.0.41-1"
 }

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -1,205 +1,205 @@
 {
-    "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN] [EXTRA1] [EXTRA2]",
+    "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN] [EXTRA1] [EXTRA2]", 
     "container-image": {
-        "entrypoint": false,
-        "image": "neurodata/ndmg:v0.0.41-1",
-        "index": "index.docker.io",
+        "entrypoint": false, 
+        "image": "neurodata/ndmg:v0.0.41-1", 
+        "index": "index.docker.io", 
         "type": "docker"
-    },
-    "description": "dwi connectome estimation pipeline",
+    }, 
+    "description": "dwi connectome estimation pipeline", 
     "error-codes": [
         {
-            "code": 1,
+            "code": 1, 
             "description": "crashed"
-        },
+        }, 
         {
-            "code": 12,
+            "code": 12, 
             "description": "crashed badly"
         }
-    ],
+    ], 
     "groups": [
         {
-            "all-or-none": true,
-            "id": "together_group",
+            "all-or-none": true, 
+            "id": "together_group", 
             "members": [
-                "extra1",
+                "extra1", 
                 "extra2"
-            ],
+            ], 
             "name": "these guys have to be toggled together"
-        },
+        }, 
         {
-            "id": "dti_group",
+            "id": "dti_group", 
             "members": [
-                "dti_file",
+                "dti_file", 
                 "dti_file_minc"
-            ],
-            "mutually-exclusive": true,
-            "name": "Group of two possible dti input files",
+            ], 
+            "mutually-exclusive": true, 
+            "name": "Group of two possible dti input files", 
             "one-is-required": true
-        },
+        }, 
         {
-            "id": "parcellation_group",
+            "id": "parcellation_group", 
             "members": [
-                "desikan",
-                "jhu",
-                "talairach",
-                "aal",
-                "harvardoxford",
+                "desikan", 
+                "jhu", 
+                "talairach", 
+                "aal", 
+                "harvardoxford", 
                 "cpac200"
-            ],
-            "name": "Group of all used parcellations",
+            ], 
+            "name": "Group of all used parcellations", 
             "one-is-required": true
         }
-    ],
+    ], 
     "inputs": [
         {
-            "id": "dti_file",
-            "name": "Diffusion Tensor Image",
-            "optional": true,
-            "type": "File",
+            "id": "dti_file", 
+            "name": "Diffusion Tensor Image", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[DTI]"
-        },
+        }, 
         {
-            "id": "extra1",
-            "name": "optional thing at the end",
-            "optional": true,
-            "type": "File",
+            "id": "extra1", 
+            "name": "optional thing at the end", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[EXTRA1]"
-        },
+        }, 
         {
-            "id": "extra2",
-            "name": "optional thing at the end",
-            "optional": true,
-            "type": "File",
+            "id": "extra2", 
+            "name": "optional thing at the end", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[EXTRA2]"
-        },
+        }, 
         {
-            "id": "dti_file_minc",
-            "name": "Diffusion Tensor Image",
-            "optional": true,
-            "type": "File",
+            "id": "dti_file_minc", 
+            "name": "Diffusion Tensor Image", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[DTI]"
-        },
+        }, 
         {
-            "id": "bval_file",
-            "name": "B-values file",
-            "optional": false,
-            "type": "File",
+            "id": "bval_file", 
+            "name": "B-values file", 
+            "optional": false, 
+            "type": "File", 
             "value-key": "[BVAL]"
-        },
+        }, 
         {
-            "id": "bvec_file",
-            "name": "Gradient vectors file",
-            "optional": false,
-            "type": "File",
+            "id": "bvec_file", 
+            "name": "Gradient vectors file", 
+            "optional": false, 
+            "type": "File", 
             "value-key": "[BVEC]"
-        },
+        }, 
         {
-            "id": "mprage_file",
-            "name": "Structural scan file",
-            "optional": false,
-            "type": "File",
+            "id": "mprage_file", 
+            "name": "Structural scan file", 
+            "optional": false, 
+            "type": "File", 
             "value-key": "[MPRAGE]"
-        },
+        }, 
         {
-            "id": "atlas",
-            "name": "Atlas image (MNI152)",
-            "optional": false,
-            "type": "String",
+            "id": "atlas", 
+            "name": "Atlas image (MNI152)", 
+            "optional": false, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
-            ],
+            ], 
             "value-key": "[ATLAS]"
-        },
+        }, 
         {
-            "id": "mask",
-            "name": "Atlas brain mask",
-            "optional": false,
-            "type": "String",
+            "id": "mask", 
+            "name": "Atlas brain mask", 
+            "optional": false, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
-            ],
+            ], 
             "value-key": "[MASK]"
-        },
+        }, 
         {
-            "id": "outdir",
-            "name": "Output directory",
-            "optional": false,
-            "type": "String",
+            "id": "outdir", 
+            "name": "Output directory", 
+            "optional": false, 
+            "type": "String", 
             "value-key": "[OUTDIR]"
-        },
+        }, 
         {
-            "id": "desikan",
-            "name": "Desikan parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "desikan", 
+            "name": "Desikan parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/desikan.nii.gz"
-            ],
+            ], 
             "value-key": "[DESIKAN]"
-        },
+        }, 
         {
-            "id": "jhu",
-            "name": "JHU parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "jhu", 
+            "name": "JHU parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/JHU.nii.gz"
-            ],
+            ], 
             "value-key": "[JHU]"
-        },
+        }, 
         {
-            "id": "talairach",
-            "name": "Talairach parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "talairach", 
+            "name": "Talairach parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/Talairach.nii.gz"
-            ],
+            ], 
             "value-key": "[TALAIRACH]"
-        },
+        }, 
         {
-            "id": "aal",
-            "name": "AAL parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "aal", 
+            "name": "AAL parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/AAL.nii.gz"
-            ],
+            ], 
             "value-key": "[AAL]"
-        },
+        }, 
         {
-            "id": "harvardoxford",
-            "name": "Harvard-Oxford parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "harvardoxford", 
+            "name": "Harvard-Oxford parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/HarvardOxford.nii.gz"
-            ],
+            ], 
             "value-key": "[HARVARDOXFORD]"
-        },
+        }, 
         {
-            "id": "cpac200",
-            "name": "CPAC200 parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "cpac200", 
+            "name": "CPAC200 parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/CPAC200.nii.gz"
-            ],
+            ], 
             "value-key": "[CPAC200]"
-        },
+        }, 
         {
-            "command-line-flag": "-c",
-            "id": "clean",
-            "name": "Clean-up flag",
-            "optional": true,
-            "type": "Flag",
+            "command-line-flag": "-c", 
+            "id": "clean", 
+            "name": "Clean-up flag", 
+            "optional": true, 
+            "type": "Flag", 
             "value-key": "[CLEAN]"
         }
-    ],
+    ], 
     "invocation-schema": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-04/schema#", 
+        "additionalProperties": false, 
         "allOf": [
             {
                 "anyOf": [
@@ -207,41 +207,41 @@
                         "required": [
                             "dti_file"
                         ]
-                    },
+                    }, 
                     {
                         "required": [
                             "dti_file_minc"
                         ]
                     }
                 ]
-            },
+            }, 
             {
                 "anyOf": [
                     {
                         "required": [
                             "desikan"
                         ]
-                    },
+                    }, 
                     {
                         "required": [
                             "jhu"
                         ]
-                    },
+                    }, 
                     {
                         "required": [
                             "talairach"
                         ]
-                    },
+                    }, 
                     {
                         "required": [
                             "aal"
                         ]
-                    },
+                    }, 
                     {
                         "required": [
                             "harvardoxford"
                         ]
-                    },
+                    }, 
                     {
                         "required": [
                             "cpac200"
@@ -249,7 +249,7 @@
                     }
                 ]
             }
-        ],
+        ], 
         "dependencies": {
             "dti_file": {
                 "properties": {
@@ -257,7 +257,7 @@
                         "not": {}
                     }
                 }
-            },
+            }, 
             "dti_file_minc": {
                 "properties": {
                     "dti_file": {
@@ -265,191 +265,191 @@
                     }
                 }
             }
-        },
-        "description": "Invocation schema for ndmg.",
+        }, 
+        "description": "Invocation schema for ndmg.", 
         "properties": {
             "aal": {
                 "enum": [
                     "/ndmg_atlases/labels/AAL.nii.gz"
                 ]
-            },
+            }, 
             "atlas": {
                 "enum": [
                     "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
                 ]
-            },
+            }, 
             "bval_file": {
                 "type": "string"
-            },
+            }, 
             "bvec_file": {
                 "type": "string"
-            },
+            }, 
             "clean": {
                 "type": "boolean"
-            },
+            }, 
             "cpac200": {
                 "enum": [
                     "/ndmg_atlases/labels/CPAC200.nii.gz"
                 ]
-            },
+            }, 
             "desikan": {
                 "enum": [
                     "/ndmg_atlases/labels/desikan.nii.gz"
                 ]
-            },
+            }, 
             "dti_file": {
                 "type": "string"
-            },
+            }, 
             "dti_file_minc": {
                 "type": "string"
-            },
+            }, 
             "extra1": {
                 "type": "string"
-            },
+            }, 
             "extra2": {
                 "type": "string"
-            },
+            }, 
             "harvardoxford": {
                 "enum": [
                     "/ndmg_atlases/labels/HarvardOxford.nii.gz"
                 ]
-            },
+            }, 
             "jhu": {
                 "enum": [
                     "/ndmg_atlases/labels/JHU.nii.gz"
                 ]
-            },
+            }, 
             "mask": {
                 "enum": [
                     "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
                 ]
-            },
+            }, 
             "mprage_file": {
                 "type": "string"
-            },
+            }, 
             "outdir": {
                 "type": "string"
-            },
+            }, 
             "talairach": {
                 "enum": [
                     "/ndmg_atlases/labels/Talairach.nii.gz"
                 ]
             }
-        },
+        }, 
         "required": [
-            "bval_file",
-            "bvec_file",
-            "mprage_file",
-            "atlas",
-            "mask",
+            "bval_file", 
+            "bvec_file", 
+            "mprage_file", 
+            "atlas", 
+            "mask", 
             "outdir"
-        ],
-        "title": "ndmg.invocationSchema",
+        ], 
+        "title": "ndmg.invocationSchema", 
         "type": "object"
-    },
-    "name": "ndmg",
+    }, 
+    "name": "ndmg", 
     "output-files": [
         {
-            "id": "aligned_dti",
-            "name": "Aligned DTI volume",
-            "optional": true,
-            "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz",
+            "id": "aligned_dti", 
+            "name": "Aligned DTI volume", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "tensors",
-            "name": "Tensor maps",
-            "optional": true,
-            "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz",
+            "id": "tensors", 
+            "name": "Tensor maps", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "fibers",
-            "name": "Fiber streamlines",
-            "optional": true,
-            "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz",
+            "id": "fibers", 
+            "name": "Fiber streamlines", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "desikan_graph",
-            "name": "Desikan graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle",
+            "id": "desikan_graph", 
+            "name": "Desikan graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "jhu_graph",
-            "name": "JHU graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle",
+            "id": "jhu_graph", 
+            "name": "JHU graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "talairach_graph",
-            "name": "Talairach graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle",
+            "id": "talairach_graph", 
+            "name": "Talairach graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "aal_graph",
-            "name": "AAL graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle",
+            "id": "aal_graph", 
+            "name": "AAL graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "harvardoxford_graph",
-            "name": "Harvard-Oxford graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle",
+            "id": "harvardoxford_graph", 
+            "name": "Harvard-Oxford graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "cpac200_graph",
-            "name": "CPAC200 graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle",
+            "id": "cpac200_graph", 
+            "name": "CPAC200 graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
         }
-    ],
-    "schema-version": "0.5",
+    ], 
+    "schema-version": "0.5", 
     "suggested-resources": {
-        "cpu-cores": 1,
-        "ram": 12,
+        "cpu-cores": 1, 
+        "ram": 12, 
         "walltime-estimate": 3600
-    },
+    }, 
     "tags": {
-        "domain": "testing",
-        "foo": "bar",
+        "domain": "testing", 
+        "foo": "bar", 
         "status": "experimental"
-    },
+    }, 
     "tool-version": "v0.0.41-1"
 }

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -1,0 +1,46 @@
+import requests
+from tabulate import tabulate
+
+
+class ZenodoError(Exception):
+    pass
+
+
+class Searcher():
+
+    def __init__(self, query, verbose):
+        if query is not None:
+            self.query = query
+        else:
+            self.query = 'boutiques'
+
+        self.verbose = verbose
+
+    def search(self):
+        r = requests.get('https://zenodo.org/api/records/?q=%s&'
+                         'keywords=boutiques&keywords=schema&'
+                         'keywords=version&file_type=json&type=software'
+                         % self.query)
+        if(r.status_code != 200):
+            self.raise_zenodo_error("Error searching Zenodo", r)
+
+        if(self.verbose):
+            self.print_zenodo_info("Zenodo search returned %d results"
+                                   % r.json()["hits"]["total"], r)
+
+        return self.create_results_table(r.json())
+
+    def create_results_table(self, results):
+        table = []
+        for hit in results["hits"]["hits"]:
+            table.append([hit["id"], hit["metadata"]["title"],
+                         hit["metadata"]["description"]])
+        return tabulate(table, headers=['ID', 'TITLE',
+                        'DESCRIPTION'], tablefmt='plain')
+
+    def print_zenodo_info(self, message, r):
+        print("[ INFO ({1}) ] {0}".format(message, r.status_code))
+
+    def raise_zenodo_error(self, message, r):
+        raise ZenodoError("Zenodo error ({0}): {1}."
+                          .format(r.status_code, message))

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -17,6 +17,10 @@ class Searcher():
         self.verbose = verbose
 
     def search(self):
+        results = self.zenodo_search()
+        return self.create_results_table(results.json())
+
+    def zenodo_search(self):
         r = requests.get('https://zenodo.org/api/records/?q=%s&'
                          'keywords=boutiques&keywords=schema&'
                          'keywords=version&file_type=json&type=software'
@@ -27,8 +31,7 @@ class Searcher():
         if(self.verbose):
             self.print_zenodo_info("Zenodo search returned %d results"
                                    % r.json()["hits"]["total"], r)
-
-        return self.create_results_table(r.json())
+        return r
 
     def create_results_table(self, results):
         table = []

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -18,6 +18,8 @@ class Searcher():
 
     def search(self):
         results = self.zenodo_search()
+        if self.verbose:
+            return self.create_results_table_verbose(results.json())
         return self.create_results_table(results.json())
 
     def zenodo_search(self):
@@ -36,11 +38,34 @@ class Searcher():
     def create_results_table(self, results):
         table = []
         for hit in results["hits"]["hits"]:
-            hit["id"] = "zenodo." + str(hit["id"])
-            table.append([hit["id"], hit["metadata"]["title"],
-                         hit["metadata"]["description"]])
+            id = "zenodo." + str(hit["id"])
+            title = hit["metadata"]["title"]
+            description = hit["metadata"]["description"]
+            table.append([id, title, description])
         return tabulate(table, headers=['ID', 'TITLE',
                         'DESCRIPTION'], tablefmt='plain')
+
+    def create_results_table_verbose(self, results):
+        table = []
+        for hit in results["hits"]["hits"]:
+            id = "zenodo." + str(hit["id"])
+            title = hit["metadata"]["title"]
+            description = hit["metadata"]["description"]
+            author = hit["metadata"]["creators"][0]["name"]
+            version = hit["metadata"]["version"]
+            doi = hit["doi"]
+            keyword_data = self.get_keyword_data(hit["metadata"]["keywords"])
+            schema_version = keyword_data["schema-version"]
+            container = keyword_data["container-type"]
+            other_tags = ",".join(keyword_data["other"])
+
+            table.append([id, title, description, author, version,
+                         doi, schema_version, container, other_tags])
+        return tabulate(table, headers=['ID', 'TITLE',
+                                        'DESCRIPTION', 'AUTHOR', 'VERSION',
+                                        'DOI', 'SCHEMA VERSION', 'CONTAINER',
+                                        'TAGS'],
+                        tablefmt='plain')
 
     def print_zenodo_info(self, message, r):
         print("[ INFO ({1}) ] {0}".format(message, r.status_code))
@@ -48,3 +73,15 @@ class Searcher():
     def raise_zenodo_error(self, message, r):
         raise ZenodoError("Zenodo error ({0}): {1}."
                           .format(r.status_code, message))
+
+    def get_keyword_data(self, keywords):
+        keyword_data = {"container-type": "None", "other": []}
+        for keyword in keywords:
+            if keyword.split(":")[0] == "schema-version":
+                keyword_data["schema-version"] = keyword.split(":")[1]
+            elif keyword.lower() == "docker" or
+            keyword.lower() == "singularity":
+                keyword_data["container-type"] = keyword
+            else:
+                keyword_data["other"].append(keyword)
+        return keyword_data

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -33,6 +33,7 @@ class Searcher():
     def create_results_table(self, results):
         table = []
         for hit in results["hits"]["hits"]:
+            hit["id"] = "zenodo." + str(hit["id"])
             table.append([hit["id"], hit["metadata"]["title"],
                          hit["metadata"]["description"]])
         return tabulate(table, headers=['ID', 'TITLE',

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -36,7 +36,7 @@ class Searcher():
             table.append([hit["id"], hit["metadata"]["title"],
                          hit["metadata"]["description"]])
         return tabulate(table, headers=['ID', 'TITLE',
-                        'DESCRIPTION', 'FILENAME'], tablefmt='plain')
+                        'DESCRIPTION'], tablefmt='plain')
 
     def print_zenodo_info(self, message, r):
         print("[ INFO ({1}) ] {0}".format(message, r.status_code))

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -36,7 +36,7 @@ class Searcher():
             table.append([hit["id"], hit["metadata"]["title"],
                          hit["metadata"]["description"]])
         return tabulate(table, headers=['ID', 'TITLE',
-                        'DESCRIPTION'], tablefmt='plain')
+                        'DESCRIPTION', 'FILENAME'], tablefmt='plain')
 
     def print_zenodo_info(self, message, r):
         print("[ INFO ({1}) ] {0}".format(message, r.status_code))

--- a/tools/python/boutiques/tests/test_example1.py
+++ b/tools/python/boutiques/tests/test_example1.py
@@ -197,7 +197,7 @@ class TestExample1(TestCase):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
         self.clean_up()
         ret = bosh.execute("launch", "-z",
-                           "example1.json",
+                           "example1_docker.json",
                            os.path.join(example1_dir,
                                         "invocation.json"))
 

--- a/tools/python/boutiques/tests/test_example1.py
+++ b/tools/python/boutiques/tests/test_example1.py
@@ -191,6 +191,49 @@ class TestExample1(TestCase):
                              invocationStr)
         assert("Unable to decode JSON object" in str(e))
 
+    @pytest.mark.skipif(subprocess.Popen("type docker", shell=True).wait(),
+                        reason="Docker not installed")
+    def test_example1_exec_docker_from_zenodo(self):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        self.clean_up()
+        ret = bosh.execute("launch", "-z",
+                           "example1.json",
+                           os.path.join(example1_dir,
+                                        "invocation.json"))
+
+        # Make sure stdout and stderr are not printed on the fly
+        # for non-streaming mode
+        out, err = self.capfd.readouterr()
+        assert("This is stdout" not in out)
+        assert("This is stderr" not in out)
+
+        print(ret)
+        assert("This is stdout" in ret.stdout)
+        assert("This is stderr" in ret.stderr)
+        assert(ret.exit_code == 0)
+        assert(ret.error_message == "")
+        assert(ret.missing_files == [])
+        assert(len(ret.output_files) == 2)
+        assert(ret.output_files[0].file_name == "log-4-coin;plop.txt" or
+               ret.output_files[1].file_name == "log-4-coin;plop.txt")
+
+        self.clean_up()
+        ret = bosh.execute("launch",
+                           os.path.join(example1_dir,
+                                        "example1_docker.json"),
+                           "-x",
+                           os.path.join(example1_dir,
+                                        "invocation.json"))
+        print(ret)
+        assert("This is stdout" in ret.stdout)
+        assert("This is stderr" in ret.stderr)
+        assert(ret.exit_code == 0)
+        assert(ret.error_message == "")
+        assert(ret.missing_files == [])
+        assert(len(ret.output_files) == 2)
+        assert(ret.output_files[0].file_name == "log-4-coin;plop.txt" or
+               ret.output_files[1].file_name == "log-4-coin;plop.txt")
+
     @pytest.mark.skipif(subprocess.Popen("type singularity", shell=True).wait(),
                         reason="Singularity not installed")
     def test_example1_exec_singularity(self):

--- a/tools/python/boutiques/tests/test_example1.py
+++ b/tools/python/boutiques/tests/test_example1.py
@@ -189,7 +189,7 @@ class TestExample1(TestCase):
                              os.path.join(example1_dir,
                                           "example1_docker.json"),
                              invocationStr)
-        assert("Unable to decode JSON object" in str(e))
+        assert("Cannot parse input" in str(e))
 
     @pytest.mark.skipif(subprocess.Popen("type docker", shell=True).wait(),
                         reason="Docker not installed")

--- a/tools/python/boutiques/tests/test_example1.py
+++ b/tools/python/boutiques/tests/test_example1.py
@@ -217,9 +217,7 @@ class TestExample1(TestCase):
                ret.output_files[1].file_name == "log-4-coin;plop.txt")
 
         self.clean_up()
-        ret = bosh.execute("launch",
-                           os.path.join(example1_dir,
-                                        "example1_docker.json"),
+        ret = bosh.execute("launch", "zenodo.1472823",
                            "-x",
                            os.path.join(example1_dir,
                                         "invocation.json"))

--- a/tools/python/boutiques/tests/test_example1.py
+++ b/tools/python/boutiques/tests/test_example1.py
@@ -196,8 +196,7 @@ class TestExample1(TestCase):
     def test_example1_exec_docker_from_zenodo(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
         self.clean_up()
-        ret = bosh.execute("launch", "-z",
-                           "example1_docker.json",
+        ret = bosh.execute("launch", "zenodo.1472823",
                            os.path.join(example1_dir,
                                         "invocation.json"))
 

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -1,38 +1,31 @@
 from boutiques.bosh import bosh
 from unittest import TestCase
+from boutiques.puller import ZenodoError
 import os
 import shutil
 
 
 class TestPull(TestCase):
 
-    def test_pull_by_filename(self):
+    def test_pull(self):
         # create a temporary directory to download the file
         tmp_dir = "test_pull_example1"
         if not os.path.isdir(tmp_dir):
             os.mkdir(tmp_dir)
         os.chdir(tmp_dir)
-        bosh(["pull", "example1_docker.json"])
+        bosh(["pull", "zenodo.1472823"])
 
         assert(os.path.exists("example1_docker.json"))
 
         os.chdir("..")
         shutil.rmtree(tmp_dir)
 
-    def test_pull_by_id(self):
-        # create a temporary directory to download the file
-        tmp_dir = "test_pull_example1"
-        if not os.path.isdir(tmp_dir):
-            os.mkdir(tmp_dir)
-        os.chdir(tmp_dir)
-        bosh(["pull", "1472823"])
-
-        assert(os.path.exists("example1_docker.json"))
-
-        os.chdir("..")
-        shutil.rmtree(tmp_dir)
+    def test_pull_missing_prefix(self):
+        with self.assertRaises(ZenodoError) as e:
+            bosh(["pull", "1472823"])
+        assert("Zenodo ID must be prefixed by 'zenodo'" in str(e.exception))
 
     def test_pull_not_found(self):
-        with self.assertRaises(IOError) as e:
-            bosh(["pull", "99999"])
+        with self.assertRaises(ZenodoError) as e:
+            bosh(["pull", "zenodo.99999"])
         assert("Descriptor not found" in str(e.exception))

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -8,7 +8,7 @@ class TestPull(TestCase):
 
     def test_pull(self):
         bosh(["pull", "zenodo.1472823"])
-        cache_dir = os.path.join(os.getenv("HOME"), ".cache", "boutiques")
+        cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")
         assert(os.path.exists(os.path.join(cache_dir, "example1_docker.json")))
 
     def test_pull_missing_prefix(self):

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -1,0 +1,36 @@
+from boutiques.bosh import bosh
+from unittest import TestCase
+import os
+import shutil
+
+
+class TestPull(TestCase):
+
+    def test_pull_by_filename(self):
+        # create a temporary directory to download the file
+        tmp_dir = "test_pull_example1"
+        os.mkdir(tmp_dir)
+        os.chdir(tmp_dir)
+        bosh(["pull", "example1.json"])
+
+        assert(os.path.exists("example1.json"))
+
+        os.chdir("..")
+        shutil.rmtree(tmp_dir)
+
+    def test_pull_by_id(self):
+        # create a temporary directory to download the file
+        tmp_dir = "test_pull_example1"
+        os.mkdir(tmp_dir)
+        os.chdir(tmp_dir)
+        bosh(["pull", "1219701"])
+
+        assert(os.path.exists("example1.json"))
+
+        os.chdir("..")
+        shutil.rmtree(tmp_dir)
+
+    def test_pull_not_found(self):
+        with self.assertRaises(IOError) as e:
+            bosh(["pull", "99999"])
+        assert("Descriptor not found" in str(e.exception))

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -12,9 +12,9 @@ class TestPull(TestCase):
         if not os.path.isdir(tmp_dir):
             os.mkdir(tmp_dir)
         os.chdir(tmp_dir)
-        bosh(["pull", "example1.json"])
+        bosh(["pull", "example1_docker.json"])
 
-        assert(os.path.exists("example1.json"))
+        assert(os.path.exists("example1_docker.json"))
 
         os.chdir("..")
         shutil.rmtree(tmp_dir)
@@ -25,9 +25,9 @@ class TestPull(TestCase):
         if not os.path.isdir(tmp_dir):
             os.mkdir(tmp_dir)
         os.chdir(tmp_dir)
-        bosh(["pull", "1219701"])
+        bosh(["pull", "1472823"])
 
-        assert(os.path.exists("example1.json"))
+        assert(os.path.exists("example1_docker.json"))
 
         os.chdir("..")
         shutil.rmtree(tmp_dir)

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -9,7 +9,8 @@ class TestPull(TestCase):
     def test_pull_by_filename(self):
         # create a temporary directory to download the file
         tmp_dir = "test_pull_example1"
-        os.mkdir(tmp_dir)
+        if not os.path.isdir(tmp_dir):
+            os.mkdir(tmp_dir)
         os.chdir(tmp_dir)
         bosh(["pull", "example1.json"])
 
@@ -21,7 +22,8 @@ class TestPull(TestCase):
     def test_pull_by_id(self):
         # create a temporary directory to download the file
         tmp_dir = "test_pull_example1"
-        os.mkdir(tmp_dir)
+        if not os.path.isdir(tmp_dir):
+            os.mkdir(tmp_dir)
         os.chdir(tmp_dir)
         bosh(["pull", "1219701"])
 

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -2,23 +2,14 @@ from boutiques.bosh import bosh
 from unittest import TestCase
 from boutiques.puller import ZenodoError
 import os
-import shutil
 
 
 class TestPull(TestCase):
 
     def test_pull(self):
-        # create a temporary directory to download the file
-        tmp_dir = "test_pull_example1"
-        if not os.path.isdir(tmp_dir):
-            os.mkdir(tmp_dir)
-        os.chdir(tmp_dir)
         bosh(["pull", "zenodo.1472823"])
-
-        assert(os.path.exists("example1_docker.json"))
-
-        os.chdir("..")
-        shutil.rmtree(tmp_dir)
+        cache_dir = os.path.join(os.getenv("HOME"), ".cache", "boutiques")
+        assert(os.path.exists(os.path.join(cache_dir, "example1_docker.json")))
 
     def test_pull_missing_prefix(self):
         with self.assertRaises(ZenodoError) as e:

--- a/tools/python/boutiques/tests/test_search.py
+++ b/tools/python/boutiques/tests/test_search.py
@@ -1,0 +1,13 @@
+from boutiques.bosh import bosh
+from unittest import TestCase
+
+
+class TestSearch(TestCase):
+
+    def test_search_all(self):
+        results = bosh(["search"])
+        assert(results)
+
+    def test_search_query(self):
+        results = bosh(["search", "-q", "ICA_AROMA"])
+        assert("ICA_AROMA" in results)

--- a/tools/python/boutiques/tests/test_search.py
+++ b/tools/python/boutiques/tests/test_search.py
@@ -9,5 +9,5 @@ class TestSearch(TestCase):
         assert(results)
 
     def test_search_query(self):
-        results = bosh(["search", "-q", "ICA_AROMA"])
+        results = bosh(["search", "ICA_AROMA"])
         assert("ICA_AROMA" in results)

--- a/tools/python/boutiques/tests/test_search.py
+++ b/tools/python/boutiques/tests/test_search.py
@@ -6,8 +6,9 @@ class TestSearch(TestCase):
 
     def test_search_all(self):
         results = bosh(["search"])
-        assert(results)
+        assert(len(results) > 0)
 
     def test_search_query(self):
         results = bosh(["search", "ICA_AROMA"])
-        assert("ICA_AROMA" in results)
+        assert(len(results) > 0)
+        assert("ICA_AROMA" in results[0]["TITLE"])

--- a/tools/python/boutiques/tests/test_search.py
+++ b/tools/python/boutiques/tests/test_search.py
@@ -7,8 +7,17 @@ class TestSearch(TestCase):
     def test_search_all(self):
         results = bosh(["search"])
         assert(len(results) > 0)
+        assert(list(results[0].keys()) == ["ID", "TITLE", "DESCRIPTION"])
 
     def test_search_query(self):
         results = bosh(["search", "ICA_AROMA"])
         assert(len(results) > 0)
         assert("ICA_AROMA" in results[0]["TITLE"])
+
+    def test_search_verbose(self):
+        results = bosh(["search", "-v"])
+        assert(len(results) > 0)
+        assert(list(results[0].keys()) == ["ID", "TITLE", "DESCRIPTION",
+                                           "AUTHOR", "VERSION", "DOI",
+                                           "SCHEMA VERSION", "CONTAINER",
+                                           "TAGS"])

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -9,7 +9,8 @@ DEPS = [
          "pytest",
          "termcolor",
          "pyyaml",
-         "jsonschema"
+         "jsonschema",
+	 "tabulate"
        ]
 
 setup(name="boutiques",

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -10,7 +10,7 @@ DEPS = [
          "termcolor",
          "pyyaml",
          "jsonschema",
-	 "tabulate"
+	       "tabulate"
        ]
 
 setup(name="boutiques",


### PR DESCRIPTION
Issue #241 

`bosh search` searches Zenodo for all descriptors and returns a list like this:
![image](https://user-images.githubusercontent.com/14361988/47945415-3814f580-ded8-11e8-9069-6fd9584df2c2.png)

`bosh search <search_query>` searches for a specific descriptor, for example `bosh search ndmg` will return:
![image](https://user-images.githubusercontent.com/14361988/47945423-4c58f280-ded8-11e8-9236-3a13833196d7.png)

`bosh pull <ZID>` downloads a descriptor from Zenodo using its ID prefixed with 'zenodo.' (as returned from bosh search), e.g. `bosh pull zenodo.1472823`

`bosh exec launch <ZID> <invocation>` launches an invocation using the pull functionality to open and use the descriptor directly from its published entry on Zenodo.
