### PR TITLE
Adjusted rounding system for exec simulate simulated floating point params

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -553,6 +553,13 @@ class LocalExecutor(object):
         # nd = number of random characters to use in generating strings,
         # nl = max number of random list items
         nd, nl = 2, 5
+        # number_decimals = the number of decimal places to round to
+        # on randomly generated floating point numbers
+        number_decimals = 3
+        # epsilon = an upper bound on the relative error due to
+        # rounding for the chosen number of decimals, making sure
+        # excluded values aren't rounded to by accident.
+        epsilon = 1.0/(10**number_decimals)
 
         def randDigs():
             # Generate random string of digits
@@ -601,12 +608,13 @@ class LocalExecutor(object):
                 minv, maxv = float(minv), float(maxv)
             # Apply exclusive boundary constraints, if any
             if self.safeGet(param_id, 'exclusive-minimum'):
-                minv += 1 if isInt else 0.001
+                minv += 1 if isInt else epsilon
             if self.safeGet(param_id, 'exclusive-maximum'):
-                maxv -= 1 if isInt else 0.001
+                maxv -= 1 if isInt else epsilon
             # Returns a random int or a random float, depending on the type of p
             return (rnd.randint(minv, maxv)
-                    if isInt else round(rnd.uniform(minv, maxv), nd))
+                    if isInt else round(rnd.uniform(minv, maxv),
+                                        number_decimals))
 
         # Generate a random parameter value based on the input
         # type (where prm \in self.inputs)

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -70,6 +70,10 @@ class TestSimulate(TestCase):
 
         # Test inclusive lower bound
         target_input["exclusive-minimum"] = False
+        mock_random.return_value = -0.001
+        self.assertRaises(SystemExit, bosh.execute, ["simulate",
+                                             json.dumps(test_json),
+                                             "-j"])
         mock_random.return_value = 0
         ret = bosh.bosh(args=["example", json.dumps(test_json)]).stdout
         self.assertIsInstance(json.loads(ret), dict)
@@ -85,6 +89,10 @@ class TestSimulate(TestCase):
 
         # Test inclusive upper bound
         target_input["exclusive-maximum"] = False
+        mock_random.return_value = 1.001
+        self.assertRaises(SystemExit, bosh.execute, ["simulate",
+                                                     json.dumps(test_json),
+                                                     "-j"])
         mock_random.return_value = 1
         ret = bosh.bosh(args=["example", json.dumps(test_json)]).stdout
         self.assertIsInstance(json.loads(ret), dict)

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -57,6 +57,47 @@ class TestSimulate(TestCase):
                                                    "inv_no_defaults.json"))
                              .exit_code)
 
+    @mock.patch('random.uniform')
+    def test_number_bounds(self, mock_random):
+        example1_dir = os.path.join(self.get_examples_dir(), "example1")
+        desc_json = open(os.path.join(example1_dir,
+                                      "example1_docker.json")).read()
+        test_json = json.loads(desc_json)
+        del test_json['groups']
+        target_input = [i for i in test_json["inputs"]
+                        if i["id"] == "num_input"][0]
+        target_input["optional"] = False
+
+        # Test inclusive lower bound
+        target_input["exclusive-minimum"] = False
+        mock_random.return_value = 0
+        ret = bosh.bosh(args=["example", json.dumps(test_json)]).stdout
+        self.assertIsInstance(json.loads(ret), dict)
+
+        # Test exclusive lower bound
+        target_input["exclusive-minimum"] = True
+        self.assertRaises(SystemExit, bosh.execute, ["simulate",
+                                                     json.dumps(test_json),
+                                                     "-j"])
+        mock_random.return_value = 0.001
+        ret = bosh.bosh(args=["example", json.dumps(test_json)]).stdout
+        self.assertIsInstance(json.loads(ret), dict)
+
+        # Test inclusive upper bound
+        target_input["exclusive-maximum"] = False
+        mock_random.return_value = 1
+        ret = bosh.bosh(args=["example", json.dumps(test_json)]).stdout
+        self.assertIsInstance(json.loads(ret), dict)
+
+        # Test exclusive upper bound
+        target_input["exclusive-maximum"] = True
+        self.assertRaises(SystemExit, bosh.execute, ["simulate",
+                                                     json.dumps(test_json),
+                                                     "-j"])
+        mock_random.return_value = 0.999
+        ret = bosh.bosh(args=["example", json.dumps(test_json)]).stdout
+        self.assertIsInstance(json.loads(ret), dict)
+
     def test_success_json(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
         desc_json = open(os.path.join(example1_dir,

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -72,8 +72,8 @@ class TestSimulate(TestCase):
         target_input["exclusive-minimum"] = False
         mock_random.return_value = -0.001
         self.assertRaises(SystemExit, bosh.execute, ["simulate",
-                                             json.dumps(test_json),
-                                             "-j"])
+                                                     json.dumps(test_json),
+                                                     "-j"])
         mock_random.return_value = 0
         ret = bosh.bosh(args=["example", json.dumps(test_json)]).stdout
         self.assertIsInstance(json.loads(ret), dict)


### PR DESCRIPTION
Closes #442 

May also close #329 

These changes create a variable `number_decimals` separate from `nd` in `localExec`'s `_randomFillInDict` function, that explicitly represents the number of decimal places to round to. `nd` is described as being the length of randomly generated strings. Given `number_decimals`, an `epsilon` is assigned acting as the upper bound error (traditional in this context) except we set it and use it to enforce exclusion as rounding may invalidate our boundaries given our current approach. Specifically, `random.uniform` is inclusive on both bounds, and if we want to exclusively generate something we are changing the specified bounds with our epsilon because we'll round it later.

While this change fixes the bug, it may be worth considering changes that more accurately reflect the exclusivity, such as checking that the resulting `random.uniform` is not at a boundary, and nudging it by a much finer `epsilon` if it is, skipping rounding altogether. This would allow descriptors to describe much finer minimums and maximums in much finer ranges than currently enforced by our `epsilon` of `0.001`. It would also render the distribution of simulated values more uniform.

Originally we had a hardcoded `epsilon` of `0.001` but rounded to two decimal places. On top of that, the affected input, `num_input` was not guaranteed to be used in the simulation. As such, this test only rarely failed.

These changes also add boundary tests on the min and max of floating point numbers being simulated, both inclusively and exclusively. The tests use the standard  `example1_docker.json` but force `num_inputs` to be required and removes the `groups` entry in that descriptor. mock is used to fix the random generation and the descriptor is manipulated before each use to get the appropriate checks.

Integer boundary tests should be considered, in particular, to verify that random numbers generated are properly being bound as expected. It may also want to be considered if the rounding keeps the distribution of potential values uniform or if we care about that.