### PR TITLE
Small fixes

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -431,7 +431,7 @@ def search(*params):
     parser.add_argument("--sandbox", action="store_true",
                         help="search Zenodo's sandbox instead of "
                         "production server. Recommended for tests.")
-    parser.add_argument("-m", "--max", action="store",
+    parser.add_argument("-m", "--max", action="store", type=int,
                         help="Specify the maximum number of results "
                         "to be returned. Default is 10.")
     parser.add_argument("-nt", "--no-trunc", action="store_true",

--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -185,7 +185,12 @@ class PrettyPrinter():
             tinp = inps[0]
             cflag = tinp.get("command-line-flag")
             if cflag:
+                # argparse crashes when dest is supplied and
+                # argument doesn't start with '--'
+                if not cflag.startswith("-"):
+                    cflag = '--' + cflag
                 inp_args += [cflag]
+                inp_kwargs['dest'] = clkey
             else:
                 inp_args += [clkey]
 

--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -68,12 +68,10 @@ class PrettyPrinter():
         else:
             tags = ""
 
-        # Grabs command-line, and figures out where params start so it can
-        # display it nicely
+        # Grabs command-line, and wraps it right to the first element of it
+        # (usually the executable) unless it's too long
         cline = self.desc['command-line']
-        cend = len(cline)
-        for clkey in self.lut.keys():
-            cend = cline.find(clkey) if 0 < cline.find(clkey) < cend else cend
+        cend = min(len(cline.split(' ')[0]) + 1, 35)
         cline = textwrap.wrap("  " + self.desc['command-line'],
                               subsequent_indent='  ' + ' ' * cend)
         cline = "Command-line:\n{0}".format("\n".join(cline))
@@ -188,7 +186,6 @@ class PrettyPrinter():
             cflag = tinp.get("command-line-flag")
             if cflag:
                 inp_args += [cflag]
-                inp_kwargs['dest'] = clkey
             else:
                 inp_args += [clkey]
 

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -32,8 +32,8 @@ class Searcher():
             self.max_results = 10
 
         # Zenodo will error if asked for more than 9999 results
-        if(int(self.max_results) > 9999):
-            self.max_results = "9999"
+        if self.max_results > 9999:
+            self.max_results = 9999
 
         # Set Zenodo endpoint
         self.zenodo_endpoint = "https://sandbox.zenodo.org" if\

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -31,6 +31,10 @@ class Searcher():
         if max_results is None:
             self.max_results = 10
 
+        # Zenodo will error if asked for more than 9999 results
+        if(int(self.max_results) > 9999):
+            self.max_results = "9999"
+
         # Set Zenodo endpoint
         self.zenodo_endpoint = "https://sandbox.zenodo.org" if\
             self.sandbox else "https://zenodo.org"


### PR DESCRIPTION
Fix for #443 
In `pprint`, the command line text was shifted such that lines are aligned with the first option. For instance, `tool blah [TEST] this is a very long line` was displayed as:
```
tool blah [TEST] this is
          a very long line
```
This created issues when the first option appeared further in the command line than the default max line length of 70 in `textwrap`. For instance, `tool blah this is a very long [TEST] line` was displayed as:
```
tool blah this is a very long [TEST]
                               l
                               i
                               n
                               e
```
Lines are now aligned with the second element in the command line:
```
tool blah this is a very
     long [TEST] line
```  
and the shift is capped to 35 in case the first element is too long.

In passing, found and fixed a bug that occurred in `zenodo-2541125`: in `argparse`, arguments with a flag that don't start with `--` can't have a `dest` defined, which crashed `pprint`. Pre-pended flags that don't start with `-` with `--`. This should rarely occur as it is a bit weird to define flags that don't start with `-`.

Also fixed #454 since I was there.