### PR TITLE
added simulation flag to print out jsons, added bosh example

### DIFF
--- a/tools/python/boutiques/__init__.py
+++ b/tools/python/boutiques/__init__.py
@@ -17,5 +17,6 @@ __all__ = ['localExec',
            'bids',
            'publisher',
            'evaluate',
+           'example',
            'prettyprint',
            'bosh']

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -167,7 +167,7 @@ def execute(*params):
             executor.generateRandomParams(1)
 
         if results.json:
-            sout = [json.dumps(executor.in_dict, indent=4)]
+            sout = [json.dumps(executor.in_dict, indent=4, sort_keys=True)]
             print(sout[0])
         else:
             executor.printCmdLine()

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -518,7 +518,7 @@ def bosh(args=None):
             return bosh_return(out, out.exit_code,
                                hide=bool(out.container_location == 'hide'))
         elif func == "example":
-            out = execute('simulate', *params, '-j')
+            out = execute('simulate', '-j', *params)
             return bosh_return(out, out.exit_code,
                                hide=bool(out.container_location == 'hide'))
         elif func == "import":

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -167,14 +167,16 @@ def execute(*params):
             executor.generateRandomParams(1)
 
         if results.json:
-            print(json.dumps(executor.in_dict, indent=4))
+            sout = [json.dumps(executor.in_dict, indent=4)]
+            print(sout[0])
         else:
             executor.printCmdLine()
+            sout = executor.cmd_line
 
         # for consistency with execute
         # Adding hide to "container location" field since it's an invalid
-        # value, and we can parse that to hide the summary print
-        return ExecutorOutput(os.linesep.join(executor.cmd_line), "",
+        # value, can parse that to hide the summary print
+        return ExecutorOutput(os.linesep.join(sout), "",
                               0, "", [], [], "", "", "hide")
 
     if mode == "prepare":

--- a/tools/python/boutiques/tests/test_bosh.py
+++ b/tools/python/boutiques/tests/test_bosh.py
@@ -23,3 +23,4 @@ class TestBosh(TestCase):
         self.assertRaises(SystemExit, bosh, ["invocation", "--help"])
         self.assertRaises(SystemExit, bosh, ["evaluate", "--help"])
         self.assertRaises(SystemExit, bosh, ["create", "--help"])
+        self.assertRaises(SystemExit, bosh, ["example", "--help"])

--- a/tools/python/boutiques/tests/test_example1.py
+++ b/tools/python/boutiques/tests/test_example1.py
@@ -315,8 +315,7 @@ class TestExample1(TestCase):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
         ret = bosh.execute("simulate",
                            os.path.join(example1_dir,
-                                        "example1_docker.json"),
-                           "-r", "3")
+                                        "example1_docker.json"))
         print(ret)
         assert(ret.stdout != ""
                and ret.stderr == ""

--- a/tools/python/boutiques/tests/test_example2.py
+++ b/tools/python/boutiques/tests/test_example2.py
@@ -51,5 +51,4 @@ class TestExample2(TestCase):
         example2_dir = os.path.join(self.get_examples_dir(), "example2")
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(example2_dir,
-                                                   "example2.json"),
-                                      "-r", "3").exit_code)
+                                                   "example2.json")).exit_code)

--- a/tools/python/boutiques/tests/test_no_spaces.py
+++ b/tools/python/boutiques/tests/test_no_spaces.py
@@ -17,6 +17,5 @@ class TestNoSpaces(TestCase):
     def test_no_spaces(self):
         out = bosh.execute("simulate",
                            os.path.join(self.get_examples_dir(),
-                                        "no_spaces.json"),
-                           "-r")
+                                        "no_spaces.json"))
         assert(' ' not in out.stdout)

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -17,11 +17,13 @@ class TestSimulate(TestCase):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(example1_dir,
-                                          "example1_docker.json")).exit_code)
+                                                   "example1_docker.json"
+                                                   )).exit_code)
 
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(self.get_examples_dir(),
-                                          "good_nooutputs.json")).exit_code)
+                                                   "good_nooutputs.json"
+                                                   )).exit_code)
 
     def test_success_desc_as_json_obj(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
@@ -32,7 +34,8 @@ class TestSimulate(TestCase):
 
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(self.get_examples_dir(),
-                                          "good_nooutputs.json")).exit_code)
+                                                   "good_nooutputs.json"
+                                                   )).exit_code)
 
     def test_success_desc_from_zenodo(self):
         self.assertFalse(bosh.execute("simulate",
@@ -40,7 +43,8 @@ class TestSimulate(TestCase):
 
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(self.get_examples_dir(),
-                                          "good_nooutputs.json")).exit_code)
+                                                   "good_nooutputs.json"
+                                                   )).exit_code)
 
     def test_success_json(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -2,6 +2,7 @@
 
 import os
 from unittest import TestCase
+import json
 from boutiques import __file__ as bfile
 import boutiques as bosh
 
@@ -16,36 +17,39 @@ class TestSimulate(TestCase):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(example1_dir,
-                                                   "example1_docker.json"),
-                                      "-r", "1").exit_code)
+                                          "example1_docker.json")).exit_code)
 
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(self.get_examples_dir(),
-                                                   "good_nooutputs.json"),
-                                      "-r", "1").exit_code)
+                                          "good_nooutputs.json")).exit_code)
 
     def test_success_desc_as_json_obj(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
         desc_json = open(os.path.join(example1_dir,
                                       "example1_docker.json")).read()
         self.assertFalse(bosh.execute("simulate",
-                                      desc_json,
-                                      "-r", "1").exit_code)
+                                      desc_json).exit_code)
 
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(self.get_examples_dir(),
-                                                   "good_nooutputs.json"),
-                                      "-r", "1").exit_code)
+                                          "good_nooutputs.json")).exit_code)
 
     def test_success_desc_from_zenodo(self):
         self.assertFalse(bosh.execute("simulate",
-                                      "zenodo.1472823",
-                                      "-r", "1").exit_code)
+                                      "zenodo.1472823").exit_code)
 
         self.assertFalse(bosh.execute("simulate",
                                       os.path.join(self.get_examples_dir(),
-                                                   "good_nooutputs.json"),
-                                      "-r", "1").exit_code)
+                                          "good_nooutputs.json")).exit_code)
+
+    def test_success_json(self):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        desc_json = open(os.path.join(example1_dir,
+                                      "example1_docker.json")).read()
+        siminvo = bosh.execute("simulate", desc_json, "-j").stdout
+        assert(isinstance(json.loads(siminvo), dict))
+        siminvo = bosh.bosh(args=["example", desc_json]).stdout
+        assert(isinstance(json.loads(siminvo), dict))
 
     def test_failing_bad_descriptor_invo_combos(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
@@ -75,13 +79,12 @@ class TestSimulate(TestCase):
         self.assertRaises(SystemExit, bosh.execute, ["simulate",
                                                      os.path.join(
                                                        example1_dir,
-                                                       "example1_docker.json"),
-                                                     "-r", "-2"])
+                                                       "example1_docker.json")])
         self.assertRaises(SystemExit, bosh.execute, ["simulate",
                                                      os.path.join(
                                                        example1_dir,
                                                        "example1_docker.json"),
-                                                     "-r", "1", "-i",
+                                                     "-i",
                                                      os.path.join(
                                                        example1_dir,
                                                        "invocation.json")])


### PR DESCRIPTION
Added JSON printing in simulate, and a simplified wrapping for this:

```
$ # bosh example boutiques/schema/examples/example1/example1_docker.json
$ #   OR
$ bosh exec simulate boutiques/schema/examples/example1/example1_docker.json -j

{
    "str_input_list": [
        "str_str_input_list_NP",
        "str_str_input_list_Xy",
        "str_str_input_list_xW"
    ],
    "str_input": "str_str_input_YT",
    "list_int_input": [
        "-27",
        "8"
    ],
    "config_num": 4,
    "num_input": 0.9
}
```