### PR TITLE
Explicit version consolidation

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -304,10 +304,10 @@ def publish(*params):
 
     from boutiques.publisher import Publisher
     publisher = Publisher(results.boutiques_descriptor,
+                          results.zenodo_token,
                           results.verbose,
                           results.sandbox,
                           results.no_int,
-                          results.zenodo_token,
                           results.replace,
                           results.id)
     publisher.publish()

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -290,6 +290,10 @@ def publish(*params):
                         help="disable interactive input.")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="print information messages.")
+    parser.add_argument("-r", "--replace", action="store",
+                        help="Zenodo ID of an existing record you wish to "
+                             "replace with a new version, prefixed by "
+                             "'zenodo.' (e.g. zenodo.123456).")
 
     results = parser.parse_args(params)
 
@@ -298,7 +302,8 @@ def publish(*params):
                           results.verbose,
                           results.sandbox,
                           results.no_int,
-                          results.zenodo_token)
+                          results.zenodo_token,
+                          results.replace)
     publisher.publish()
     if hasattr(publisher, 'doi'):
         return publisher.doi

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -292,13 +292,13 @@ def publish(*params):
                         help="print information messages.")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-r", "--replace", action="store_true",
-                        help="Publish an updated version of an existing "
-                        "record. The descriptor must contain a DOI, which "
-                        "will be replaced with a new one.")
+                       help="Publish an updated version of an existing "
+                       "record. The descriptor must contain a DOI, which "
+                       "will be replaced with a new one.")
     group.add_argument("--id", action="store",
-                        help="Zenodo ID of an existing record you wish to "
-                        "update with a new version, prefixed by "
-                        "'zenodo.' (e.g. zenodo.123456).")
+                       help="Zenodo ID of an existing record you wish to "
+                       "update with a new version, prefixed by "
+                       "'zenodo.' (e.g. zenodo.123456).")
 
     results = parser.parse_args(params)
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -290,10 +290,15 @@ def publish(*params):
                         help="disable interactive input.")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="print information messages.")
-    parser.add_argument("-r", "--replace", action="store",
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-r", "--replace", action="store_true",
+                        help="Publish an updated version of an existing "
+                        "record. The descriptor must contain a DOI, which "
+                        "will be replaced with a new one.")
+    group.add_argument("--id", action="store",
                         help="Zenodo ID of an existing record you wish to "
-                             "replace with a new version, prefixed by "
-                             "'zenodo.' (e.g. zenodo.123456).")
+                        "update with a new version, prefixed by "
+                        "'zenodo.' (e.g. zenodo.123456).")
 
     results = parser.parse_args(params)
 
@@ -303,7 +308,8 @@ def publish(*params):
                           results.sandbox,
                           results.no_int,
                           results.zenodo_token,
-                          results.replace)
+                          results.replace,
+                          results.id)
     publisher.publish()
     if hasattr(publisher, 'doi'):
         return publisher.doi

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1155,7 +1155,7 @@ def loadJson(userInput, verbose=False):
         json_file = userInput
     elif userInput.split(".")[0].lower() == "zenodo":
         from boutiques.puller import Puller
-        puller = Puller(userInput, verbose, False)
+        puller = Puller(userInput, verbose)
         json_file = puller.pull()
     if json_file is not None:
         with open(json_file, 'r') as f:

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -13,9 +13,9 @@ class ZenodoError(Exception):
 
 class Publisher():
 
-    def __init__(self, descriptor_file_name,
-                 verbose, sandbox, no_int,
-                 auth_token, replace, id):
+    def __init__(self, descriptor_file_name, auth_token,
+                 verbose=False, sandbox=False, no_int=False,
+                 replace=False, id=None):
         # Straightforward assignments
         self.verbose = verbose
         self.sandbox = sandbox

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -140,8 +140,9 @@ class Publisher():
                           % deposition_id,
                           params={'access_token': self.zenodo_access_token})
         if(r.status_code != 201):
-            raise_error(ZenodoError, "Deposition of new version failed. Check that the "
-                                     "Zenodo ID is correct (if one was provided).", r)
+            raise_error(ZenodoError, "Deposition of new version failed. Check "
+                                     "that the Zenodo ID is correct (if one "
+                                     "was provided).", r)
         if(self.verbose):
             print_info("Deposition of new version succeeded", r)
         new_url = r.json()['links']['latest_draft']
@@ -251,7 +252,8 @@ class Publisher():
                     publish_update = True
 
         if publish_update:
-            deposition_id = self.zenodo_deposit_updated_version(self.id_to_update)
+            deposition_id = \
+                self.zenodo_deposit_updated_version(self.id_to_update)
         else:
             deposition_id = self.zenodo_deposit()
 

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -15,7 +15,7 @@ except ImportError:
 
 class Puller():
 
-    def __init__(self, zid, verbose, sandbox):
+    def __init__(self, zid, verbose=False, sandbox=False):
         # remove zenodo prefix
         try:
             self.zid = zid.split(".", 1)[1]

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_with_doi.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_with_doi.json
@@ -1,5 +1,6 @@
 {
-    "command-line": "exampleTool1.py [CONFIG_FILE] [STRING_INPUT_LIST] [STRING_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [INT_LIST_INPUT] &> [LOG]", 
+    "author": "Test author",
+    "command-line": "exampleTool1.py [CONFIG_FILE] [STRING_INPUT_LIST] [STRING_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [INT_LIST_INPUT] &> [LOG]",
     "container-image": {
         "image": "boutiques/example1:test", 
         "type": "docker"

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -10,7 +10,7 @@ from boutiques.publisher import ZenodoError
 
 class Searcher():
 
-    def __init__(self, query, verbose, sandbox, max_results=None,
+    def __init__(self, query, verbose=False, sandbox=False, max_results=None,
                  no_trunc=False, exact_match=False):
         if query is not None:
             self.query = query

--- a/tools/python/boutiques/tests/boutiques_mocks.py
+++ b/tools/python/boutiques/tests/boutiques_mocks.py
@@ -29,17 +29,19 @@ def mock_zenodo_deposit(mock_zid):
     return MockHttpResponse(201, mock_json)
 
 
-def mock_zenodo_deposit_updated(mock_zid):
+def mock_zenodo_deposit_updated(old_zid, new_zid):
     mock_json = {
                   "links": {
                     "latest_draft": "https://zenodo.org/api/record/%s"
-                                    % mock_zid
+                                    % new_zid
                   },
                   "files": [
                     {
                       "id": 1234
                     }
-                  ]
+                  ],
+                  "doi": "10.5072/zenodo.%s"
+                         % old_zid
                 }
     return MockHttpResponse(201, mock_json)
 

--- a/tools/python/boutiques/tests/test_publisher.py
+++ b/tools/python/boutiques/tests/test_publisher.py
@@ -36,13 +36,13 @@ def mock_post_publish_then_update():
     return ([mock_zenodo_deposit(1234567),
             mock_zenodo_upload_descriptor(),
             mock_zenodo_publish(1234567),
-            mock_zenodo_deposit_updated(2345678),
+            mock_zenodo_deposit_updated(1234567, 2345678),
             mock_zenodo_upload_descriptor(),
             mock_zenodo_publish(2345678)])
 
 
 def mock_post_publish_update_only():
-    return ([mock_zenodo_deposit_updated(2345678),
+    return ([mock_zenodo_deposit_updated(1234567, 2345678),
             mock_zenodo_upload_descriptor(),
             mock_zenodo_publish(2345678)])
 

--- a/tools/python/boutiques/tests/test_publisher.py
+++ b/tools/python/boutiques/tests/test_publisher.py
@@ -16,7 +16,7 @@ else:
     from unittest import TestCase
 
 
-def mock_get():
+def mock_get_publish_then_update():
     mock_record = MockZenodoRecord(1234567, "Example Boutiques Tool")
     return ([mock_zenodo_test_api_fail(),
             mock_zenodo_test_api(),
@@ -26,11 +26,23 @@ def mock_get():
             mock_zenodo_search([mock_record])])
 
 
-def mock_post():
+# for publishing updates with --replace option
+def mock_get_no_search():
+    return ([mock_zenodo_test_api_fail(),
+            mock_zenodo_test_api()])
+
+
+def mock_post_publish_then_update():
     return ([mock_zenodo_deposit(1234567),
             mock_zenodo_upload_descriptor(),
             mock_zenodo_publish(1234567),
             mock_zenodo_deposit_updated(2345678),
+            mock_zenodo_upload_descriptor(),
+            mock_zenodo_publish(2345678)])
+
+
+def mock_post_publish_update_only():
+    return ([mock_zenodo_deposit_updated(2345678),
             mock_zenodo_upload_descriptor(),
             mock_zenodo_publish(2345678)])
 
@@ -53,8 +65,8 @@ class TestPublisher(TestCase):
         return op.join(op.dirname(bfile),
                        "schema", "examples")
 
-    @mock.patch('requests.get', side_effect=mock_get())
-    @mock.patch('requests.post', side_effect=mock_post())
+    @mock.patch('requests.get', side_effect=mock_get_publish_then_update())
+    @mock.patch('requests.post', side_effect=mock_post_publish_then_update())
     @mock.patch('requests.put', return_value=mock_put())
     @mock.patch('requests.delete', return_value=mock_delete())
     def test_publication(self, mock_get, mock_post, mock_put, mock_delete):
@@ -161,3 +173,33 @@ class TestPublisher(TestCase):
                                    stderr=subprocess.PIPE)
         process.communicate()
         self.assertTrue(process.returncode)
+
+    @mock.patch('requests.get', side_effect=mock_get_no_search())
+    @mock.patch('requests.post', side_effect=mock_post_publish_update_only())
+    @mock.patch('requests.put', return_value=mock_put())
+    @mock.patch('requests.delete', return_value=mock_delete())
+    def test_publication_replace(self, mock_get, mock_post, mock_put,
+                                 mock_delete):
+        example1_dir = op.join(self.get_examples_dir(), "example1")
+        example1_desc = op.join(example1_dir, "example1_docker.json")
+        temp_descriptor = tempfile.NamedTemporaryFile(suffix=".json")
+        shutil.copyfile(example1_desc, temp_descriptor.name)
+
+        # Make sure that example1.json doesn't have a DOI yet
+        with open(temp_descriptor.name, 'r') as fhandle:
+            descriptor = json.load(fhandle)
+            assert (descriptor.get('doi') is None)
+
+        # Publish an updated version of an already published descriptor
+        doi = bosh(["publish",
+                    temp_descriptor.name,
+                    "--sandbox", "-y", "-v",
+                    "--zenodo-token", "hAaW2wSBZMskxpfigTYHcuDrC"
+                                      "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r",
+                    "--replace", "zenodo.1234567"])
+        assert (doi)
+
+        # Now descriptor should have a DOI
+        with open(temp_descriptor.name, 'r') as fhandle:
+            descriptor = json.load(fhandle)
+            assert (descriptor.get('doi') == doi)


### PR DESCRIPTION
#393 

Added a `--replace <zenodo-id>` option to `bosh publish` to publish updated versions using the unique Zenodo ID.