### PR TITLE
Removed some redundant/ambigious code. Function is the same, but there is less code and intent is clearer

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -390,7 +390,6 @@ def test(*params):
         return 0
 
     for test in descriptor["tests"]:
-        # Create temporary file for the invocation() function.
         invocation_JSON = test["invocation"]
 
         # Check if the invocation is valid.

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -393,7 +393,7 @@ def test(*params):
 
         # Check if the invocation is valid.
         invocation(result.descriptor, "--invocation",
-                   json.dumps(invocation_JSON).encode())
+                   json.dumps(invocation_JSON))
 
     # Invocations have been properly validated. We can launch the actual tests.
     test_path = op.join(op.dirname(op.realpath(__file__)), "test.py")

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -334,7 +334,7 @@ def invocation(*params):
                 f.write(json.dumps(descriptor, indent=4, sort_keys=True))
     if result.invocation:
         from boutiques.invocationSchemaHandler import validateSchema
-        validateSchema(invSchema, loadJson(result.invocation))
+        validateSchema(invSchema, loadJson(result.invocation)))
 
 
 def evaluate(*params):
@@ -393,10 +393,10 @@ def test(*params):
         invocation_JSON = test["invocation"]
 
         # Check if the invocation is valid.
-        invocation(result.descriptor, "--invocation",
-                   json.dumps(invocation_JSON))
+        invocation(result.descriptor, "--invocation", json.dumps(invocation_JSON).encode())
 
     # Invocations have been properly validated. We can launch the actual tests.
+
     test_path = op.join(op.dirname(op.realpath(__file__)), "test.py")
     return pytest.main([test_path, "--descriptor", result.descriptor])
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -336,6 +336,7 @@ def invocation(*params):
         from boutiques.invocationSchemaHandler import validateSchema
         validateSchema(invSchema, loadJson(result.invocation))
 
+
 def evaluate(*params):
     parser = ArgumentParser("Evaluates parameter values for a descriptor"
                             " and invocation")
@@ -366,6 +367,7 @@ def evaluate(*params):
     for query in result.query:
         query_results += [evaluateEngine(executor, query)]
     return query_results[0] if len(query_results) == 1 else query_results
+
 
 def test(*params):
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -368,6 +368,7 @@ def evaluate(*params):
         query_results += [evaluateEngine(executor, query)]
     return query_results[0] if len(query_results) == 1 else query_results
 
+
 def test(*params):
 
     parser = ArgumentParser("Perform all the tests defined within the"

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -368,7 +368,6 @@ def evaluate(*params):
         query_results += [evaluateEngine(executor, query)]
     return query_results[0] if len(query_results) == 1 else query_results
 
-
 def test(*params):
 
     parser = ArgumentParser("Perform all the tests defined within the"

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -367,7 +367,6 @@ def evaluate(*params):
         query_results += [evaluateEngine(executor, query)]
     return query_results[0] if len(query_results) == 1 else query_results
 
-
 def test(*params):
 
     parser = ArgumentParser("Perform all the tests defined within the"

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -392,7 +392,8 @@ def test(*params):
         invocation_JSON = test["invocation"]
 
         # Check if the invocation is valid.
-        invocation(result.descriptor, "--invocation", json.dumps(invocation_JSON).encode())
+        invocation(result.descriptor, "--invocation",
+                   json.dumps(invocation_JSON).encode())
 
     # Invocations have been properly validated. We can launch the actual tests.
     test_path = op.join(op.dirname(op.realpath(__file__)), "test.py")

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -334,8 +334,7 @@ def invocation(*params):
                 f.write(json.dumps(descriptor, indent=4, sort_keys=True))
     if result.invocation:
         from boutiques.invocationSchemaHandler import validateSchema
-        validateSchema(invSchema, loadJson(result.invocation)))
-
+        validateSchema(invSchema, loadJson(result.invocation))
 
 def evaluate(*params):
     parser = ArgumentParser("Evaluates parameter values for a descriptor"
@@ -396,7 +395,6 @@ def test(*params):
         invocation(result.descriptor, "--invocation", json.dumps(invocation_JSON).encode())
 
     # Invocations have been properly validated. We can launch the actual tests.
-
     test_path = op.join(op.dirname(op.realpath(__file__)), "test.py")
     return pytest.main([test_path, "--descriptor", result.descriptor])
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -392,7 +392,7 @@ def test(*params):
         invocation_JSON = test["invocation"]
         # Check if the invocation is valid.
         invocation(result.descriptor, "--invocation",
-                   json.dumps(invocation_JSON).encode())
+                   json.dumps(invocation_JSON))
 
     # Invocations have been properly validated. We can launch the actual tests.
     test_path = op.join(op.dirname(op.realpath(__file__)), "test.py")

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -89,7 +89,7 @@ class Searcher():
                                       ("CONTAINER", container),
                                       ("TAGS", other_tags)])
             for k, v in list(result_dict.items()):
-                if isinstance(v, unicode):
+                if isinstance(v, str) or isinstance(v, unicode):
                     result_dict[k] = v.encode('ascii', 'xmlcharrefreplace')
             if not self.no_trunc:
                 result_dict = self.truncate(result_dict, 40)

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -94,7 +94,8 @@ class Searcher():
                     if isinstance(v, unicode):
                         result_dict[k] = v.encode('ascii', 'xmlcharrefreplace')
                 elif isinstance(v, str):
-                    result_dict[k] = v.encode('ascii', 'xmlcharrefreplace')
+                    result_dict[k] = \
+                        v.encode('ascii', 'xmlcharrefreplace').decode()
             if not self.no_trunc:
                 result_dict = self.truncate(result_dict, 40)
             results_list.append(result_dict)

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import requests
-import sys
 from collections import OrderedDict
 import json
 from operator import itemgetter
@@ -92,13 +91,6 @@ class Searcher():
                                       ("SCHEMA VERSION", schema_version),
                                       ("CONTAINER", container),
                                       ("TAGS", other_tags)])
-            for k, v in list(result_dict.items()):
-                if sys.version_info[0] < 3:
-                    if isinstance(v, unicode):
-                        result_dict[k] = v.encode('ascii', 'xmlcharrefreplace')
-                elif isinstance(v, str):
-                    result_dict[k] = \
-                        v.encode('ascii', 'xmlcharrefreplace').decode()
             if not self.no_trunc:
                 result_dict = self.truncate(result_dict, 40)
             results_list.append(result_dict)

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import requests
+import sys
 from collections import OrderedDict
 import json
 from operator import itemgetter
@@ -89,7 +90,10 @@ class Searcher():
                                       ("CONTAINER", container),
                                       ("TAGS", other_tags)])
             for k, v in list(result_dict.items()):
-                if isinstance(v, str) or isinstance(v, unicode):
+                if sys.version_info[0] < 3:
+                    if isinstance(v, unicode):
+                        result_dict[k] = v.encode('ascii', 'xmlcharrefreplace')
+                elif isinstance(v, str):
                     result_dict[k] = v.encode('ascii', 'xmlcharrefreplace')
             if not self.no_trunc:
                 result_dict = self.truncate(result_dict, 40)

--- a/tools/python/requirements.txt
+++ b/tools/python/requirements.txt
@@ -1,16 +1,4 @@
-attrs==17.4.0
-boutiques==0.5.8
-certifi==2018.4.16
-chardet==3.0.4
-funcsigs==1.0.2
-functools32==3.2.3.post2
-idna==2.6
 jsonschema==2.6.0
-more-itertools==4.1.0
-pluggy==0.6.0
-py==1.5.3
 pytest==3.5.0
 requests==2.18.4
 simplejson==3.13.2
-six==1.11.0
-urllib3==1.22


### PR DESCRIPTION
 - I've in-lined the json String in test's call of bosh.py's invocation instead of exporting a temporary json file and passing that. Function is the same, but there is less code and intent is clearer. https://github.com/boutiques/boutiques/blob/97fe5b0e5824812202f7207e62b02af5c1e24216/tools/python/boutiques/bosh.py#L395-L404
 - I've localised the loadJson call on result.invocation in invocation() to simplify the code as it is only used after the latter if statement and so you do not need the former. Function is the same, just cleaner. https://github.com/boutiques/boutiques/blob/97fe5b0e5824812202f7207e62b02af5c1e24216/tools/python/boutiques/bosh.py#L325-L340
 - I have changed the read mode to "universal newline mode" as this was not the default in older python. These changes were only needed in [test_import](https://github.com/boutiques/boutiques/blob/develop/tools/python/boutiques/tests/test_import.py) and [test_export](https://github.com/boutiques/boutiques/blob/develop/tools/python/boutiques/tests/test_export.py). Explicit "universal newline mode" is deprecated in modern python as this is the default behaviour for reading text files, but this supports backwards compatibility if windows/mac work with the test json. Without this change, tests would fail on python 2.7 (at least) when comparing the contents of files read in that had non-unix linebreaks.
 - I have stripped down the tools/versions listed in [requirements.txt](https://github.com/boutiques/boutiques/blob/develop/tools/python/requirements.txt) to only those packages that are listed in setup.py. There is no functional change here.
   - This should fix https://github.com/boutiques/boutiques/issues/372 (I cannot confirm)
   - A follow-up might be what we've identified in https://github.com/boutiques/boutiques/issues/383. 