### PR TITLE
Fixed bug + reimplemented bosh prepare to use a lockdir

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -399,23 +399,24 @@ class LocalExecutor(object):
             else:
                 container_location = "Pulled from Docker"
         elif conType == 'singularity':
+            if not conIndex:
+                conIndex = "shub://"
+            elif not conIndex.endswith("://"):
+                conIndex = conIndex + "://"
+            conName = conImage.replace("/", "-").replace(":", "-") + ".simg"
+
+            imagePath = './'
+            if self.imagePath is not None:
+                imagePath = self.imagePath
+                os.environ["SINGULARITY_PULLFOLDER"] = imagePath
+
             # Create a lockfile to protect against other threads trying to pull
             # the image
             lockfile = conName + ".lock"
             lock = FileLock(lockfile)
             lock.acquire()
+
             try:
-                if not conIndex:
-                    conIndex = "shub://"
-                elif not conIndex.endswith("://"):
-                    conIndex = conIndex + "://"
-                conName = conImage.replace("/", "-").replace(":", "-") + ".simg"
-
-                imagePath = './'
-                if self.imagePath is not None:
-                    imagePath = self.imagePath
-                    os.environ["SINGULARITY_PULLFOLDER"] = imagePath
-
                 if conName not in os.listdir(imagePath):
                     pull_loc = "\"{0}\" {1}{2}".format(conName,
                                                        conIndex,

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -416,7 +416,7 @@ class LocalExecutor(object):
 
             # Container does not exist, try to pull it
             lockdir = conName + "-lock"
-            maxcount = 90  # how long to wait before timing out
+            maxcount = 36
             count = 0
             try:
                 while count < maxcount:
@@ -424,7 +424,7 @@ class LocalExecutor(object):
                     try:
                         os.mkdir(lockdir)
                     except OSError:
-                        time.sleep(20)
+                        time.sleep(5)
                     else:
                         # Check if container was created while waiting
                         if self._singConExists(conName):

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -411,7 +411,7 @@ class LocalExecutor(object):
             # If lockdir exists, block until it no longer exists
             while os.path.isdir(lockdir):
                 # time out after 30 mins of waiting
-                if (time.time() - os.stat(lockdir).st_mtime > 1800):
+                if time.time() - os.stat(lockdir).st_mtime > 1800:
                     raise ExecutorError("Process timed out trying "
                                         "to pull Singularity container")
                 # wait 20 seconds before checking again

--- a/tools/python/boutiques/tests/test_prepare.py
+++ b/tools/python/boutiques/tests/test_prepare.py
@@ -49,3 +49,10 @@ class TestPrepare(TestCase):
                            os.path.join(self.get_examples_dir(),
                                         "no_container.json"))
         assert("Descriptor does not specify a container image." in ret.stdout)
+
+    def test_prepare_sing_creates_lockfile(self):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        ret = bosh.execute("prepare",
+                           os.path.join(example1_dir,
+                                        "example1_sing.json"))
+        assert(os.path.isfile("boutiques-example1-test.simg.lock"))

--- a/tools/python/boutiques/tests/test_prepare.py
+++ b/tools/python/boutiques/tests/test_prepare.py
@@ -43,16 +43,10 @@ class TestPrepare(TestCase):
                                             "example1_sing.json"),
                                "--imagepath", os.path.expanduser('~'))
         assert("Could not pull Singularity image" in str(e))
+        assert("SINGULARITY_PULLFOLDER" not in os.environ)
 
     def test_prepare_no_container(self):
         ret = bosh.execute("prepare",
                            os.path.join(self.get_examples_dir(),
                                         "no_container.json"))
         assert("Descriptor does not specify a container image." in ret.stdout)
-
-    def test_prepare_sing_creates_lockfile(self):
-        example1_dir = os.path.join(self.get_examples_dir(), "example1")
-        ret = bosh.execute("prepare",
-                           os.path.join(example1_dir,
-                                        "example1_sing.json"))
-        assert(os.path.isfile("boutiques-example1-test.simg.lock"))

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -10,8 +10,7 @@ DEPS = [
          "termcolor",
          "pyyaml",
          "jsonschema",
-         "tabulate",
-         "filelock"
+         "tabulate"
        ]
 
 setup(name="boutiques",


### PR DESCRIPTION
`bosh prepare` creates a lock directory while pulling the Singularity image such that other processes trying to pull the same image will be blocked while they wait for the lockdir to no longer exist.