### PR TITLE
Specify max number of results returned by bosh search

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -372,11 +372,15 @@ def search(*params):
     parser.add_argument("--sandbox", action="store_true",
                         help="search Zenodo's sandbox instead of "
                         "production server. Recommended for tests.")
+    parser.add_argument("-m", "--max", action="store",
+                        help="Specify the maximum number of results "
+                        "to be returned. Default is 10.")
 
     result = parser.parse_args(params)
 
     from boutiques.searcher import Searcher
-    searcher = Searcher(result.query, result.verbose, result.sandbox)
+    searcher = Searcher(result.query, result.verbose, result.sandbox,
+                        result.max)
 
     return searcher.search()
 

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -217,7 +217,7 @@ class Publisher():
         # of an existing one
         from boutiques.searcher import Searcher
         searcher = Searcher(self.descriptor.get("name"), self.verbose,
-                            self.sandbox)
+                            self.sandbox, None)
         r = searcher.zenodo_search()
 
         id_to_update = 0

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -30,7 +30,7 @@ class Puller():
 
     def pull(self):
         from boutiques.searcher import Searcher
-        searcher = Searcher(None, self.verbose, self.sandbox)
+        searcher = Searcher(None, self.verbose, self.sandbox, None)
         r = searcher.zenodo_search()
 
         for hit in r.json()["hits"]["hits"]:

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -9,7 +9,7 @@ class ZenodoError(Exception):
 
 class Searcher():
 
-    def __init__(self, query, verbose, sandbox):
+    def __init__(self, query, verbose, sandbox, max_results):
         if query is not None:
             self.query = query
         else:
@@ -17,6 +17,12 @@ class Searcher():
 
         self.verbose = verbose
         self.sandbox = sandbox
+
+        # Return max 10 results by default
+        if max_results is not None:
+            self.max_results = max_results
+        else:
+            self.max_results = 10
 
         # Set Zenodo endpoint
         self.zenodo_endpoint = "https://sandbox.zenodo.org" if\
@@ -35,13 +41,15 @@ class Searcher():
         r = requests.get(self.zenodo_endpoint + '/api/records/?q=%s&'
                          'keywords=boutiques&keywords=schema&'
                          'keywords=version&file_type=json&type=software'
-                         % self.query)
+                         '&page=1&size=%s' % (self.query, self.max_results))
         if(r.status_code != 200):
             self.raise_zenodo_error("Error searching Zenodo", r)
 
         if(self.verbose):
-            self.print_zenodo_info("Zenodo search returned %d results"
-                                   % r.json()["hits"]["total"], r)
+            self.print_zenodo_info("Search successful. Showing %d of %d "
+                                   "results."
+                                   % (len(r.json()["hits"]["hits"]),
+                                      r.json()["hits"]["total"]), r)
         return r
 
     def create_results_list(self, results):

--- a/tools/python/boutiques/tests/test_search.py
+++ b/tools/python/boutiques/tests/test_search.py
@@ -21,3 +21,7 @@ class TestSearch(TestCase):
                                            "AUTHOR", "VERSION", "DOI",
                                            "SCHEMA VERSION", "CONTAINER",
                                            "TAGS"])
+
+    def test_search_specify_max_results(self):
+        results = bosh(["search", "--sandbox", "-m", "20"])
+        assert(len(results) == 20)


### PR DESCRIPTION
Issue #335

`bosh search` will return a maximum of 10 results by default, unless the `-m` option is used to specify a different number. 