### PR TITLE
Zenodo Improvements

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -455,14 +455,11 @@ def pull(*params):
     parser.add_argument("--sandbox", action="store_true",
                         help="pull from Zenodo's sandbox instead of "
                         "production server. Recommended for tests.")
-    parser.add_argument("--no-int", '-y', action="store_true",
-                        help="disable interactive input.")
 
     result = parser.parse_args(params)
 
     from boutiques.puller import Puller
-    puller = Puller(result.zid, result.verbose, True, result.sandbox,
-                    result.no_int)
+    puller = Puller(result.zid, result.verbose, result.sandbox)
     return puller.pull()
 
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -439,12 +439,14 @@ def pull(*params):
     parser.add_argument("--sandbox", action="store_true",
                         help="pull from Zenodo's sandbox instead of "
                         "production server. Recommended for tests.")
+    parser.add_argument("--no-int", '-y', action="store_true",
+                        help="disable interactive input.")
 
     result = parser.parse_args(params)
 
     from boutiques.puller import Puller
-    puller = Puller(result.zid, result.verbose, True, result.sandbox)
-
+    puller = Puller(result.zid, result.verbose, True, result.sandbox,
+                    result.no_int)
     return puller.pull()
 
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -416,12 +416,14 @@ def search(*params):
     parser.add_argument("-m", "--max", action="store",
                         help="Specify the maximum number of results "
                         "to be returned. Default is 10.")
+    parser.add_argument("-nt", "--no-trunc", action="store_true",
+                        help="Do not truncate long tool descriptions.")
 
     result = parser.parse_args(params)
 
     from boutiques.searcher import Searcher
     searcher = Searcher(result.query, result.verbose, result.sandbox,
-                        result.max)
+                        result.max, result.no_trunc)
 
     return searcher.search()
 

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1162,7 +1162,7 @@ def loadJson(userInput):
     # Zenodo ID
     elif userInput.split(".")[0].lower() == "zenodo":
         from boutiques.puller import Puller
-        puller = Puller(userInput, False, False, False)
+        puller = Puller(userInput, False, False, False, True)
         return json.loads(puller.pull().read().decode('utf-8'))
     # Try to parse JSON object
     e = ("Cannot parse input {}: file not found, "

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1163,7 +1163,7 @@ def loadJson(userInput):
     elif userInput.split(".")[0].lower() == "zenodo":
         from boutiques.puller import Puller
         puller = Puller(userInput, False, False, False, True)
-        return json.loads(puller.pull().read().decode('utf-8'))
+        return json.loads(puller.pull())
     # Try to parse JSON object
     e = ("Cannot parse input {}: file not found, "
          "invalid Zenodo ID, or invalid JSON object").format(userInput)

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -289,6 +289,10 @@ class Publisher():
                     keywords += [key + ":" + item for item in value]
         if self.descriptor.get('container-image'):
             keywords.append(self.descriptor['container-image']['type'])
+        if self.descriptor.get('tests'):
+            keywords.append('tests:y')
+        else:
+            keywords.append('tests:n')
         if self.url is not None:
             if data['metadata'].get('related_identifiers') is None:
                 data['metadata']['related_identifiers'] = []

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -212,7 +212,7 @@ class Publisher():
         # of an existing one
         from boutiques.searcher import Searcher
         searcher = Searcher(self.descriptor.get("name"), self.verbose,
-                            self.sandbox, None)
+                            self.sandbox, None, True)
         r = searcher.zenodo_search()
 
         id_to_update = 0

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -285,9 +285,7 @@ class Publisher():
         if self.descriptor.get('container-image'):
             keywords.append(self.descriptor['container-image']['type'])
         if self.descriptor.get('tests'):
-            keywords.append('tests:y')
-        else:
-            keywords.append('tests:n')
+            keywords.append('tested')
         if self.url is not None:
             if data['metadata'].get('related_identifiers') is None:
                 data['metadata']['related_identifiers'] = []

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -31,7 +31,7 @@ class Puller():
 
     def pull(self):
         from boutiques.searcher import Searcher
-        searcher = Searcher(self.zid, self.verbose, self.sandbox, None)
+        searcher = Searcher(self.zid, self.verbose, self.sandbox, None, True)
         r = searcher.zenodo_search()
 
         for hit in r.json()["hits"]["hits"]:
@@ -53,16 +53,16 @@ class Puller():
                         if ret.upper() != "Y":
                             return
                     if(self.verbose):
-                        self.print_info("Downloading descriptor %s"
-                                        % file_name, r)
+                        print_info("Downloading descriptor %s"
+                                   % file_name)
                     downloaded = urlretrieve(file_path,
                                              os.path.join(self.cache_dir,
                                                           file_name))
                     print("Downloaded descriptor to " + self.cache_dir)
                     return downloaded
                 if(self.verbose):
-                    self.print_info("Opening descriptor %s"
-                                    % file_name, r)
+                    print_info("Opening descriptor %s"
+                               % file_name)
                 # use the cached file if it exists
                 if os.path.isfile(os.path.join(self.cache_dir, file_name)):
                     return open(os.path.join(self.cache_dir, file_name), "r")

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -65,7 +65,8 @@ class Puller():
                                % file_name)
                 # use the cached file if it exists
                 if os.path.isfile(os.path.join(self.cache_dir, file_name)):
-                    return open(os.path.join(self.cache_dir, file_name), "r")
-                return urlopen(file_path)
+                    return open(os.path.join(self.cache_dir, file_name),
+                                "r").read()
+                return urlopen(file_path).read().decode('utf-8')
 
         raise_error(ZenodoError, "Descriptor not found")

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -1,6 +1,7 @@
 import requests
 from collections import OrderedDict
 import json
+from operator import itemgetter
 
 
 class ZenodoError(Exception):
@@ -55,15 +56,21 @@ class Searcher():
     def create_results_list(self, results):
         results_list = []
         for hit in results["hits"]["hits"]:
-            (id, title, description) = self.parse_basic_info(hit)
-            results_list.append(OrderedDict([("ID", id), ("TITLE", title),
-                                ("DESCRIPTION", description)]))
+            (id, title, description, downloads) = self.parse_basic_info(hit)
+            result_dict = OrderedDict([("ID", id), ("TITLE", title),
+                                      ("DESCRIPTION", description),
+                                      ("DOWNLOADS", downloads)])
+            if not self.no_trunc:
+                result_dict = self.truncate(result_dict, 40)
+            results_list.append(result_dict)
+        results_list = sorted(results_list, key=itemgetter('DOWNLOADS'),
+                              reverse=True)
         return results_list
 
     def create_results_list_verbose(self, results):
         results_list = []
         for hit in results["hits"]["hits"]:
-            (id, title, description) = self.parse_basic_info(hit)
+            (id, title, description, downloads) = self.parse_basic_info(hit)
             author = hit["metadata"]["creators"][0]["name"]
             version = hit["metadata"]["version"]
             doi = hit["doi"]
@@ -71,26 +78,37 @@ class Searcher():
             schema_version = keyword_data["schema-version"]
             container = keyword_data["container-type"]
             other_tags = ",".join(keyword_data["other"])
-            results_list.append(OrderedDict([
-                                ("ID", id),
-                                ("TITLE", title),
-                                ("DESCRIPTION", description),
-                                ("AUTHOR", author),
-                                ("VERSION", version),
-                                ("DOI", doi),
-                                ("SCHEMA VERSION", schema_version),
-                                ("CONTAINER", container),
-                                ("TAGS", other_tags)]))
+            result_dict = OrderedDict([("ID", id),
+                                      ("TITLE", title),
+                                      ("DESCRIPTION", description),
+                                      ("DOWNLOADS", downloads),
+                                      ("AUTHOR", author),
+                                      ("VERSION", version),
+                                      ("DOI", doi),
+                                      ("SCHEMA VERSION", schema_version),
+                                      ("CONTAINER", container),
+                                      ("TAGS", other_tags)])
+            if not self.no_trunc:
+                result_dict = self.truncate(result_dict, 40)
+            results_list.append(result_dict)
+        results_list = sorted(results_list, key=itemgetter('DOWNLOADS'),
+                              reverse=True)
         return results_list
 
     def parse_basic_info(self, hit):
-        max_descr_length = 50
         id = "zenodo." + str(hit["id"])
         title = hit["metadata"]["title"]
         description = hit["metadata"]["description"]
-        if len(description) > max_descr_length and not self.no_trunc:
-            description = description[:50] + "..."
-        return (id, title, description)
+        downloads = hit["stats"]["version_downloads"]
+        return (id, title, description, downloads)
+
+    # truncates every value of a dictionary whose length is
+    # greater than max_length
+    def truncate(self, d, max_length):
+        for k, v in list(d.items()):
+            if len(str(v)) > max_length:
+                d[k] = v[:max_length] + "..."
+        return d
 
     def print_zenodo_info(self, message, r):
         print("[ INFO ({1}) ] {0}".format(message, r.status_code))

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -10,7 +10,7 @@ from boutiques.publisher import ZenodoError
 
 class Searcher():
 
-    def __init__(self, query, verbose, sandbox, max_results, no_trunc=False):
+    def __init__(self, query, verbose, sandbox, max_results, no_trunc):
         if query is not None:
             self.query = query
         else:

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -7,16 +7,16 @@ import os
 class TestPull(TestCase):
 
     def test_pull(self):
-        bosh(["pull", "zenodo.1472823", "-y"])
+        bosh(["pull", "zenodo.1472823"])
         cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")
-        assert(os.path.exists(os.path.join(cache_dir, "example1_docker.json")))
+        assert(os.path.exists(os.path.join(cache_dir, "zenodo-1472823.json")))
 
     def test_pull_missing_prefix(self):
         with self.assertRaises(ZenodoError) as e:
-            bosh(["pull", "1472823", "-y"])
+            bosh(["pull", "1472823"])
         assert("Zenodo ID must be prefixed by 'zenodo'" in str(e.exception))
 
     def test_pull_not_found(self):
         with self.assertRaises(ZenodoError) as e:
-            bosh(["pull", "zenodo.99999", "-y"])
+            bosh(["pull", "zenodo.99999"])
         assert("Descriptor not found" in str(e.exception))

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -7,16 +7,16 @@ import os
 class TestPull(TestCase):
 
     def test_pull(self):
-        bosh(["pull", "zenodo.1472823"])
+        bosh(["pull", "zenodo.1472823", "-y"])
         cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")
         assert(os.path.exists(os.path.join(cache_dir, "example1_docker.json")))
 
     def test_pull_missing_prefix(self):
         with self.assertRaises(ZenodoError) as e:
-            bosh(["pull", "1472823"])
+            bosh(["pull", "1472823", "-y"])
         assert("Zenodo ID must be prefixed by 'zenodo'" in str(e.exception))
 
     def test_pull_not_found(self):
         with self.assertRaises(ZenodoError) as e:
-            bosh(["pull", "zenodo.99999"])
+            bosh(["pull", "zenodo.99999", "-y"])
         assert("Descriptor not found" in str(e.exception))

--- a/tools/python/boutiques/tests/test_search.py
+++ b/tools/python/boutiques/tests/test_search.py
@@ -7,7 +7,8 @@ class TestSearch(TestCase):
     def test_search_all(self):
         results = bosh(["search"])
         assert(len(results) > 0)
-        assert(list(results[0].keys()) == ["ID", "TITLE", "DESCRIPTION"])
+        assert(list(results[0].keys()) == ["ID", "TITLE", "DESCRIPTION",
+                                           "DOWNLOADS"])
 
     def test_search_query(self):
         results = bosh(["search", "ICA_AROMA"])
@@ -18,10 +19,37 @@ class TestSearch(TestCase):
         results = bosh(["search", "-v"])
         assert(len(results) > 0)
         assert(list(results[0].keys()) == ["ID", "TITLE", "DESCRIPTION",
-                                           "AUTHOR", "VERSION", "DOI",
-                                           "SCHEMA VERSION", "CONTAINER",
-                                           "TAGS"])
+                                           "DOWNLOADS", "AUTHOR", "VERSION",
+                                           "DOI", "SCHEMA VERSION",
+                                           "CONTAINER", "TAGS"])
 
     def test_search_specify_max_results(self):
         results = bosh(["search", "--sandbox", "-m", "20"])
         assert(len(results) == 20)
+
+    def test_search_sorts_by_num_downloads(self):
+        results = bosh(["search"])
+        downloads = []
+        for r in results:
+            downloads.append(r["DOWNLOADS"])
+        assert(all(downloads[i] >= downloads[i+1]
+               for i in range(len(downloads)-1)))
+
+    def test_search_truncates_long_text(self):
+        results = bosh(["search"])
+        for r in results:
+            for k, v in r.items():
+                assert(len(str(v)) <= 43)
+
+    def test_search_no_trunc(self):
+        results = bosh(["search", "--no-trunc"])
+        has_no_trunc = False
+        for r in results:
+            for k, v in r.items():
+                if len(str(v)) > 43:
+                    has_no_trunc = True
+                    break
+            else:
+                continue
+            break
+        assert(has_no_trunc)


### PR DESCRIPTION
1. Added "tests:y/n" keyword to Zenodo metadata on `bosh publish` (#328)
2. When doing a `bosh search`, any returned fields longer than 40 characters are truncated, unless the `--no-trunc` option is supplied (#356)
3. `bosh search` results are sorted in descending order by number of downloads (#360)
4. Puller checks if the cached file exists before pulling and returns it if it exists (#361)