### PR TITLE
Removed extra space at end of list inputs

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -804,7 +804,10 @@ class LocalExecutor(object):
                             s = str(x)
                             if escape:
                                 s = escape_string(str(x))
-                            s_val += s + " "
+                            if val.index(x) == len(val)-1:
+                                s_val += s
+                            else:
+                                s_val += s + " "
                         val = s_val
                     else:
                         val = str(val)

--- a/tools/python/boutiques/schema/examples/no_spaces.json
+++ b/tools/python/boutiques/schema/examples/no_spaces.json
@@ -1,5 +1,5 @@
 {
-    "command-line": "there[INPUT]shouldnotbeanyspace[INPUT]inhereaftersubstitution", 
+    "command-line": "there[INPUT]shouldnotbeanyspace[INPUT_LIST]inhereaftersubstitution", 
     "description": "A command-line with no space", 
     "inputs": [
         {
@@ -7,6 +7,15 @@
             "name": "param", 
             "type": "String", 
             "value-key": "[INPUT]"
+        },
+        {
+            "id": "param2", 
+            "name": "param2", 
+            "type": "String",
+            "list": true, 
+            "min-list-entries": 1,
+            "max-list-entries": 1,
+            "value-key": "[INPUT_LIST]"
         }
     ],
     "name": "nospace", 


### PR DESCRIPTION
There was a bug where list inputs appeared in the command line with an extra space at the end. 