### PR TITLE
Fixed issue where some singularity containers suspended python

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -334,8 +334,8 @@ class LocalExecutor(object):
                 # Only forces contains for cli when user hasn't already
                 forced_container_opts = ""
                 if os.path.basename(sys.argv[0]) != "bosh" and \
-                   not any([s.startswith('-contain') for s in conOpts]):
-                    forced_container_opts = " -contain"
+                   not any([s.startswith('--contain') for s in conOpts]):
+                    forced_container_opts = " --contain"
 
                 container_command = (envString + 'singularity exec '
                                      '--cleanenv ' +


### PR DESCRIPTION
This closes #431

 - Adds `-contain` to singularity opts if it or `-containall` aren't
already there
 - sets `conOpts` to `[]` if it is None for simpler control-flow later

I am not sure if boutiques should be allowing singularity to run
without `-contains` but there is plausibly a reason, and if it comes up
we might need a means to allow this, maybe with a flag? As this seems to
only affect certain singularity containers (that pollute the parent
processes signals, it seems), there is an argument to be made that the
descriptor author should be responsible... it's just such an esoteric
and hard-to-catch issue that I think defaulting to this until someone
asks makes more sense, as someone asking deliberately intends to
communicate signals to the parent process, so they'll be able to ask the
boutques team the correct questions.

I'm not sure what sane tests there are as I think putting in something that isn't caught by this fix might actually break pytest, so I'm not sure of the result/utility. I _think_ running `top` within a singularity image allow someone to duplicate the error?