### PR TITLE
Boolean command-line options fix.

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1196,7 +1196,8 @@ def loadJson(userInput, verbose=False):
 def addDefaultValues(desc_dict, in_dict):
     inputs = desc_dict['inputs']
     for in_param in [s for s in inputs
-                     if s.get("default-value") is not None]:
+                     if s.get("default-value") is not None
+                     and not s.get("optional")]:
         if in_dict.get(in_param['id']) is None:
             df = in_param.get("default-value")
             if not in_param['type'] == 'Flag':


### PR DESCRIPTION
When 'optional' was set to true for an input
flag (e.g. "-x") and the input is NOT specified in
the invoke.json, then the command line built got
the flag anyway (e.g "-x" was added).

There is no issue associated with this bug.