### PR TITLE
Bosh search appends wildcards to the beginning and end of queries

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -424,12 +424,14 @@ def search(*params):
                         "to be returned. Default is 10.")
     parser.add_argument("-nt", "--no-trunc", action="store_true",
                         help="Do not truncate long tool descriptions.")
+    parser.add_argument("-e", "--exact", action="store_true",
+                        help="Only return results containing the exact query.")
 
     result = parser.parse_args(params)
 
     from boutiques.searcher import Searcher
     searcher = Searcher(result.query, result.verbose, result.sandbox,
-                        result.max, result.no_trunc)
+                        result.max, result.no_trunc, result.exact)
 
     return searcher.search()
 

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -214,7 +214,7 @@ class Publisher():
         # of an existing one
         from boutiques.searcher import Searcher
         searcher = Searcher(self.descriptor.get("name"), self.verbose,
-                            self.sandbox, None, True)
+                            self.sandbox, exact_match=True)
         r = searcher.zenodo_search()
 
         id_to_update = 0

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -38,7 +38,8 @@ class Puller():
             return self.cached_fname
 
         from boutiques.searcher import Searcher
-        searcher = Searcher(self.zid, self.verbose, self.sandbox, None, True)
+        searcher = Searcher(self.zid, self.verbose, self.sandbox,
+                            exact_match=True)
         r = searcher.zenodo_search()
 
         for hit in r.json()["hits"]["hits"]:

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -10,11 +10,15 @@ from boutiques.publisher import ZenodoError
 
 class Searcher():
 
-    def __init__(self, query, verbose, sandbox, max_results, no_trunc):
+    def __init__(self, query, verbose, sandbox, max_results, no_trunc,
+                 exact_match):
         if query is not None:
             self.query = query
         else:
             self.query = 'boutiques'
+
+        if not exact_match:
+            self.query = '*' + self.query + '*'
 
         self.verbose = verbose
         self.sandbox = sandbox

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -10,8 +10,8 @@ from boutiques.publisher import ZenodoError
 
 class Searcher():
 
-    def __init__(self, query, verbose, sandbox, max_results, no_trunc,
-                 exact_match):
+    def __init__(self, query, verbose, sandbox, max_results=None,
+                 no_trunc=False, exact_match=False):
         if query is not None:
             self.query = query
         else:
@@ -23,11 +23,10 @@ class Searcher():
         self.verbose = verbose
         self.sandbox = sandbox
         self.no_trunc = no_trunc
+        self.max_results = max_results
 
         # Return max 10 results by default
-        if max_results is not None:
-            self.max_results = max_results
-        else:
+        if max_results is None:
             self.max_results = 10
 
         # Set Zenodo endpoint

--- a/tools/python/boutiques/tests/boutiques_mocks.py
+++ b/tools/python/boutiques/tests/boutiques_mocks.py
@@ -80,7 +80,7 @@ def mock_zenodo_search(mock_records):
                               "name": "Test author"
                             }
                           ],
-                          "description": "Test description",
+                          "description": record.description,
                           "doi": "10.5281/zenodo.%s" % record.id,
                           "keywords": [
                             "schema-version:0.5",

--- a/tools/python/boutiques/tests/test_logger.py
+++ b/tools/python/boutiques/tests/test_logger.py
@@ -9,6 +9,20 @@ from boutiques import __file__ as bfile
 from boutiques.localExec import ExecutorError
 from argparse import ArgumentParser
 from unittest import TestCase
+import mock
+from boutiques_mocks import mock_zenodo_search, MockZenodoRecord
+
+
+def mock_get(*args, **kwargs):
+    query = args[0].split("=")[1]
+    query = query[:query.find("&")]
+    query = query.replace("*", '')
+
+    mock_records = []
+    # Return an arbitrary list of results
+    for i in range(0, 10):
+        mock_records.append(MockZenodoRecord(i, "Example Tool %s" % i))
+    return mock_zenodo_search(mock_records)
 
 
 class TestLogger(TestCase):
@@ -28,7 +42,8 @@ class TestLogger(TestCase):
                              invocationStr)
         assert("[ ERROR ]" in str(e))
 
-    def test_print_info(self):
+    @mock.patch('requests.get', side_effect=mock_get)
+    def test_print_info(self, mock_get):
         bosh.search("-v")
         out, err = self.capfd.readouterr()
         assert("[ INFO ]" in out)

--- a/tools/python/boutiques/tests/test_search.py
+++ b/tools/python/boutiques/tests/test_search.py
@@ -7,16 +7,34 @@ from boutiques_mocks import mock_zenodo_search, MockZenodoRecord
 def mock_get(*args, **kwargs):
     query = args[0].split("=")[1]
     query = query[:query.find("&")]
+
+    exact = False
+    if "*" not in query:
+        exact = True
+
+    query = query.replace("*", '')
     max_results = args[0].split("=")[-1]
+
+    # Long description text to test truncation
+    long_description = ("Lorem ipsum dolor sit amet, consectetur adipiscing "
+                        "elit, sed do eiusmod tempor incididunt ut labore et "
+                        "dolore magna aliqua. Ut enim ad minim veniam, quis "
+                        "nostrud exercitation ullamco laboris nisi ut aliquip "
+                        "ex ea commodo consequat.")
 
     mock_records = []
     # Return an arbitrary list of results with length max_results
     if query == "boutiques":
         for i in range(0, int(max_results)):
-            mock_records.append(MockZenodoRecord(i, "Example Tool %s" % i))
-    # Return only the record matching the query
+            mock_records.append(MockZenodoRecord(i, "Example Tool %s" % i,
+                                                 long_description,
+                                                 "exampleTool%s.json" % i, i))
+    # Return only records containing the query
     else:
         mock_records.append(MockZenodoRecord(1234567, query))
+        if not exact:
+            mock_records.append(MockZenodoRecord(1234568, "foo-" + query))
+            mock_records.append(MockZenodoRecord(1234569, query + "-bar"))
 
     return mock_zenodo_search(mock_records)
 
@@ -34,7 +52,18 @@ class TestSearch(TestCase):
     def test_search_query(self, mock_get):
         results = bosh(["search", "Example Tool 5"])
         assert(len(results) > 0)
-        assert("Example Tool 5" in results[0]["TITLE"])
+        assert(any(d['TITLE'] == 'Example Tool 5' for d in results))
+        assert(any(d['TITLE'] == 'foo-Example Tool 5' for d in results))
+        assert(any(d['TITLE'] == 'Example Tool 5-bar' for d in results))
+
+    @mock.patch('requests.get', side_effect=mock_get)
+    def test_search_exact_match(self, mock_get):
+        results = bosh(["search", "Example Tool 5", "--exact"])
+        print(results)
+        assert(len(results) > 0)
+        assert(any(d['TITLE'] == 'Example Tool 5' for d in results))
+        assert(not any(d['TITLE'] == 'foo-Example Tool 5' for d in results))
+        assert(not any(d['TITLE'] == 'Example Tool 5-bar' for d in results))
 
     @mock.patch('requests.get', side_effect=mock_get)
     def test_search_verbose(self, mock_get):
@@ -47,10 +76,11 @@ class TestSearch(TestCase):
 
     @mock.patch('requests.get', side_effect=mock_get)
     def test_search_specify_max_results(self, mock_get):
-        results = bosh(["search", "--sandbox", "-m", "20"])
+        results = bosh(["search", "-m", "20"])
         assert(len(results) == 20)
 
-    def test_search_sorts_by_num_downloads(self):
+    @mock.patch('requests.get', side_effect=mock_get)
+    def test_search_sorts_by_num_downloads(self, mock_get):
         results = bosh(["search"])
         downloads = []
         for r in results:
@@ -58,13 +88,15 @@ class TestSearch(TestCase):
         assert(all(downloads[i] >= downloads[i+1]
                for i in range(len(downloads)-1)))
 
-    def test_search_truncates_long_text(self):
+    @mock.patch('requests.get', side_effect=mock_get)
+    def test_search_truncates_long_text(self, mock_get):
         results = bosh(["search"])
         for r in results:
             for k, v in r.items():
                 assert(len(str(v)) <= 43)
 
-    def test_search_no_trunc(self):
+    @mock.patch('requests.get', side_effect=mock_get)
+    def test_search_no_trunc(self, mock_get):
         results = bosh(["search", "--no-trunc"])
         has_no_trunc = False
         for r in results:


### PR DESCRIPTION
Fix for #363 

By default, `bosh search` now appends the wildcard character (*) to the beginning and end of the query to allow for non-exact match searches. For example, the search query `fsl` would be automatically converted to `*fsl*` so that it can return results like `fsl-first`. 

Exact match search can still be done by providing the flag `-e` or `--exact`. 