### PR TITLE
Release 0.5.14

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@
    cd jsonschema2md
    npm link
    cd ..
-   jsonschema2md -d ./tools/python/boutiques/schema/descriptor.schema.json
+   jsonschema2md -d ./tools/python/boutiques/schema/descriptor.schema.json -v 04
    cp out/descriptor.schema.md schema/README.md
    ```
 3. If the `README.md` at the root of this repository was updated, update `tools/python/README.rst` using [pandoc](https://pandoc.org/)

--- a/schema/README.md
+++ b/schema/README.md
@@ -7,7 +7,7 @@
 
 | Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
 |----------|------------|--------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Forbidden |  |
+| Can be instantiated | No | Experimental | No | Forbidden | Forbidden | [descriptor.schema.json](descriptor.schema.json) |
 
 # Tool Properties
 
@@ -18,6 +18,7 @@
 | [container-image](#container-image) | `object` | Optional | Tool (this schema) |
 | [custom](#custom) | `object` | Optional | Tool (this schema) |
 | [description](#description) | `string` | **Required** | Tool (this schema) |
+| [descriptor-url](#descriptor-url) | `string` | Optional | Tool (this schema) |
 | [doi](#doi) | `string` | Optional | Tool (this schema) |
 | [environment-variables](#environment-variables) | `object[]` | Optional | Tool (this schema) |
 | [error-codes](#error-codes) | `object[]` | Optional | Tool (this schema) |
@@ -127,6 +128,25 @@ Tool description.
 * defined in this schema
 
 ### description Type
+
+
+`string`
+* minimum length: 1 characters
+
+
+
+
+
+## descriptor-url
+
+Link to the descriptor itself (e.g. the GitHub repo where it is hosted).
+
+`descriptor-url`
+* is optional
+* type: `string`
+* defined in this schema
+
+### descriptor-url Type
 
 
 `string`

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -2,7 +2,7 @@ import sys
 from setuptools import setup
 import sys
 
-VERSION = "0.5.13"
+VERSION = "0.5.14"
 DEPS = [
          "simplejson",
          "requests",


### PR DESCRIPTION
* Bumped version number in `setup.py`
* Updated markdown version of schema
* Updated release instructions to add missing option for `jsonschema2md`