### PR TITLE
Default values are always used when input values are not provided, fixed validation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ Simple! Just open your favourite terminal and type:
 
     $ pip install boutiques
 
-Alongside installing the Boutiques package, this will also ensure the dependencies are installed: `simplejson`, `jsonschema`,
-`requests`, and `pytest`. 
-
+Alongside installing the Boutiques package, this will also ensure the dependencies are installed: `simplejson`, `jsonschema`, 
+`requests`, `pytest`, `termcolor`, `pyyaml`, `tabulate` and `mock`. 
 
 ## Command-Line API
 
@@ -37,7 +36,7 @@ Perhaps someone has already described the tool you are looking for and
 you could reuse their work. For instance, if you are looking for a tool 
 from the FSL suite, try:
 
-$ bosh search fsl
+    $ bosh search fsl
 
 Search returns a list of identifiers for tools matching your query. You 
 can use these identifiers in any `bosh` command transparently. Even 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -16,7 +16,7 @@ from boutiques.localExec import ExecutorOutput
 from boutiques.localExec import ExecutorError
 from boutiques.exporter import ExportError
 from boutiques.importer import ImportError
-from boutiques.localExec import loadJson
+from boutiques.localExec import loadJson, addDefaultValues
 from boutiques.logger import raise_error
 from tabulate import tabulate
 
@@ -162,11 +162,6 @@ def execute(*params):
         if rand and inp:
             raise_error(SystemExit, "--random setting and --input value cannot "
                         "be used together.")
-        if inp and not os.path.isfile(inp):
-            raise_error(SystemExit, "Input file {} does not exist.".format(inp))
-        if inp and not inp.endswith(".json"):
-            raise_error(SystemExit, "Input file {} must end in 'json'.".
-                        format(inp))
         if not rand and not inp:
             raise_error(SystemExit, "The default mode requires an input (-i).")
 
@@ -346,6 +341,7 @@ def invocation(*params):
                 f.write(json.dumps(descriptor, indent=4, sort_keys=True))
     if result.invocation:
         from boutiques.invocationSchemaHandler import validateSchema
+        data = addDefaultValues(descriptor, data)
         validateSchema(invSchema, data)
 
 

--- a/tools/python/boutiques/invocationSchemaHandler.py
+++ b/tools/python/boutiques/invocationSchemaHandler.py
@@ -161,24 +161,23 @@ def generateInvocationSchema(toolDesc, oname=None, validateWrtMetaSchema=True):
 
 # Validate data with respect to the invocation schema
 def validateSchema(s, d=None, **kwargs):
-        # Check schema wrt meta-schema
+    # Check schema wrt meta-schema
+    try:
+        jsonschema.Draft4Validator.check_schema(s)
+    except jsonschema.SchemaError as se:
+        errExit("Invocation schema is invalid.\n" +
+                str(se.message), False)
+    # Check data instance against schema
+    if d:
         try:
-                jsonschema.Draft4Validator.check_schema(s)
-        except jsonschema.SchemaError as se:
-                errExit("Invocation schema is invalid.\n" +
-                        str(se.message), False)
-        # Check data instance against schema
-        if d:
-                try:
-                        jsonschema.validate(d, s)
-                except ValidationError as e:
-                        raise e
-                        raise_error(InvocationValidationError, e)
-                if kwargs.get("verbose"):
-                        print_info("Invocation Schema validation OK")
+            jsonschema.validate(d, s)
+        except ValidationError as e:
+            raise_error(InvocationValidationError, e)
+        if kwargs.get("verbose"):
+            print_info("Invocation Schema validation OK")
 
 
 # Script exit helper
 def errExit(msg, parser, err_code=1):
-        sys.stderr.write('Error: ' + msg + '\n')
-        sys.exit(err_code)
+    sys.stderr.write('Error: ' + msg + '\n')
+    sys.exit(err_code)

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -807,16 +807,7 @@ class LocalExecutor(object):
             del self.in_dict[r]
         # Add default values for required parameters,
         # if no value has been given
-        for input in [s for s in self.inputs
-                      if s.get("default-value") is not None
-                      and not s.get("optional")]:
-            if self.in_dict.get(input['id']) is None:
-                df = input.get("default-value")
-                if not input['type'] == 'Flag':
-                    self.in_dict[input['id']] = df
-                else:
-                    self.in_dict[input['id']] = str(df)
-        # Check results (as much as possible)
+        addDefaultValues(self.desc_dict, self.in_dict)
         try:
             pass  # self._validateDict()
         except Exception:  # Avoid catching BaseExceptions like SystemExit
@@ -1177,3 +1168,18 @@ def loadJson(userInput, verbose=False):
         return json.loads(userInput)
     except ValueError:
         raise_error(ExecutorError, e)
+
+
+# Adds default values to input dictionary
+# for parameters whose values were not given
+def addDefaultValues(desc_dict, in_dict):
+    inputs = desc_dict['inputs']
+    for input in [s for s in inputs
+                  if s.get("default-value") is not None]:
+        if in_dict.get(input['id']) is None:
+            df = input.get("default-value")
+            if not input['type'] == 'Flag':
+                in_dict[input['id']] = df
+            else:
+                in_dict[input['id']] = str(df)
+    return in_dict

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -808,6 +808,7 @@ class LocalExecutor(object):
         # Add default values for required parameters,
         # if no value has been given
         addDefaultValues(self.desc_dict, self.in_dict)
+        # Check results (as much as possible)
         try:
             pass  # self._validateDict()
         except Exception:  # Avoid catching BaseExceptions like SystemExit

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1175,12 +1175,12 @@ def loadJson(userInput, verbose=False):
 # for parameters whose values were not given
 def addDefaultValues(desc_dict, in_dict):
     inputs = desc_dict['inputs']
-    for input in [s for s in inputs
-                  if s.get("default-value") is not None]:
-        if in_dict.get(input['id']) is None:
-            df = input.get("default-value")
-            if not input['type'] == 'Flag':
-                in_dict[input['id']] = df
+    for in_param in [s for s in inputs
+                     if s.get("default-value") is not None]:
+        if in_dict.get(in_param['id']) is None:
+            df = in_param.get("default-value")
+            if not in_param['type'] == 'Flag':
+                in_dict[in_param['id']] = df
             else:
-                in_dict[input['id']] = str(df)
+                in_dict[in_param['id']] = str(df)
     return in_dict

--- a/tools/python/boutiques/schema/examples/example1/example1_docker.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker.json
@@ -38,7 +38,7 @@
     "inputs": [
         {
             "command-line-flag": "-i",
-            "default-value": "aStringValue",
+            "default-value": ["aStringValue"],
             "description": "Describe the use and meaning of the parameter",
             "id": "str_input_list",
             "list": true,

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_exported.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_exported.json
@@ -11,7 +11,9 @@
     "name": "Example Boutiques Tool",
     "parameters": [
         {
-            "defaultValue": "aStringValue",
+            "defaultValue": [
+                "aStringValue"
+            ],
             "description": "Describe the use and meaning of the parameter",
             "id": "str_input_list",
             "isOptional": false,

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_exported_doi.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_exported_doi.json
@@ -11,13 +11,24 @@
     "name": "Example Boutiques Tool",
     "parameters": [
         {
+            "defaultValue": [
+                "aStringValue"
+            ],
+            "description": "Describe the use and meaning of the parameter",
+            "id": "str_input_list",
+            "isOptional": false,
+            "isReturnedValue": false,
+            "name": "A list of string inputs",
+            "type": "List"
+        },
+        {
             "defaultValue": "aStringValue",
             "description": "Describe the use and meaning of the parameter",
             "id": "str_input",
             "isOptional": false,
             "isReturnedValue": false,
             "name": "A string input",
-            "type": "List"
+            "type": "String"
         },
         {
             "description": "Describe the use and meaning of the parameter",

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_exported_doi_python2.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_exported_doi_python2.json
@@ -11,13 +11,24 @@
     "name": "Example Boutiques Tool", 
     "parameters": [
         {
+            "defaultValue": [
+                "aStringValue"
+            ], 
+            "description": "Describe the use and meaning of the parameter", 
+            "id": "str_input_list", 
+            "isOptional": false, 
+            "isReturnedValue": false, 
+            "name": "A list of string inputs", 
+            "type": "List"
+        }, 
+        {
             "defaultValue": "aStringValue", 
             "description": "Describe the use and meaning of the parameter", 
             "id": "str_input", 
             "isOptional": false, 
             "isReturnedValue": false, 
             "name": "A string input", 
-            "type": "List"
+            "type": "String"
         }, 
         {
             "description": "Describe the use and meaning of the parameter", 

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_exported_python2.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_exported_python2.json
@@ -11,7 +11,9 @@
     "name": "Example Boutiques Tool", 
     "parameters": [
         {
-            "defaultValue": "aStringValue", 
+            "defaultValue": [
+                "aStringValue"
+            ], 
             "description": "Describe the use and meaning of the parameter", 
             "id": "str_input_list", 
             "isOptional": false, 

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_updated.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_updated.json
@@ -38,7 +38,7 @@
     "inputs": [
         {
             "command-line-flag": "-i",
-            "default-value": "aStringValue",
+            "default-value": ["aStringValue"],
             "description": "Describe the use and meaning of the parameter",
             "id": "str_input_list",
             "list": true,

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_with_doi.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_with_doi.json
@@ -1,5 +1,5 @@
 {
-    "command-line": "exampleTool1.py [CONFIG_FILE] [STRING_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [INT_LIST_INPUT] &> [LOG]", 
+    "command-line": "exampleTool1.py [CONFIG_FILE] [STRING_INPUT_LIST] [STRING_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [INT_LIST_INPUT] &> [LOG]", 
     "container-image": {
         "image": "boutiques/example1:test", 
         "type": "docker"
@@ -27,18 +27,27 @@
     ], 
     "inputs": [
         {
-            "command-line-flag": "-i", 
-            "default-value": "aStringValue", 
-            "description": "Describe the use and meaning of the parameter", 
-            "id": "str_input", 
-            "list": true, 
-            "max-list-entries": 3, 
-            "min-list-entries": 1, 
-            "name": "A string input", 
-            "type": "String", 
+            "command-line-flag": "-i",
+            "default-value": ["aStringValue"],
+            "description": "Describe the use and meaning of the parameter",
+            "id": "str_input_list",
+            "list": true,
+            "max-list-entries": 3,
+            "min-list-entries": 1,
+            "name": "A list of string inputs",
+            "type": "String",
+            "value-key": "[STRING_INPUT_LIST]"
+        },
+        {
+            "command-line-flag": "-s",
+            "default-value": "aStringValue",
+            "description": "Describe the use and meaning of the parameter",
+            "id": "str_input",
+            "name": "A string input",
+            "type": "String",
             "value-key": "[STRING_INPUT]"
         },
-	{
+	    {
             "command-line-flag": "-l", 
             "description": "Describe the use and meaning of the parameter", 
             "id": "list_int_input", 

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_with_doi.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_with_doi.json
@@ -47,7 +47,7 @@
             "type": "String",
             "value-key": "[STRING_INPUT]"
         },
-	    {
+        {
             "command-line-flag": "-l", 
             "description": "Describe the use and meaning of the parameter", 
             "id": "list_int_input", 

--- a/tools/python/boutiques/schema/examples/example1/inv_no_defaults.json
+++ b/tools/python/boutiques/schema/examples/example1/inv_no_defaults.json
@@ -1,0 +1,6 @@
+{
+    "file_input" : "./setup.py",
+    "list_int_input": [1, 2, 3],
+    "config_num" : 4,
+    "enum_input" : "val1"
+}

--- a/tools/python/boutiques/schema/examples/good.json
+++ b/tools/python/boutiques/schema/examples/good.json
@@ -1,222 +1,222 @@
 {
-    "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN] [EXTRA1] [EXTRA2] [EXTRA3]",
+    "command-line": "ndmg_pipeline [DTI] [BVAL] [BVEC] [MPRAGE] [ATLAS] [MASK] [OUTDIR] [DESIKAN] [JHU] [TALAIRACH] [AAL] [HARVARDOXFORD] [CPAC200] [CLEAN] [EXTRA1] [EXTRA2] [EXTRA3]", 
     "container-image": {
-        "entrypoint": false,
-        "image": "neurodata/ndmg:v0.0.41-1",
-        "index": "index.docker.io",
+        "entrypoint": false, 
+        "image": "neurodata/ndmg:v0.0.41-1", 
+        "index": "index.docker.io", 
         "type": "docker"
-    },
-    "description": "dwi connectome estimation pipeline",
+    }, 
+    "description": "dwi connectome estimation pipeline", 
     "error-codes": [
         {
-            "code": 1,
+            "code": 1, 
             "description": "crashed"
-        },
+        }, 
         {
-            "code": 12,
+            "code": 12, 
             "description": "crashed badly"
         }
-    ],
+    ], 
     "groups": [
         {
-            "all-or-none": true,
-            "id": "together_group",
+            "all-or-none": true, 
+            "id": "together_group", 
             "members": [
-                "extra1",
+                "extra1", 
                 "extra2"
-            ],
+            ], 
             "name": "these guys have to be toggled together"
-        },
+        }, 
         {
-            "id": "mutex_group",
+            "id": "mutex_group", 
             "members": [
-                "extra2",
+                "extra2", 
                 "extra3"
-            ],
-            "mutually-exclusive": true,
+            ], 
+            "mutually-exclusive": true, 
             "name": "group of mutually-exclusive inputs"
-        },
+        }, 
         {
-            "id": "dti_group",
+            "id": "dti_group", 
             "members": [
-                "dti_file",
+                "dti_file", 
                 "dti_file_minc"
-            ],
-            "mutually-exclusive": true,
-            "name": "Group of two possible dti input files",
+            ], 
+            "mutually-exclusive": true, 
+            "name": "Group of two possible dti input files", 
             "one-is-required": true
-        },
+        }, 
         {
-            "id": "parcellation_group",
+            "id": "parcellation_group", 
             "members": [
-                "desikan",
-                "jhu",
-                "talairach",
-                "aal",
-                "harvardoxford",
+                "desikan", 
+                "jhu", 
+                "talairach", 
+                "aal", 
+                "harvardoxford", 
                 "cpac200"
-            ],
-            "name": "Group of all used parcellations",
+            ], 
+            "name": "Group of all used parcellations", 
             "one-is-required": true
         }
-    ],
+    ], 
     "inputs": [
         {
-            "id": "dti_file",
-            "name": "Diffusion Tensor Image",
-            "optional": true,
-            "type": "File",
+            "id": "dti_file", 
+            "name": "Diffusion Tensor Image", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[DTI]"
-        },
+        }, 
         {
-            "id": "extra1",
-            "name": "optional thing at the end",
-            "optional": true,
-            "type": "File",
+            "id": "extra1", 
+            "name": "optional thing at the end", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[EXTRA1]"
-        },
+        }, 
         {
-            "id": "extra2",
-            "name": "optional thing at the end",
-            "optional": true,
-            "type": "File",
+            "id": "extra2", 
+            "name": "optional thing at the end", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[EXTRA2]"
-        },
+        }, 
         {
-            "id": "extra3",
-            "name": "optional thing at the end",
-            "optional": true,
-            "type": "File",
+            "id": "extra3", 
+            "name": "optional thing at the end", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[EXTRA3]"
-        },
+        }, 
         {
-            "id": "dti_file_minc",
-            "name": "Diffusion Tensor Image",
-            "optional": true,
-            "type": "File",
+            "id": "dti_file_minc", 
+            "name": "Diffusion Tensor Image", 
+            "optional": true, 
+            "type": "File", 
             "value-key": "[DTI]"
-        },
+        }, 
         {
-            "id": "bval_file",
-            "name": "B-values file",
-            "optional": false,
-            "type": "File",
+            "id": "bval_file", 
+            "name": "B-values file", 
+            "optional": false, 
+            "type": "File", 
             "value-key": "[BVAL]"
-        },
+        }, 
         {
-            "id": "bvec_file",
-            "name": "Gradient vectors file",
-            "optional": false,
-            "type": "File",
+            "id": "bvec_file", 
+            "name": "Gradient vectors file", 
+            "optional": false, 
+            "type": "File", 
             "value-key": "[BVEC]"
-        },
+        }, 
         {
-            "id": "mprage_file",
-            "name": "Structural scan file",
-            "optional": false,
-            "type": "File",
+            "id": "mprage_file", 
+            "name": "Structural scan file", 
+            "optional": false, 
+            "type": "File", 
             "value-key": "[MPRAGE]"
-        },
+        }, 
         {
-            "id": "atlas",
-            "name": "Atlas image (MNI152)",
-            "optional": false,
-            "type": "String",
+            "id": "atlas", 
+            "name": "Atlas image (MNI152)", 
+            "optional": false, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
-            ],
+            ], 
             "value-key": "[ATLAS]"
-        },
+        }, 
         {
-            "id": "mask",
-            "name": "Atlas brain mask",
-            "optional": false,
-            "type": "String",
+            "id": "mask", 
+            "name": "Atlas brain mask", 
+            "optional": false, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
-            ],
+            ], 
             "value-key": "[MASK]"
-        },
+        }, 
         {
-            "id": "outdir",
-            "name": "Output directory",
-            "optional": false,
-            "type": "String",
+            "id": "outdir", 
+            "name": "Output directory", 
+            "optional": false, 
+            "type": "String", 
             "value-key": "[OUTDIR]"
-        },
+        }, 
         {
-            "id": "desikan",
-            "name": "Desikan parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "desikan", 
+            "name": "Desikan parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/desikan.nii.gz"
-            ],
+            ], 
             "value-key": "[DESIKAN]"
-        },
+        }, 
         {
-            "id": "jhu",
-            "name": "JHU parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "jhu", 
+            "name": "JHU parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/JHU.nii.gz"
-            ],
+            ], 
             "value-key": "[JHU]"
-        },
+        }, 
         {
-            "id": "talairach",
-            "name": "Talairach parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "talairach", 
+            "name": "Talairach parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/Talairach.nii.gz"
-            ],
+            ], 
             "value-key": "[TALAIRACH]"
-        },
+        }, 
         {
-            "id": "aal",
-            "name": "AAL parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "aal", 
+            "name": "AAL parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/AAL.nii.gz"
-            ],
+            ], 
             "value-key": "[AAL]"
-        },
+        }, 
         {
-            "id": "harvardoxford",
-            "name": "Harvard-Oxford parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "harvardoxford", 
+            "name": "Harvard-Oxford parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/HarvardOxford.nii.gz"
-            ],
+            ], 
             "value-key": "[HARVARDOXFORD]"
-        },
+        }, 
         {
-            "id": "cpac200",
-            "name": "CPAC200 parcellation",
-            "optional": true,
-            "type": "String",
+            "id": "cpac200", 
+            "name": "CPAC200 parcellation", 
+            "optional": true, 
+            "type": "String", 
             "value-choices": [
                 "/ndmg_atlases/labels/CPAC200.nii.gz"
-            ],
+            ], 
             "value-key": "[CPAC200]"
-        },
+        }, 
         {
-            "command-line-flag": "-c",
+            "command-line-flag": "-c", 
             "description": "flag which toggles the removal of intermediate outputs",
-            "id": "clean",
-            "name": "Clean-up flag",
-            "optional": true,
-            "type": "Flag",
+            "id": "clean", 
+            "name": "Clean-up flag", 
+            "optional": true, 
+            "type": "Flag", 
             "value-key": "[CLEAN]"
         }
-    ],
+    ], 
     "invocation-schema": {
-        "$schema": "http://json-schema.org/draft-04/schema#",
-        "additionalProperties": false,
+        "$schema": "http://json-schema.org/draft-04/schema#", 
+        "additionalProperties": false, 
         "allOf": [
             {
                 "anyOf": [
@@ -224,41 +224,41 @@
                         "required": [
                             "dti_file"
                         ]
-                    },
+                    }, 
                     {
                         "required": [
                             "dti_file_minc"
                         ]
                     }
                 ]
-            },
+            }, 
             {
                 "anyOf": [
                     {
                         "required": [
                             "desikan"
                         ]
-                    },
+                    }, 
                     {
                         "required": [
                             "jhu"
                         ]
-                    },
+                    }, 
                     {
                         "required": [
                             "talairach"
                         ]
-                    },
+                    }, 
                     {
                         "required": [
                             "aal"
                         ]
-                    },
+                    }, 
                     {
                         "required": [
                             "harvardoxford"
                         ]
-                    },
+                    }, 
                     {
                         "required": [
                             "cpac200"
@@ -266,7 +266,7 @@
                     }
                 ]
             }
-        ],
+        ], 
         "dependencies": {
             "dti_file": {
                 "properties": {
@@ -274,7 +274,7 @@
                         "not": {}
                     }
                 }
-            },
+            }, 
             "dti_file_minc": {
                 "properties": {
                     "dti_file": {
@@ -282,194 +282,194 @@
                     }
                 }
             }
-        },
-        "description": "Invocation schema for ndmg.",
+        }, 
+        "description": "Invocation schema for ndmg.", 
         "properties": {
             "aal": {
                 "enum": [
                     "/ndmg_atlases/labels/AAL.nii.gz"
                 ]
-            },
+            }, 
             "atlas": {
                 "enum": [
                     "/ndmg_atlases/atlas/MNI152_T1_1mm.nii.gz"
                 ]
-            },
+            }, 
             "bval_file": {
                 "type": "string"
-            },
+            }, 
             "bvec_file": {
                 "type": "string"
-            },
+            }, 
             "clean": {
                 "type": "boolean"
-            },
+            }, 
             "cpac200": {
                 "enum": [
                     "/ndmg_atlases/labels/CPAC200.nii.gz"
                 ]
-            },
+            }, 
             "desikan": {
                 "enum": [
                     "/ndmg_atlases/labels/desikan.nii.gz"
                 ]
-            },
+            }, 
             "dti_file": {
                 "type": "string"
-            },
+            }, 
             "dti_file_minc": {
                 "type": "string"
-            },
+            }, 
             "extra1": {
                 "type": "string"
-            },
+            }, 
             "extra2": {
                 "type": "string"
-            },
+            }, 
             "extra3": {
                 "type": "string"
-            },
+            }, 
             "harvardoxford": {
                 "enum": [
                     "/ndmg_atlases/labels/HarvardOxford.nii.gz"
                 ]
-            },
+            }, 
             "jhu": {
                 "enum": [
                     "/ndmg_atlases/labels/JHU.nii.gz"
                 ]
-            },
+            }, 
             "mask": {
                 "enum": [
                     "/ndmg_atlases/atlas/MNI152_T1_1mm_brain_mask.nii.gz"
                 ]
-            },
+            }, 
             "mprage_file": {
                 "type": "string"
-            },
+            }, 
             "outdir": {
                 "type": "string"
-            },
+            }, 
             "talairach": {
                 "enum": [
                     "/ndmg_atlases/labels/Talairach.nii.gz"
                 ]
             }
-        },
+        }, 
         "required": [
-            "bval_file",
-            "bvec_file",
-            "mprage_file",
-            "atlas",
-            "mask",
+            "bval_file", 
+            "bvec_file", 
+            "mprage_file", 
+            "atlas", 
+            "mask", 
             "outdir"
-        ],
-        "title": "ndmg.invocationSchema",
+        ], 
+        "title": "ndmg.invocationSchema", 
         "type": "object"
-    },
-    "name": "ndmg",
+    }, 
+    "name": "ndmg", 
     "output-files": [
         {
-            "id": "aligned_dti",
-            "name": "Aligned DTI volume",
-            "optional": true,
-            "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz",
+            "id": "aligned_dti", 
+            "name": "Aligned DTI volume", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/reg_dti/[DTI]_aligned.nii.gz", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "tensors",
-            "name": "Tensor maps",
-            "optional": true,
-            "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz",
+            "id": "tensors", 
+            "name": "Tensor maps", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/tensors/[DTI]_tensors.npz", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "fibers",
-            "name": "Fiber streamlines",
-            "optional": true,
-            "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz",
+            "id": "fibers", 
+            "name": "Fiber streamlines", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/fibers/[DTI]_fibers.npz", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "desikan_graph",
-            "name": "Desikan graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle",
+            "id": "desikan_graph", 
+            "name": "Desikan graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/desikan/[DTI]_desikan.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "jhu_graph",
-            "name": "JHU graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle",
+            "id": "jhu_graph", 
+            "name": "JHU graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/JHU/[DTI]_JHU.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "talairach_graph",
-            "name": "Talairach graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle",
+            "id": "talairach_graph", 
+            "name": "Talairach graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/Talairach/[DTI]_Talairach.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "aal_graph",
-            "name": "AAL graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle",
+            "id": "aal_graph", 
+            "name": "AAL graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/AAL/[DTI]_AAL.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "harvardoxford_graph",
-            "name": "Harvard-Oxford graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle",
+            "id": "harvardoxford_graph", 
+            "name": "Harvard-Oxford graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/HarvardOxford/[DTI]_HarvardOxford.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
-        },
+        }, 
         {
-            "id": "cpac200_graph",
-            "name": "CPAC200 graph",
-            "optional": true,
-            "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle",
+            "id": "cpac200_graph", 
+            "name": "CPAC200 graph", 
+            "optional": true, 
+            "path-template": "[OUTDIR]/graphs/CPAC200/[DTI]_CPAC200.gpickle", 
             "path-template-stripped-extensions": [
-                ".nii",
+                ".nii", 
                 ".nii.gz"
             ]
         }
-    ],
-    "schema-version": "0.5",
+    ], 
+    "schema-version": "0.5", 
     "suggested-resources": {
-        "cpu-cores": 1,
-        "ram": 12,
+        "cpu-cores": 1, 
+        "ram": 12, 
         "walltime-estimate": 3600
-    },
+    }, 
     "tags": {
-        "domain": "testing",
-        "foo": "bar",
+        "domain": "testing", 
+        "foo": "bar", 
         "status": "experimental"
-    },
+    }, 
     "tool-version": "v0.0.41-1"
 }

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -42,21 +42,21 @@ class TestSimulate(TestCase):
                                       desc_json,
                                       "-r", "1").exit_code)
 
-        self.assertFalse(bosh.execute("simulate",
-                                      os.path.join(self.get_examples_dir(),
-                                                   "good_nooutputs.json"),
-                                      "-r", "1").exit_code)
-
     @mock.patch('requests.get', return_value=mock_get())
     def test_success_desc_from_zenodo(self, mock_get):
         self.assertFalse(bosh.execute("simulate",
                                       "zenodo.1472823",
                                       "-r", "1").exit_code)
 
+    def test_success_default_values(self):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
         self.assertFalse(bosh.execute("simulate",
-                                      os.path.join(self.get_examples_dir(),
-                                                   "good_nooutputs.json"),
-                                      "-r", "1").exit_code)
+                                      os.path.join(example1_dir,
+                                                   "example1_docker.json"),
+                                      "-i",
+                                      os.path.join(example1_dir,
+                                                   "inv_no_defaults.json"))
+                             .exit_code)
 
     def test_failing_bad_descriptor_invo_combos(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")


### PR DESCRIPTION
* (#362) Fixed bug where not providing a value for a mandatory input with a default value threw a schema validation error. The default values are temporarily added to the input dictionary right before the invocation is validated to prevent the error. 
* (#338) Default value is always used when a value is not provided, even when the input is optional.
* Minor fixes, including fixing indentation in `invocationSchemaHandler` and fixing the `example1` descriptors to have the proper default value for the `str_input_list` input.