### PR TITLE
fixed bug in tags

### DIFF
--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -61,7 +61,10 @@ class PrettyPrinter():
                                                   self.desc.get("tool-version"))
         description = "Tool description: {0}".format(self.desc['description'])
         if self.desc.get("tags"):
-            tags = "Tags: {0}".format(", ".join(self.desc["tags"]))
+            taglist = ["{0}: {1}".format(k, v) if not isinstance(v, list)
+                       else "{0}: {1}".format(k, ", ".join(v))
+                       for k, v in self.desc["tags"].items()]
+            tags = "Tags: {0}".format("; ".join(taglist))
         else:
             tags = ""
 

--- a/tools/python/boutiques/schema/examples/test_pretty_print.json
+++ b/tools/python/boutiques/schema/examples/test_pretty_print.json
@@ -174,7 +174,7 @@
     }, 
     "tags": {
         "domain": "testing",
-        "foo": "bar",
+        "foo": ["bar1", "bar2"],
         "programming-language": "Python"
     },
     "tool-version": "0.0.1"


### PR DESCRIPTION
Now tags print out like this:

```
Tags: domain: testing; foo: bar1, bar2; programming-language: Python
```