### PR TITLE
Add support for JSON objects/Zenodo IDs passed on the CLI in bosh

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -335,9 +335,7 @@ def test(*params):
     invocation(result.descriptor)
 
     # Extraction of all the invocations defined for the test-cases.
-    with open(result.descriptor) as fhandle:
-        # might just need to be `fhandle` in this context, but not sure
-        descriptor = json.loads(fhandle.read())
+    descriptor = loadJson(result.descriptor)
 
     if (not descriptor.get("tests")):
         # If no tests have been specified, we consider testing successful.

--- a/tools/python/boutiques/conftest.py
+++ b/tools/python/boutiques/conftest.py
@@ -1,16 +1,16 @@
 import json
 import tempfile
 import os.path as op
+from boutiques.localExec import loadJson
 
 
 def pytest_addoption(parser):
     parser.addoption("--descriptor", action="append", default=[])
 
 
-def fetch_tests(descriptor_filename):
+def fetch_tests(descriptor_input):
 
-    with open(descriptor_filename) as fhandle:
-        descriptor = json.loads(fhandle.read())
+    descriptor = loadJson(descriptor_input)
 
     tests = []
 
@@ -25,7 +25,7 @@ def fetch_tests(descriptor_filename):
         temp_invocation_JSON.seek(0)
 
         # Now we setup the necessary elements for the testing function.
-        tests.append([descriptor_filename, test, temp_invocation_JSON])
+        tests.append([descriptor_input, test, temp_invocation_JSON])
 
     return (descriptor["name"], tests)
 

--- a/tools/python/boutiques/exporter.py
+++ b/tools/python/boutiques/exporter.py
@@ -3,6 +3,7 @@
 import json
 import os
 import uuid
+from boutiques.localExec import loadJson
 
 
 class ExportError(Exception):
@@ -46,8 +47,7 @@ class Exporter():
 
     def carmin(self, output_file):
         carmin_desc = {}
-        with open(self.descriptor, 'r') as fhandle:
-            descriptor = json.load(fhandle)
+        descriptor = loadJson(self.descriptor)
 
         if descriptor.get('doi'):
             self.identifier = descriptor.get('doi')

--- a/tools/python/boutiques/importer.py
+++ b/tools/python/boutiques/importer.py
@@ -3,6 +3,7 @@
 from argparse import ArgumentParser
 from jsonschema import ValidationError
 from boutiques.validator import validate_descriptor
+from boutiques.localExec import loadJson
 import boutiques
 import yaml
 import json
@@ -54,8 +55,7 @@ class Importer():
           "walltime-estimate": 3600
         },
         """
-        with open(self.input_descriptor, 'r') as fhandle:
-            descriptor = json.load(fhandle)
+        descriptor = loadJson(self.input_descriptor)
 
         if descriptor["schema-version"] != "0.4":
             raise ImportError("The input descriptor must have 'schema-version'"

--- a/tools/python/boutiques/tests/test_evaluate.py
+++ b/tools/python/boutiques/tests/test_evaluate.py
@@ -14,8 +14,53 @@ class TestEvaluate(TestCase):
         self.desc = os.path.join(example1_dir, "example1_docker.json")
         self.invo = os.path.join(example1_dir, "invocation.json")
 
+    def set_examples_json_obj(self):
+        example1_dir = os.path.join(os.path.dirname(bfile), "schema",
+                                    "examples", "example1")
+        self.desc = open(os.path.join(example1_dir,
+                         "example1_docker.json")).read()
+        self.invo = open(os.path.join(example1_dir, "invocation.json")).read()
+
+    def set_examples_from_zenodo(self):
+        example1_dir = os.path.join(os.path.dirname(bfile), "schema",
+                                    "examples", "example1")
+        self.desc = "zenodo.1472823"
+        self.invo = os.path.join(example1_dir, "invocation.json")
+
     def test_evaloutput(self):
         self.set_examples()
+        query = bosh.evaluate(self.desc, self.invo, "output-files/")
+        expect = {'logfile': 'log-4-coin;plop.txt',
+                  'output_files': 'output/*_exampleOutputTag.resultType',
+                  'config_file': './config.txt'}
+        assert(query == expect)
+
+        query = bosh.evaluate(self.desc, self.invo, "output-files/id=logfile")
+        expect = {'logfile': 'log-4-coin;plop.txt'}
+        assert(query == expect)
+
+        query = bosh.evaluate(self.desc, self.invo, "output-files/id=log-file")
+        expect = {}
+        assert(query == expect)
+
+    def test_evaloutput_json_obj(self):
+        self.set_examples_json_obj()
+        query = bosh.evaluate(self.desc, self.invo, "output-files/")
+        expect = {'logfile': 'log-4-coin;plop.txt',
+                  'output_files': 'output/*_exampleOutputTag.resultType',
+                  'config_file': './config.txt'}
+        assert(query == expect)
+
+        query = bosh.evaluate(self.desc, self.invo, "output-files/id=logfile")
+        expect = {'logfile': 'log-4-coin;plop.txt'}
+        assert(query == expect)
+
+        query = bosh.evaluate(self.desc, self.invo, "output-files/id=log-file")
+        expect = {}
+        assert(query == expect)
+
+    def test_evaloutput_from_zenodo(self):
+        self.set_examples_from_zenodo()
         query = bosh.evaluate(self.desc, self.invo, "output-files/")
         expect = {'logfile': 'log-4-coin;plop.txt',
                   'output_files': 'output/*_exampleOutputTag.resultType',

--- a/tools/python/boutiques/tests/test_export.py
+++ b/tools/python/boutiques/tests/test_export.py
@@ -55,3 +55,42 @@ class TestExport(TestCase):
         assert(result == open(ref_file, "r").read().strip() or
                result == open(ref_file_p2, "r").read().strip())
         os.remove(fout)
+
+    def test_export_json_obj(self):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        example1_desc = open(os.path.join(example1_dir,
+                             "example1_docker.json")).read()
+        example1_desc_doi = os.path.join(example1_dir,
+                                         "example1_docker_with_doi.json")
+        fout = "test-example1-carmin.json"
+        ref_name = "example1_docker_exported.json"
+        ref_file = opj(example1_dir, ref_name)
+        ref_name_p2 = "example1_docker_exported_python2.json"
+        ref_file_p2 = opj(example1_dir, ref_name_p2)
+        # Identifier is passed, descriptor has no DOI
+        self.assertFalse(bosh(["export",
+                               "carmin",
+                               example1_desc,
+                               "--identifier", "123", fout]))
+        result = open(fout, "r").read().strip()
+        assert(result == open(ref_file, "r").read().strip() or
+               result == open(ref_file_p2, "r").read().strip())
+        # Identifier is not passed, descriptor has no DOI
+        with self.assertRaises(ExportError) as e:
+                bosh(["export",
+                      "carmin",
+                      example1_desc,
+                      fout])
+        self.assertTrue("Descriptor must have a DOI, or identifier "
+                        "must be specified" in str(e.exception))
+        self.assertRaises(ExportError, )
+        # Identifier is not passed, descriptor has a DOI
+        ref_name = "example1_docker_exported_doi.json"
+        ref_file = opj(example1_dir, ref_name)
+        ref_name_p2 = "example1_docker_exported_doi_python2.json"
+        ref_file_p2 = opj(example1_dir, ref_name_p2)
+        self.assertFalse(bosh(["export", "carmin", example1_desc_doi, fout]))
+        result = open(fout, "r").read().strip()
+        assert(result == open(ref_file, "r").read().strip() or
+               result == open(ref_file_p2, "r").read().strip())
+        os.remove(fout)

--- a/tools/python/boutiques/tests/test_import.py
+++ b/tools/python/boutiques/tests/test_import.py
@@ -56,6 +56,23 @@ class TestImport(TestCase):
                result == open(ref_file_p2, "r").read().strip())
         os.remove(fout)
 
+    def test_upgrade_04_json_obj(self):
+        fin = open(opj(op.split(bfile)[0],
+                   "schema/examples/upgrade04.json")).read()
+        fout = opj(op.split(bfile)[0], "schema/examples/upgraded05.json")
+        ref_name = "test-import-04-ref.json"
+        ref_file = opj(op.split(bfile)[0], "schema/examples", ref_name)
+        ref_name_p2 = "test-import-04-ref-python2.json"
+        ref_file_p2 = opj(op.split(bfile)[0], "schema/examples",
+                          ref_name_p2)
+        if op.isfile(fout):
+                os.remove(fout)
+        self.assertFalse(bosh(["import", "0.4",  fout, fin]))
+        result = open(fout, "r").read().strip()
+        assert(result == open(ref_file, "r").read().strip() or
+               result == open(ref_file_p2, "r").read().strip())
+        os.remove(fout)
+
     def test_import_cwl_valid(self):
         ex_dir = opj(op.split(bfile)[0], "tests/cwl")
         # These ones are supposed to crash

--- a/tools/python/boutiques/tests/test_invocation.py
+++ b/tools/python/boutiques/tests/test_invocation.py
@@ -19,6 +19,17 @@ class TestInvocation(TestCase):
         self.assertFalse(bosh(["invocation", descriptor, "-i",
                                invocation, "-w"]))
 
+    def test_invocation_json_obj(self):
+        descriptor = open(os.path.join(os.path.split(bfile)[0],
+                                       "schema/examples/good.json")).read()
+        invocation = open(os.path.join(os.path.split(bfile)[0],
+                                       "schema/examples/"
+                                       "good_invocation.json")).read()
+        self.assertFalse(bosh(["invocation", descriptor, "-i",
+                               invocation, "-w"]))
+        self.assertFalse(bosh(["invocation", descriptor, "-i",
+                               invocation, "-w"]))
+
     def test_invocation_invalid_cli(self):
         descriptor = os.path.join(os.path.split(bfile)[0],
                                   "schema/examples/good.json")

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -24,6 +24,29 @@ class TestSimulate(TestCase):
                                                    "good_nooutputs.json"),
                                       "-r", "1").exit_code)
 
+    def test_success_desc_as_json_obj(self):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        desc_json = open(os.path.join(example1_dir,
+                                      "example1_docker.json")).read()
+        self.assertFalse(bosh.execute("simulate",
+                                      desc_json,
+                                      "-r", "1").exit_code)
+
+        self.assertFalse(bosh.execute("simulate",
+                                      os.path.join(self.get_examples_dir(),
+                                                   "good_nooutputs.json"),
+                                      "-r", "1").exit_code)
+
+    def test_success_desc_from_zenodo(self):
+        self.assertFalse(bosh.execute("simulate",
+                                      "zenodo.1472823",
+                                      "-r", "1").exit_code)
+
+        self.assertFalse(bosh.execute("simulate",
+                                      os.path.join(self.get_examples_dir(),
+                                                   "good_nooutputs.json"),
+                                      "-r", "1").exit_code)
+
     def test_failing_bad_descriptor_invo_combos(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
 

--- a/tools/python/boutiques/tests/test_test.py
+++ b/tools/python/boutiques/tests/test_test.py
@@ -26,6 +26,19 @@ class TestTest(TestCase):
                                op.join(self.get_examples_dir(),
                                        "tests_good.json")]))
 
+    @pytest.mark.skipif(subprocess.Popen("type docker", shell=True).wait(),
+                        reason="Docker not installed")
+    def test_test_good_desc_as_json_obj(self):
+        self.assertFalse(bosh(["test",
+                               open(op.join(self.get_examples_dir(),
+                                            "tests_good.json")).read()]))
+
+    @pytest.mark.skipif(subprocess.Popen("type docker", shell=True).wait(),
+                        reason="Docker not installed")
+    def test_test_good_from_zenodo(self):
+        self.assertFalse(bosh(["test",
+                               "zenodo.1472823"]))
+
     def test_test_invalid(self):
         with self.assertRaises(ValidationError) as context:
             bosh(["test",


### PR DESCRIPTION
Issue #277 

Modified the following bosh functions to accept JSON objects and Zenodo IDs for descriptors and/or invocations:
* Test
* Export
* Import

Wrote test cases for accepting JSON objects/Zenodo IDs for all bosh functions. Some test cases were not written:
* Import: no Zenodo test because there are no published descriptors that use schema version 04 to test the `upgrade_04` function
* Export: no Zenodo test because the published "Example Boutiques Tool" has version 0.0.3 and the one used for the export tests has version 0.0.1. I could change it to 0.0.3 everywhere but I figured this would be tedious as we'd just need to change it again every time we publish a new version. 
* Publish: no test with JSON obj because published items must be files; no test with Zenodo since it doesn't make sense to publish an already published descriptor. 
* Invocation: no Zenodo test because the test uses `good.json` which isn't published