### PR TITLE
Bosh exec prepare

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -104,6 +104,9 @@ def execute(*params):
         parser.add_argument("-s", "--stream", action="store_true",
                             help="Streams stdout and stderr in real time "
                             "during execution.")
+        parser.add_argument("--imagepath", action="store",
+                            help="Location of Singularity image "
+                            "(default is current directory).")
         results = parser.parse_args(params)
         descriptor = results.descriptor
         inp = results.invocation
@@ -117,7 +120,8 @@ def execute(*params):
                                  {"forcePathType": True,
                                   "debug": results.debug,
                                   "changeUser": results.user,
-                                  "stream": results.stream})
+                                  "stream": results.stream,
+                                  "imagepath": results.imagepath})
         # Execute it
         return executor.execute(results.volumes)
 
@@ -182,6 +186,9 @@ def execute(*params):
         parser.add_argument("-s", "--stream", action="store_true",
                             help="Streams stdout and stderr in real time "
                             "during execution.")
+        parser.add_argument("--imagepath", action="store",
+                            help="Location of Singularity image "
+                            "(default is current directory).")
         results = parser.parse_args(params)
         descriptor = results.descriptor
 
@@ -193,7 +200,8 @@ def execute(*params):
         executor = LocalExecutor(descriptor, None,
                                  {"forcePathType": True,
                                   "debug": results.debug,
-                                  "stream": results.stream})
+                                  "stream": results.stream,
+                                  "imagePath": results.imagepath})
         container_location = executor.prepare()[1]
         print("Container location: " + container_location)
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -121,7 +121,7 @@ def execute(*params):
                                   "debug": results.debug,
                                   "changeUser": results.user,
                                   "stream": results.stream,
-                                  "imagepath": results.imagepath})
+                                  "imagePath": results.imagepath})
         # Execute it
         return executor.execute(results.volumes)
 

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -14,6 +14,7 @@ import pwd
 import os.path as op
 from termcolor import colored
 from boutiques.evaluate import evaluateEngine
+from filelock import FileLock
 
 
 class ExecutorOutput():
@@ -238,43 +239,8 @@ class LocalExecutor(object):
         container_location = ""
         container_command = ""
         if conIsPresent:
-            if conType == 'docker':
-                # Pull the docker image
-                if self._localExecute("docker pull " + str(conImage))[1]:
-                    container_location = "Local copy"
-            elif conType == 'singularity':
-                if not conIndex:
-                    conIndex = "shub://"
-                elif not conIndex.endswith("://"):
-                    conIndex = conIndex + "://"
-                conName = conImage.replace("/", "-").replace(":", "-") + ".simg"
-
-                if conName not in os.listdir('./'):
-                    pull_loc = "\"{0}\" {1}{2}".format(conName,
-                                                       conIndex,
-                                                       conImage)
-                    container_location = ("Pulled from {1}{2} ({0} not found "
-                                          "in current "
-                                          "working directory)").format(conName,
-                                                                       conIndex,
-                                                                       conImage)
-                    # Pull the singularity image
-                    sing_command = "singularity pull --name " + pull_loc
-                    (stdout, stderr), return_code = self._localExecute(
-                                                            sing_command)
-                    if return_code:
-                        message = ("Could not pull Singularity"
-                                   " image: " + os.linesep + " * Pull command: "
-                                   + sing_command + os.linesep + " * Error: "
-                                   + stderr.decode("utf-8"))
-                        raise ExecutorError(message)
-                else:
-                    container_location = "Local ({0})".format(conName)
-                conName = op.abspath(conName)
-            else:
-                raise ExecutorError('Unrecognized container'
-                                    ' type: \"%s\"' % conType)
-
+            # Pull the container
+            (conName, container_location) = self.prepare()
             # Generate command script
             # Get the supported shell by the docker or singularity
             cmdString = "#!"+self.shell+" -l\n" + str(command)
@@ -414,6 +380,65 @@ class LocalExecutor(object):
                               missing_files,
                               command,
                               container_command, container_location)
+
+    def prepare(self):
+        con = self.con
+        # Check for Container image
+        conType, conImage = con.get('type'), con.get('image'),
+        conIndex = con.get("index")
+        if conImage is None:
+            return
+
+        # If container is present, alter the command template accordingly
+        conName = ""
+        container_location = ""
+        if conType == 'docker':
+            # Pull the docker image
+            if self._localExecute("docker pull " + str(conImage))[1]:
+                container_location = "Local copy"
+            else:
+                container_location = "Pulled from Docker"
+        elif conType == 'singularity':
+            if not conIndex:
+                conIndex = "shub://"
+            elif not conIndex.endswith("://"):
+                conIndex = conIndex + "://"
+            conName = conImage.replace("/", "-").replace(":", "-") + ".simg"
+
+            # Create a lockfile to protect against other threads trying to pull
+            # the image
+            lockfile = conName + ".lock"
+            lock = FileLock(lockfile)
+            lock.acquire()
+            try:
+                if conName not in os.listdir('./'):
+                    pull_loc = "\"{0}\" {1}{2}".format(conName,
+                                                       conIndex,
+                                                       conImage)
+                    container_location = ("Pulled from {1}{2} ({0} not found "
+                                          "in current "
+                                          "working directory)").format(conName,
+                                                                       conIndex,
+                                                                       conImage)
+                    # Pull the singularity image
+                    sing_command = "singularity pull --name " + pull_loc
+                    (stdout, stderr), return_code = self._localExecute(
+                                                            sing_command)
+                    if return_code:
+                        message = ("Could not pull Singularity"
+                                   " image: " + os.linesep + " * Pull command: "
+                                   + sing_command + os.linesep + " * Error: "
+                                   + stderr.decode("utf-8"))
+                        raise ExecutorError(message)
+                else:
+                    container_location = "Local ({0})".format(conName)
+            finally:
+                lock.release()
+            conName = op.abspath(conName)
+        else:
+            raise ExecutorError('Unrecognized container'
+                                ' type: \"%s\"' % conType)
+        return (conName, container_location)
 
     # Private method that attempts to locally execute the given
     # command. Returns the exit code.

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -383,11 +383,11 @@ class LocalExecutor(object):
 
     def prepare(self):
         con = self.con
-        # Check for Container image
+        if con is None:
+            return ("", "Descriptor does not specify a container image.")
+
         conType, conImage = con.get('type'), con.get('image'),
         conIndex = con.get("index")
-        if conImage is None:
-            return
 
         # If container is present, alter the command template accordingly
         conName = ""
@@ -404,7 +404,6 @@ class LocalExecutor(object):
             lockfile = conName + ".lock"
             lock = FileLock(lockfile)
             lock.acquire()
-
             try:
                 if not conIndex:
                     conIndex = "shub://"

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -3,8 +3,8 @@
     "container-image": {
         "entrypoint": false, 
         "image": "neurodata/ndmg:v0.0.41-1", 
-        "index": "index.docker.io", 
-        "type": "docker"
+        "index": "docker://", 
+        "type": "singularity"
     }, 
     "description": "dwi connectome estimation pipeline", 
     "error-codes": [

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -2,9 +2,9 @@
     "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN] [EXTRA1] [EXTRA2] [EXTRA3]", 
     "container-image": {
         "entrypoint": false, 
-        "image": "neurodata/ndmg:v0.0.41-1", 
-        "index": "index.docker.io", 
-        "type": "docker"
+        "image": "neurodatadsadsa/ndmg:v0.0.41-1", 
+        "index": "docker://", 
+        "type": "singularity"
     }, 
     "description": "dwi connectome estimation pipeline", 
     "error-codes": [

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -2,9 +2,9 @@
     "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN] [EXTRA1] [EXTRA2] [EXTRA3]", 
     "container-image": {
         "entrypoint": false, 
-        "image": "neurodatadsadsa/ndmg:v0.0.41-1", 
-        "index": "docker://", 
-        "type": "singularity"
+        "image": "neurodata/ndmg:v0.0.41-1", 
+        "index": "index.docker.io", 
+        "type": "docker"
     }, 
     "description": "dwi connectome estimation pipeline", 
     "error-codes": [

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -3,8 +3,8 @@
     "container-image": {
         "entrypoint": false, 
         "image": "neurodata/ndmg:v0.0.41-1", 
-        "index": "docker://", 
-        "type": "singularity"
+        "index": "index.docker.io", 
+        "type": "docker"
     }, 
     "description": "dwi connectome estimation pipeline", 
     "error-codes": [

--- a/tools/python/boutiques/tests/test_prepare.py
+++ b/tools/python/boutiques/tests/test_prepare.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import pytest
+from unittest import TestCase
+from boutiques import __file__ as bfile
+import boutiques as bosh
+
+
+class TestPrepare(TestCase):
+
+    def get_examples_dir(self):
+        return os.path.join(os.path.dirname(bfile),
+                            "schema", "examples")
+
+    @pytest.mark.skipif(subprocess.Popen("type docker", shell=True).wait(),
+                        reason="Docker not installed")
+    def test_prepare_docker(self):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        ret = bosh.execute("prepare",
+                           os.path.join(example1_dir,
+                                        "example1_docker.json"))
+        assert("Local copy" in ret.stdout)
+
+    @pytest.mark.skipif(subprocess.Popen("type singularity", shell=True).wait(),
+                        reason="Singularity not installed")
+    def test_prepare_sing(self):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        ret = bosh.execute("prepare",
+                           os.path.join(example1_dir,
+                                        "example1_sing.json"))
+        assert("Local (boutiques-example1-test.simg)" in ret.stdout)

--- a/tools/python/boutiques/tests/test_prepare.py
+++ b/tools/python/boutiques/tests/test_prepare.py
@@ -6,6 +6,7 @@ import pytest
 from unittest import TestCase
 from boutiques import __file__ as bfile
 import boutiques as bosh
+from boutiques.localExec import ExecutorError
 
 
 class TestPrepare(TestCase):
@@ -31,3 +32,20 @@ class TestPrepare(TestCase):
                            os.path.join(example1_dir,
                                         "example1_sing.json"))
         assert("Local (boutiques-example1-test.simg)" in ret.stdout)
+
+    @pytest.mark.skipif(subprocess.Popen("type singularity", shell=True).wait(),
+                        reason="Singularity not installed")
+    def test_prepare_sing_specify_imagepath(self):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        with pytest.raises(ExecutorError) as e:
+            ret = bosh.execute("prepare",
+                               os.path.join(example1_dir,
+                                            "example1_sing.json"),
+                               "--imagepath", os.path.expanduser('~'))
+        assert("Could not pull Singularity image" in str(e))
+
+    def test_prepare_no_container(self):
+        ret = bosh.execute("prepare",
+                           os.path.join(self.get_examples_dir(),
+                                        "no_container.json"))
+        assert("Descriptor does not specify a container image." in ret.stdout)

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -10,7 +10,8 @@ DEPS = [
          "termcolor",
          "pyyaml",
          "jsonschema",
-	       "tabulate"
+         "tabulate",
+         "filelock"
        ]
 
 setup(name="boutiques",


### PR DESCRIPTION
Issue #351 

Added `bosh exec prepare` which pulls the Docker or Singularity container image for a descriptor and prints the container location. In the case of a Singularity image, this method creates a lockfile for the image file so that multiple threads trying to pull the same image at the same time won't conflict with each other. Also added the option to specify a custom path for the Singularity image.