### PR TITLE
Minor changes to bosh search and pull

### DIFF
--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -30,7 +30,7 @@ class Puller():
 
     def pull(self):
         from boutiques.searcher import Searcher
-        searcher = Searcher(None, self.verbose, self.sandbox, None)
+        searcher = Searcher(self.zid, self.verbose, self.sandbox, None)
         r = searcher.zenodo_search()
 
         for hit in r.json()["hits"]["hits"]:
@@ -45,8 +45,10 @@ class Puller():
                     if(self.verbose):
                         self.print_zenodo_info("Downloading descriptor %s"
                                                % file_name, r)
-                    return urlretrieve(file_path, os.path.join(cache_dir,
-                                       file_name))
+                    downloaded = urlretrieve(file_path, os.path.join(cache_dir,
+                                             file_name))
+                    print("Downloaded descriptor to " + cache_dir)
+                    return downloaded
                 if(self.verbose):
                     self.print_zenodo_info("Opening descriptor %s"
                                            % file_name, r)

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -33,6 +33,9 @@ class Searcher():
 
     def search(self):
         results = self.zenodo_search()
+        print("Showing %d of %d results."
+              % (len(results.json()["hits"]["hits"]),
+                 results.json()["hits"]["total"]))
         if self.verbose:
             return self.create_results_list_verbose(results.json())
         return self.create_results_list(results.json())
@@ -44,12 +47,8 @@ class Searcher():
                          '&page=1&size=%s' % (self.query, self.max_results))
         if(r.status_code != 200):
             self.raise_zenodo_error("Error searching Zenodo", r)
-
         if(self.verbose):
-            self.print_zenodo_info("Search successful. Showing %d of %d "
-                                   "results."
-                                   % (len(r.json()["hits"]["hits"]),
-                                      r.json()["hits"]["total"]), r)
+            self.print_zenodo_info("Search successful.", r)
         return r
 
     def create_results_list(self, results):


### PR DESCRIPTION
Fixed a bug in `bosh pull` where if the descriptor isn't in the first 10 search results, it won't be found and the pull will fail. Instead of searching for all boutiques descriptors, it searches with the ZID as the query, which seems to always return the desired descriptor as the first and only result. 

Also added some info messages which I think are necessary even in non-verbose mode:
* `bosh search` prints the number of results displayed out of the total (so the user will know if there are additional results that were not displayed).
* `bosh pull` prints the name of the download folder (the cache directory) so the user will know where to find the pulled file.