### PR TITLE
Fixed imagePath for bosh exec launch/prepare

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -119,8 +119,9 @@ def execute(*params):
                             help="Streams stdout and stderr in real time "
                             "during execution.")
         parser.add_argument("--imagepath", action="store",
-                            help="Location of Singularity image "
-                            "(default is current directory).")
+                            help="Absolute path to Singularity image. "
+                                 "If not specified, will use current "
+                                 "directory.")
         results = parser.parse_args(params)
         descriptor = results.descriptor
         inp = results.invocation

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -120,8 +120,7 @@ def execute(*params):
                             "during execution.")
         parser.add_argument("--imagepath", action="store",
                             help="Absolute path to Singularity image. "
-                                 "If not specified, will use current "
-                                 "directory.")
+                            "If not specified, will use current directory.")
         results = parser.parse_args(params)
         descriptor = results.descriptor
         inp = results.invocation
@@ -194,8 +193,8 @@ def execute(*params):
                             help="Streams stdout and stderr in real time "
                             "during execution.")
         parser.add_argument("--imagepath", action="store",
-                            help="Location of Singularity image "
-                            "(default is current directory).")
+                            help="Absolute path to Singularity image. "
+                            "If not specified, will use current directory.")
         results = parser.parse_args(params)
         descriptor = results.descriptor
 

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -242,7 +242,7 @@ class LocalExecutor(object):
         container_command = ""
         if conIsPresent:
             # Pull the container
-            (conName, container_location) = self.prepare()
+            (conPath, container_location) = self.prepare()
             # Generate command script
             # Get the supported shell by the docker or singularity
             cmdString = "#!"+self.shell+" -l\n" + str(command)
@@ -335,7 +335,7 @@ class LocalExecutor(object):
                                      singularity_mounts +
                                      ' -W ' + launchDir + ' ' +
                                      conOptsString +
-                                     str(conName) + ' ' + dsname)
+                                     str(conPath) + ' ' + dsname)
             else:
                 raise_error(ExecutorError, 'Unrecognized container type: '
                             '\"%s\"' % conType)
@@ -396,7 +396,6 @@ class LocalExecutor(object):
 
         # If container is present, alter the command template accordingly
         conName = ""
-        container_location = ""
 
         if conType == 'docker':
             # Pull the docker image
@@ -411,56 +410,66 @@ class LocalExecutor(object):
                 conIndex = "shub://"
             elif not conIndex.endswith("://"):
                 conIndex = conIndex + "://"
-            conName = conImage.replace("/", "-").replace(":", "-") + ".simg"
+
+            if self.imagePath:
+                conName = op.basename(self.imagePath)
+                imageDir = op.dirname(self.imagePath)
+            else:
+                conName = conImage.replace("/", "-").replace(":", "-") + ".simg"
+                imageDir = "./"
 
             # Check if container already exists
-            if self._singConExists(conName):
-                return (conName, "Local ({0})".format(conName))
+            if self._singConExists(conName, imageDir):
+                conPath = op.abspath(op.join(imageDir, conName))
+                return conPath, "Local ({0})".format(conName)
 
             # Container does not exist, try to pull it
-            lockdir = conName + "-lock"
+            if self.imagePath:
+                lockDir = self.imagePath + "-lock"
+            else:
+                lockDir = conName + "-lock"
+
             maxcount = 36
             count = 0
-            try:
-                while count < maxcount:
-                    count += 1
-                    try:
-                        os.mkdir(lockdir)
-                    except OSError:
-                        time.sleep(5)
-                    else:
-                        # Check if container was created while waiting
-                        if self._singConExists(conName):
-                            return (conName, "Local ({0})".format(conName))
-                        # Container still does not exist, so pull it
-                        return self._pullSingImage(conName, conIndex, conImage)
-                # If loop times out, check again for existence, otherwise
-                # raise an error
-                if self._singConExists(conName):
-                    return (conName, "Local ({0})".format(conName))
-                raise_error(ExecutorError, "Unable to retrieve Singularity "
-                            "image.")
-            finally:
-                os.rmdir(lockdir)
-                if "SINGULARITY_PULLFOLDER" in os.environ:
-                    del os.environ["SINGULARITY_PULLFOLDER"]
+
+            while count < maxcount:
+                count += 1
+                try:
+                    os.mkdir(lockDir)
+                except OSError:
+                    time.sleep(5)
+                else:
+                    # Check if container was created while waiting
+                    if self._singConExists(conName, imageDir):
+                        self._cleanUpAfterSingPull(lockDir)
+                        conPath = op.abspath(op.join(imageDir, conName))
+                        return conPath, "Local ({0})".format(conName)
+                    # Container still does not exist, so pull it
+                    return self._pullSingImage(conName, conIndex, conImage,
+                                               imageDir, lockDir)
+            # If loop times out, check again for existence, otherwise
+            # raise an error
+            if self._singConExists(conName, imageDir):
+                conPath = op.abspath(op.join(imageDir, conName))
+                return conPath, "Local ({0})".format(conName)
+            raise_error(ExecutorError, "Unable to retrieve Singularity "
+                        "image.")
 
         # Invalid container type
         raise_error(ExecutorError, 'Unrecognized container'
                     ' type: \"%s\"' % conType)
 
     # Private method that checks if a Singularity image exists locally
-    def _singConExists(self, conName):
-        imagePath = self.imagePath or './'
-        return conName in os.listdir(imagePath)
+    def _singConExists(self, conName, imageDir):
+        return conName in os.listdir(imageDir)
 
     # Private method that pulls a Singularity image
-    def _pullSingImage(self, conName, conIndex, conImage):
+    def _pullSingImage(self, conName, conIndex, conImage, imageDir, lockDir):
         # Give the file a temporary name while it's building
         conNameTmp = conName + ".tmp"
         # Set the pull directory to the specified imagePath
-        if self.imagePath is not None:
-            os.environ["SINGULARITY_PULLFOLDER"] = self.imagePath
+        if self.imagePath:
+            os.environ["SINGULARITY_PULLFOLDER"] = imageDir
         pull_loc = "\"{0}\" {1}{2}".format(conNameTmp,
                                            conIndex,
                                            conImage)
@@ -474,15 +483,23 @@ class LocalExecutor(object):
         sing_command = "singularity pull --name " + pull_loc
         (stdout, stderr), return_code = self._localExecute(
                                                 sing_command)
+        self._cleanUpAfterSingPull(lockDir)
         if return_code:
             message = ("Could not pull Singularity"
                        " image: " + os.linesep + " * Pull command: "
                        + sing_command + os.linesep + " * Error: "
                        + stderr.decode("utf-8"))
             raise_error(ExecutorError, message)
-        os.rename(conNameTmp, conName)
-        conName = op.abspath(conName)
-        return (conName, container_location)
+        os.rename(op.join(imageDir, conNameTmp), op.join(imageDir, conName))
+        conPath = op.abspath(op.join(imageDir, conName))
+        return conPath, container_location
+
+    # Removes the lock directory and environment variable
+    # created while pulling an image
+    def _cleanUpAfterSingPull(self, lockDir):
+        os.rmdir(lockDir)
+        if "SINGULARITY_PULLFOLDER" in os.environ:
+            del os.environ["SINGULARITY_PULLFOLDER"]
 
     # Private method that attempts to locally execute the given
     # command. Returns the exit code.

--- a/tools/python/boutiques/tests/test_prepare.py
+++ b/tools/python/boutiques/tests/test_prepare.py
@@ -87,7 +87,7 @@ class TestPrepare(TestCase):
     @pytest.mark.skipif(subprocess.Popen("type singularity", shell=True).wait(),
                         reason="Singularity not installed")
     def test_prepare_sing_multiple_processes(self, mock_mkdir, mock_exists,
-                                        mock_clean_up):
+                                             mock_clean_up):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
         # Specify the wrong path for the image, but mock that another process
         # created the image at that path while this process was waiting

--- a/tools/python/boutiques/tests/test_prepare.py
+++ b/tools/python/boutiques/tests/test_prepare.py
@@ -19,12 +19,28 @@ def mock_mkdir():
     return [OSError("cannot mkdir"), None]
 
 
+def mock_mkdir_timeout():
+    return OSError("cannot mkdir")
+
+
+def mock_sleep():
+    return None
+
+
 def mock_clean_up():
     return None
 
 
 def mock_exists():
     return [False, True]
+
+
+def mock_sing_pull():
+    return ((None, None), 0), None
+
+
+def mock_os_rename():
+    return None
 
 
 class TestPrepare(TestCase):
@@ -89,8 +105,9 @@ class TestPrepare(TestCase):
     def test_prepare_sing_multiple_processes(self, mock_mkdir, mock_exists,
                                              mock_clean_up):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
-        # Specify the wrong path for the image, but mock that another process
-        # created the image at that path while this process was waiting
+        # Specify path for image that does not exist.
+        # Mock that another process created the image at that path
+        # while this process was waiting.
         ret = bosh.execute("prepare",
                            os.path.join(example1_dir,
                                         "example1_sing.json"),
@@ -98,6 +115,62 @@ class TestPrepare(TestCase):
                            os.path.join(os.path.expanduser('~'),
                                         "boutiques-example1-test.simg"))
         assert ("Local (boutiques-example1-test.simg)" in ret.stdout)
+
+    @mock.patch('os.mkdir', side_effect=mock_mkdir_timeout())
+    @mock.patch('time.sleep', side_effect=mock_sleep())
+    @pytest.mark.skipif(subprocess.Popen("type singularity", shell=True).wait(),
+                        reason="Singularity not installed")
+    def test_prepare_sing_timeout(self, mock_mkdir, mock_sleep):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        # Specify path for image that does not exist.
+        # Mock that another process has the lockdir and this one
+        # times out while waiting.
+        with pytest.raises(ExecutorError) as e:
+            bosh.execute("prepare",
+                         os.path.join(example1_dir,
+                                      "example1_sing.json"),
+                         "--imagepath",
+                         os.path.join(os.path.expanduser('~'),
+                                      "boutiques-example1-test.simg"))
+        assert ("Unable to retrieve Singularity image" in str(e))
+
+    @mock.patch('os.mkdir', side_effect=mock_mkdir_timeout())
+    @mock.patch('time.sleep', side_effect=mock_sleep())
+    @mock.patch('boutiques.localExec.LocalExecutor._singConExists',
+                side_effect=mock_exists())
+    @pytest.mark.skipif(subprocess.Popen("type singularity", shell=True).wait(),
+                        reason="Singularity not installed")
+    def test_prepare_sing_timeout_success(self, mock_mkdir, mock_sleep,
+                                                mock_exists):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        # Specify path for image that does not exist.
+        # Mock that another process has the lockdir and this one
+        # times out while waiting, but image was created by the
+        # other process.
+        ret = bosh.execute("prepare",
+                           os.path.join(example1_dir,
+                                        "example1_sing.json"),
+                           "--imagepath",
+                           os.path.join(os.path.expanduser('~'),
+                                        "boutiques-example1-test.simg"))
+        assert ("Local (boutiques-example1-test.simg)" in ret.stdout)
+
+    @mock.patch('boutiques.localExec.LocalExecutor._localExecute',
+                side_effect=mock_sing_pull())
+    @mock.patch('os.rename', side_effect=mock_os_rename())
+    @pytest.mark.skipif(subprocess.Popen("type singularity", shell=True).wait(),
+                        reason="Singularity not installed")
+    def test_prepare_sing_pull_success(self, mock_sing_pull, mock_os_rename):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        # Specify path for image that does not exist.
+        # Try to pull it and mock that the pull was successful.
+        ret = bosh.execute("prepare",
+                           os.path.join(example1_dir,
+                                        "example1_sing.json"),
+                           "--imagepath",
+                           os.path.join(os.path.expanduser('~'),
+                                        "boutiques-example1-test.simg"))
+        assert ("Pulled from docker://boutiques/example1:test" in ret.stdout)
 
     def test_prepare_no_container(self):
         ret = bosh.execute("prepare",

--- a/tools/python/boutiques/tests/test_prepare.py
+++ b/tools/python/boutiques/tests/test_prepare.py
@@ -6,7 +6,6 @@ import pytest
 from unittest import TestCase
 from boutiques import __file__ as bfile
 import boutiques as bosh
-from boutiques.localExec import ExecutorError
 
 
 class TestPrepare(TestCase):
@@ -37,12 +36,13 @@ class TestPrepare(TestCase):
                         reason="Singularity not installed")
     def test_prepare_sing_specify_imagepath(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
-        with pytest.raises(ExecutorError) as e:
-            ret = bosh.execute("prepare",
-                               os.path.join(example1_dir,
-                                            "example1_sing.json"),
-                               "--imagepath", os.path.expanduser('~'))
-        assert("Could not pull Singularity image" in str(e))
+        ret = bosh.execute("prepare",
+                           os.path.join(example1_dir,
+                                        "example1_sing.json"),
+                           "--imagepath",
+                           os.path.join(os.getcwd(),
+                                        "boutiques-example1-test.simg"))
+        assert("Local (boutiques-example1-test.simg)" in ret.stdout)
         assert("SINGULARITY_PULLFOLDER" not in os.environ)
 
     def test_prepare_no_container(self):

--- a/tools/python/boutiques/tests/test_prepare.py
+++ b/tools/python/boutiques/tests/test_prepare.py
@@ -3,9 +3,28 @@
 import os
 import subprocess
 import pytest
-from unittest import TestCase
 from boutiques import __file__ as bfile
 import boutiques as bosh
+from boutiques.localExec import ExecutorError
+import mock
+import sys
+from boutiques_mocks import *
+if sys.version_info < (2, 7):
+    from unittest2 import TestCase
+else:
+    from unittest import TestCase
+
+
+def mock_mkdir():
+    return [OSError("cannot mkdir"), None]
+
+
+def mock_clean_up():
+    return None
+
+
+def mock_exists():
+    return [False, True]
 
 
 class TestPrepare(TestCase):
@@ -44,6 +63,41 @@ class TestPrepare(TestCase):
                                         "boutiques-example1-test.simg"))
         assert("Local (boutiques-example1-test.simg)" in ret.stdout)
         assert("SINGULARITY_PULLFOLDER" not in os.environ)
+
+    @pytest.mark.skipif(subprocess.Popen("type singularity", shell=True).wait(),
+                        reason="Singularity not installed")
+    def test_prepare_sing_image_does_not_exist(self):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        # Specify the wrong path for the image
+        # Will try to pull it and pull will fail
+        with pytest.raises(ExecutorError) as e:
+            bosh.execute("prepare",
+                         os.path.join(example1_dir,
+                                      "example1_sing.json"),
+                         "--imagepath",
+                         os.path.join(os.path.expanduser('~'),
+                                      "boutiques-example1-test.simg"))
+        assert("Could not pull Singularity image" in str(e))
+
+    @mock.patch('os.mkdir', side_effect=mock_mkdir())
+    @mock.patch('boutiques.localExec.LocalExecutor._singConExists',
+                side_effect=mock_exists())
+    @mock.patch('boutiques.localExec.LocalExecutor._cleanUpAfterSingPull',
+                side_effect=mock_clean_up())
+    @pytest.mark.skipif(subprocess.Popen("type singularity", shell=True).wait(),
+                        reason="Singularity not installed")
+    def test_prepare_sing_multiple_processes(self, mock_mkdir, mock_exists,
+                                        mock_clean_up):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        # Specify the wrong path for the image, but mock that another process
+        # created the image at that path while this process was waiting
+        ret = bosh.execute("prepare",
+                           os.path.join(example1_dir,
+                                        "example1_sing.json"),
+                           "--imagepath",
+                           os.path.join(os.path.expanduser('~'),
+                                        "boutiques-example1-test.simg"))
+        assert ("Local (boutiques-example1-test.simg)" in ret.stdout)
 
     def test_prepare_no_container(self):
         ret = bosh.execute("prepare",

--- a/tools/python/boutiques/tests/test_prepare.py
+++ b/tools/python/boutiques/tests/test_prepare.py
@@ -141,7 +141,7 @@ class TestPrepare(TestCase):
     @pytest.mark.skipif(subprocess.Popen("type singularity", shell=True).wait(),
                         reason="Singularity not installed")
     def test_prepare_sing_timeout_success(self, mock_mkdir, mock_sleep,
-                                                mock_exists):
+                                          mock_exists):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
         # Specify path for image that does not exist.
         # Mock that another process has the lockdir and this one


### PR DESCRIPTION
Fixes for #404, #405 

* Fixed the `--imagepath` option in `bosh exec launch` and `bosh exec prepare` to be the absolute path of the Singularity image (this can refer to either an existing image file or the path you want the image to have when it's pulled)
* Made it so the lockdir is created in the same location as the imagepath, so that processes can be run from different locations using the same imagepath and it should not cause problems.
* Removed the `finally` clause that deletes the lockdir and pullfolder environment variable and replaced it with a method that does this only once a container image has been found locally or pulled successfully. The `finally` clause was causing a bug where if a process timed out while trying to pull the image, it would still delete the lockdir, causing issues for other processes that are still running. 

@prioux