### PR TITLE
Support lists of input files

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1234,7 +1234,11 @@ class LocalExecutor(object):
                 id = x.get('id')
                 path = public_in_dict.get(id)
                 if path is not None:
-                    public_in_dict[id] = self._buildPublicFile(path)
+                    if isinstance(path, list):
+                        public_in_dict[id] = [self._buildPublicFile(p)
+                                              for p in path]
+                    else:
+                        public_in_dict[id] = self._buildPublicFile(path)
 
         return public_in_dict
 

--- a/tools/python/boutiques/schema/examples/example1/example1_docker.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker.json
@@ -102,10 +102,10 @@
         {
             "command-line-flag": "-t",
             "id": "file_list_input",
+            "list": true,
             "name": "A file list input",
             "optional": true,
             "type": "File",
-            "list": true,
             "value-key": "[FILE_LIST_INPUT]"
         },
         {

--- a/tools/python/boutiques/schema/examples/example1/example1_docker.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker.json
@@ -1,6 +1,6 @@
 {
     "author": "Test author",
-    "command-line": "exampleTool1.py [CONFIG_FILE] [STRING_INPUT_LIST] [STRING_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [LOG] [INT_LIST_INPUT]",
+    "command-line": "exampleTool1.py [CONFIG_FILE] [STRING_INPUT_LIST] [STRING_INPUT] [FILE_LIST_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [LOG] [INT_LIST_INPUT]",
     "container-image": {
         "container-opts": [
             "-e",
@@ -98,6 +98,15 @@
             "optional": true,
             "type": "File",
             "value-key": "[FILE_INPUT]"
+        },
+        {
+            "command-line-flag": "-t",
+            "id": "file_list_input",
+            "name": "A file list input",
+            "optional": true,
+            "type": "File",
+            "list": true,
+            "value-key": "[FILE_LIST_INPUT]"
         },
         {
             "command-line-flag": "-e",

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_exported.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_exported.json
@@ -60,6 +60,13 @@
             "type": "File"
         },
         {
+            "id": "file_list_input",
+            "isOptional": true,
+            "isReturnedValue": false,
+            "name": "A file list input",
+            "type": "List"
+        },
+        {
             "id": "enum_input",
             "isOptional": true,
             "isReturnedValue": false,

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_exported_doi.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_exported_doi.json
@@ -60,6 +60,13 @@
             "type": "File"
         },
         {
+            "id": "file_list_input",
+            "isOptional": true,
+            "isReturnedValue": false,
+            "name": "A file list input",
+            "type": "List"
+        },
+        {
             "id": "enum_input",
             "isOptional": true,
             "isReturnedValue": false,

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_exported_doi_python2.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_exported_doi_python2.json
@@ -58,7 +58,14 @@
             "isReturnedValue": false, 
             "name": "A file input", 
             "type": "File"
-        }, 
+        },
+        {
+            "id": "file_list_input",
+            "isOptional": true,
+            "isReturnedValue": false,
+            "name": "A file list input",
+            "type": "List"
+        },
         {
             "id": "enum_input", 
             "isOptional": true, 

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_exported_doi_python2.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_exported_doi_python2.json
@@ -58,14 +58,14 @@
             "isReturnedValue": false, 
             "name": "A file input", 
             "type": "File"
-        },
+        }, 
         {
-            "id": "file_list_input",
-            "isOptional": true,
-            "isReturnedValue": false,
-            "name": "A file list input",
+            "id": "file_list_input", 
+            "isOptional": true, 
+            "isReturnedValue": false, 
+            "name": "A file list input", 
             "type": "List"
-        },
+        }, 
         {
             "id": "enum_input", 
             "isOptional": true, 

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_exported_python2.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_exported_python2.json
@@ -58,7 +58,14 @@
             "isReturnedValue": false, 
             "name": "A file input", 
             "type": "File"
-        }, 
+        },
+        {
+            "id": "file_list_input",
+            "isOptional": true,
+            "isReturnedValue": false,
+            "name": "A file list input",
+            "type": "List"
+        },
         {
             "id": "enum_input", 
             "isOptional": true, 

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_exported_python2.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_exported_python2.json
@@ -58,14 +58,14 @@
             "isReturnedValue": false, 
             "name": "A file input", 
             "type": "File"
-        },
+        }, 
         {
-            "id": "file_list_input",
-            "isOptional": true,
-            "isReturnedValue": false,
-            "name": "A file list input",
+            "id": "file_list_input", 
+            "isOptional": true, 
+            "isReturnedValue": false, 
+            "name": "A file list input", 
             "type": "List"
-        },
+        }, 
         {
             "id": "enum_input", 
             "isOptional": true, 

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_nonutf8.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_nonutf8.json
@@ -1,6 +1,6 @@
 {
     "author": "Test author",
-    "command-line": "exampleTool1_nonutf8.py [CONFIG_FILE] [STRING_INPUT_LIST] [STRING_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [LOG] [INT_LIST_INPUT]",
+    "command-line": "exampleTool1_nonutf8.py [CONFIG_FILE] [STRING_INPUT_LIST] [STRING_INPUT] [FILE_LIST_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [LOG] [INT_LIST_INPUT]",
     "container-image": {
         "container-opts": [
             "-e",
@@ -98,6 +98,15 @@
             "optional": true,
             "type": "File",
             "value-key": "[FILE_INPUT]"
+        },
+        {
+            "command-line-flag": "-t",
+            "id": "file_list_input",
+            "list": true,
+            "name": "A file list input",
+            "optional": true,
+            "type": "File",
+            "value-key": "[FILE_LIST_INPUT]"
         },
         {
             "command-line-flag": "-e",

--- a/tools/python/boutiques/schema/examples/example1/example1_docker_with_doi.json
+++ b/tools/python/boutiques/schema/examples/example1/example1_docker_with_doi.json
@@ -1,6 +1,6 @@
 {
     "author": "Test author",
-    "command-line": "exampleTool1.py [CONFIG_FILE] [STRING_INPUT_LIST] [STRING_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [INT_LIST_INPUT] &> [LOG]",
+    "command-line": "exampleTool1.py [CONFIG_FILE] [STRING_INPUT_LIST] [STRING_INPUT] [FILE_LIST_INPUT] [FLAG_INPUT] [NUMBER_INPUT] [ENUM_INPUT] [FILE_INPUT] [INT_LIST_INPUT] &> [LOG]",
     "container-image": {
         "image": "boutiques/example1:test", 
         "type": "docker"
@@ -86,7 +86,16 @@
             "optional": true, 
             "type": "File", 
             "value-key": "[FILE_INPUT]"
-        }, 
+        },
+        {
+            "command-line-flag": "-t",
+            "id": "file_list_input",
+            "name": "A file list input",
+            "optional": true,
+            "type": "File",
+            "list": true,
+            "value-key": "[FILE_LIST_INPUT]"
+        },
         {
             "command-line-flag": "-e", 
             "id": "enum_input", 

--- a/tools/python/boutiques/schema/examples/example1/exampleTool1.py
+++ b/tools/python/boutiques/schema/examples/example1/exampleTool1.py
@@ -18,6 +18,8 @@ def main(args=None):
                          help='A config file with a number.')
     parser.add_argument('-i', '--string_input', nargs='+', help='One or more strings.')
     parser.add_argument('-l', '--int_input', nargs='+', help='One or more ints.', type=int)
+    parser.add_argument('-t', '--file_list', nargs='+', help='One or more files.',
+                        type=lambda x: file_exists(parser, x))
     parser.add_argument('file', metavar='file_input',
                         type=lambda x: file_exists(parser, x),
                         nargs=1, help='Any existing file.')

--- a/tools/python/boutiques/schema/examples/example1/exampleTool1_nonutf8.py
+++ b/tools/python/boutiques/schema/examples/example1/exampleTool1_nonutf8.py
@@ -23,6 +23,8 @@ def main(args=None):
                         help='A config file with a number.')
     parser.add_argument('-i', '--string_input', nargs='+', help='One or more strings.')
     parser.add_argument('-l', '--int_input', nargs='+', help='One or more ints.', type=int)
+    parser.add_argument('-t', '--file_list', nargs='+', help='One or more files.',
+                        type=lambda x: file_exists(parser, x))
     parser.add_argument('file', metavar='file_input',
                         type=lambda x: file_exists(parser, x),
                         nargs=1, help='Any existing file.')

--- a/tools/python/boutiques/schema/examples/example1/invocation.json
+++ b/tools/python/boutiques/schema/examples/example1/invocation.json
@@ -2,6 +2,7 @@
     "str_input_list" : [ "fo '; echo FAIL", "bar" ],
     "str_input" : "coin;plop",
     "file_input" : "./setup.py",
+    "file_list_input": ["./setup.py", "./requirements.txt"],
     "list_int_input": [1, 2, 3],
     "config_num" : 4,
     "enum_input" : "val1"

--- a/tools/python/boutiques/tests/boutiques_mocks.py
+++ b/tools/python/boutiques/tests/boutiques_mocks.py
@@ -1,4 +1,4 @@
-class MockHttpResponse():
+class MockHttpResponse:
     def __init__(self, status_code, mock_json={}):
         self.status_code = status_code
         self.mock_json = mock_json
@@ -7,13 +7,21 @@ class MockHttpResponse():
         return self.mock_json
 
 
-class MockZenodoRecord():
+class MockZenodoRecord:
     def __init__(self, id, title, description="", filename="", downloads=1):
         self.id = id
         self.title = title
         self.filename = filename
         self.downloads = downloads
         self.description = description
+
+
+# Mock object representing the current version of Example Boutiques Tool
+# on Zenodo
+example_boutiques_tool = MockZenodoRecord(2634310, "Example Boutiques Tool",
+                                          "", "https://zenodo.org/api/files/"
+                                          "009cc264-76f6-459c-a824-"
+                                          "5db6241a979f/example1_docker.json")
 
 
 def mock_zenodo_test_api():

--- a/tools/python/boutiques/tests/test_data_collection.py
+++ b/tools/python/boutiques/tests/test_data_collection.py
@@ -7,16 +7,13 @@ import subprocess
 import pytest
 from boutiques import __file__ as bfile
 from boutiques.localExec import loadJson
-from boutiques_mocks import mock_zenodo_search, MockZenodoRecord
+from boutiques_mocks import mock_zenodo_search, MockZenodoRecord,\
+    example_boutiques_tool
 import boutiques as bosh
 
 
 def mock_get():
-    mock_record = MockZenodoRecord(1472823, "Example Boutiques Tool", "",
-                                   "https://zenodo.org/api/files/"
-                                   "e5628764-fc57-462e-9982-65f8d6fdb487/"
-                                   "example1_docker.json")
-    return mock_zenodo_search([mock_record])
+    return mock_zenodo_search([example_boutiques_tool])
 
 
 def retrieve_data_record():
@@ -120,14 +117,15 @@ class TestDataCollection(TestCase):
     @mock.patch('requests.get', return_value=mock_get())
     def test_read_doi_zenodo(self, mock_get):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")
-        bosh.execute("launch", "zenodo.1472823",
+        bosh.execute("launch", "zenodo." + str(example_boutiques_tool.id),
                      os.path.join(example1_dir,
                                   "invocation.json"))
         data_collect_dict = retrieve_data_record()
 
         summary = data_collect_dict.get("summary")
         self.assertIsNotNone(summary)
-        self.assertEqual(summary.get("descriptor-doi"), "zenodo.1472823")
+        self.assertEqual(summary.get("descriptor-doi"),
+                         "zenodo." + str(example_boutiques_tool.id))
 
         self.clean_up()
 

--- a/tools/python/boutiques/tests/test_evaluate.py
+++ b/tools/python/boutiques/tests/test_evaluate.py
@@ -94,6 +94,7 @@ class TestEvaluate(TestCase):
                   'config_num': 4,
                   'num_input': None,
                   'file_input': './setup.py',
+                  'file_list_input': ['./setup.py', './requirements.txt'],
                   'enum_input': 'val1',
                   'list_int_input': [1, 2, 3],
                   'flag_input': None}

--- a/tools/python/boutiques/tests/test_evaluate.py
+++ b/tools/python/boutiques/tests/test_evaluate.py
@@ -5,15 +5,12 @@ from unittest import TestCase
 from boutiques import __file__ as bfile
 import boutiques as bosh
 import mock
-from boutiques_mocks import mock_zenodo_search, MockZenodoRecord
+from boutiques_mocks import mock_zenodo_search, MockZenodoRecord,\
+    example_boutiques_tool
 
 
 def mock_get():
-    mock_record = MockZenodoRecord(1472823, "Example Boutiques Tool", "",
-                                   "https://zenodo.org/api/files/"
-                                   "e5628764-fc57-462e-9982-65f8d6fdb487/"
-                                   "example1_docker.json")
-    return mock_zenodo_search([mock_record])
+    return mock_zenodo_search([example_boutiques_tool])
 
 
 class TestEvaluate(TestCase):
@@ -34,7 +31,7 @@ class TestEvaluate(TestCase):
     def set_examples_from_zenodo(self):
         example1_dir = os.path.join(os.path.dirname(bfile), "schema",
                                     "examples", "example1")
-        self.desc = "zenodo.1472823"
+        self.desc = "zenodo." + str(example_boutiques_tool.id)
         self.invo = os.path.join(example1_dir, "invocation.json")
 
     def test_evaloutput(self):

--- a/tools/python/boutiques/tests/test_example1.py
+++ b/tools/python/boutiques/tests/test_example1.py
@@ -7,15 +7,12 @@ from boutiques.util.BaseTest import BaseTest
 import boutiques as bosh
 from boutiques.localExec import ExecutorError
 import mock
-from boutiques_mocks import mock_zenodo_search, MockZenodoRecord
+from boutiques_mocks import mock_zenodo_search, MockZenodoRecord,\
+    example_boutiques_tool
 
 
 def mock_get():
-    mock_record = MockZenodoRecord(1472823, "Example Boutiques Tool", "",
-                                   "https://zenodo.org/api/files/"
-                                   "e5628764-fc57-462e-9982-65f8d6fdb487/"
-                                   "example1_docker.json")
-    return mock_zenodo_search([mock_record])
+    return mock_zenodo_search([example_boutiques_tool])
 
 
 class TestExample1(BaseTest):
@@ -150,7 +147,8 @@ class TestExample1(BaseTest):
     @mock.patch('requests.get', return_value=mock_get())
     def test_example1_exec_docker_from_zenodo(self, mock_get):
         self.clean_up()
-        ret = bosh.execute("launch", "zenodo.1472823",
+        ret = bosh.execute("launch",
+                           "zenodo." + str(example_boutiques_tool.id),
                            self.get_file_path("invocation.json"),
                            "--skip-data-collection")
 
@@ -165,7 +163,7 @@ class TestExample1(BaseTest):
 
         self.clean_up()
         self.assert_successful_return(
-            bosh.execute("launch", "zenodo.1472823",
+            bosh.execute("launch", "zenodo." + str(example_boutiques_tool.id),
                          "-x",
                          self.get_file_path("invocation.json"),
                          "--skip-data-collection"),

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -3,19 +3,17 @@ from unittest import TestCase
 from boutiques.puller import ZenodoError
 import os
 import mock
-from boutiques_mocks import mock_zenodo_search, MockZenodoRecord
+from boutiques_mocks import mock_zenodo_search, MockZenodoRecord,\
+    example_boutiques_tool
 
 
 def mock_get(*args, **kwargs):
-    mock_record1 = MockZenodoRecord(1472823, "Example Boutiques Tool", "",
-                                    "https://zenodo.org/api/files/"
-                                    "e5628764-fc57-462e-9982-65f8d6fdb487/"
-                                    "example1_docker.json")
+    mock_record1 = example_boutiques_tool
     mock_record2 = MockZenodoRecord(2587160, "makeblastdb", "",
                                     "https://zenodo.org/api/files/"
                                     "d861b2cd-ec68-4613-9847-1911904a1218/"
                                     "makeblastdb.json")
-    if "1472823" in args[0]:
+    if str(example_boutiques_tool.id) in args[0]:
         return mock_zenodo_search([mock_record1])
     if "2587160" in args[0]:
         return mock_zenodo_search([mock_record2])
@@ -26,30 +24,32 @@ class TestPull(TestCase):
 
     @mock.patch('requests.get', side_effect=mock_get)
     def test_pull(self, mock_get):
-        bosh(["pull", "zenodo.1472823"])
+        bosh(["pull", "zenodo." + str(example_boutiques_tool.id)])
         cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")
-        self.assertTrue(os.path.exists(os.path.join(cache_dir,
-                                                    "zenodo-1472823.json")))
+        self.assertTrue(os.path.exists(os.path.join(
+            cache_dir, "zenodo-" + str(example_boutiques_tool.id) + ".json")))
 
     @mock.patch('requests.get', side_effect=mock_get)
     def test_pull_multi(self, mock_get):
-        results = bosh(["pull", "zenodo.1472823", "zenodo.2587160"])
+        results = bosh(["pull", "zenodo." +
+                        str(example_boutiques_tool.id), "zenodo.2587160"])
         cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")
-        self.assertTrue(os.path.exists(os.path.join(cache_dir,
-                                                    "zenodo-1472823.json")))
+        self.assertTrue(os.path.exists(os.path.join(
+            cache_dir, "zenodo-" + str(example_boutiques_tool.id) + ".json")))
         self.assertTrue(os.path.exists(os.path.join(cache_dir,
                                                     "zenodo-2587160.json")))
         self.assertEqual(len(results), 2, results)
 
     @mock.patch('requests.get', side_effect=mock_get)
     def test_pull_duplicate_collapses(self, mock_get):
-        results = bosh(["pull", "zenodo.1472823", "zenodo.2587160",
+        results = bosh(["pull", "zenodo." +
+                        str(example_boutiques_tool.id), "zenodo.2587160",
                         "zenodo.2587160"])
         self.assertEqual(len(results), 2, results)
 
     @mock.patch('requests.get', side_effect=mock_get)
     def test_pull_missing_raises_exception(self, mock_get):
-        good1 = "zenodo.1472823"
+        good1 = "zenodo." + str(example_boutiques_tool.id)
         good2 = "zenodo.2587160"
         bad1 = "zenodo.9999990"
         with self.assertRaises(ZenodoError) as e:
@@ -61,7 +61,7 @@ class TestPull(TestCase):
     @mock.patch('requests.get', side_effect=mock_get)
     def test_pull_missing_prefix(self, mock_get):
         with self.assertRaises(ZenodoError) as e:
-            bosh(["pull", "1472823"])
+            bosh(["pull", str(example_boutiques_tool.id)])
         self.assertIn("Zenodo ID must be prefixed by 'zenodo'",
                       str(e.exception))
 

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -6,15 +6,12 @@ import json
 from boutiques import __file__ as bfile
 import boutiques as bosh
 import mock
-from boutiques_mocks import mock_zenodo_search, MockZenodoRecord
+from boutiques_mocks import mock_zenodo_search, MockZenodoRecord,\
+    example_boutiques_tool
 
 
 def mock_get():
-    mock_record = MockZenodoRecord(1472823, "Example Boutiques Tool", "",
-                                   "https://zenodo.org/api/files/"
-                                   "e5628764-fc57-462e-9982-65f8d6fdb487/"
-                                   "example1_docker.json")
-    return mock_zenodo_search([mock_record])
+    return mock_zenodo_search([example_boutiques_tool])
 
 
 class TestSimulate(TestCase):
@@ -45,7 +42,9 @@ class TestSimulate(TestCase):
     @mock.patch('requests.get', return_value=mock_get())
     def test_success_desc_from_zenodo(self, mock_get):
         self.assertFalse(bosh.execute("simulate",
-                                      "zenodo.1472823").exit_code)
+                                      "zenodo." +
+                                      str(example_boutiques_tool.id))
+                         .exit_code)
 
     def test_success_default_values(self):
         example1_dir = os.path.join(self.get_examples_dir(), "example1")

--- a/tools/python/boutiques/tests/test_test.py
+++ b/tools/python/boutiques/tests/test_test.py
@@ -8,7 +8,8 @@ from boutiques import bosh
 from jsonschema.exceptions import ValidationError
 import sys
 import mock
-from boutiques_mocks import mock_zenodo_search, MockZenodoRecord
+from boutiques_mocks import mock_zenodo_search, MockZenodoRecord,\
+    example_boutiques_tool
 if sys.version_info < (2, 7):
     from unittest2 import TestCase
 else:
@@ -16,11 +17,7 @@ else:
 
 
 def mock_get():
-    mock_record = MockZenodoRecord(1472823, "Example Boutiques Tool", "",
-                                   "https://zenodo.org/api/files/"
-                                   "e5628764-fc57-462e-9982-65f8d6fdb487/"
-                                   "example1_docker.json")
-    return mock_zenodo_search([mock_record])
+    return mock_zenodo_search([example_boutiques_tool])
 
 
 class TestTest(TestCase):
@@ -48,7 +45,7 @@ class TestTest(TestCase):
     @mock.patch('requests.get', return_value=mock_get())
     def test_test_good_from_zenodo(self, mock_get):
         self.assertFalse(bosh(["test",
-                               "zenodo.1472823"]))
+                               "zenodo." + str(example_boutiques_tool.id)]))
 
     def test_test_invalid(self):
         with self.assertRaises(ValidationError) as context:


### PR DESCRIPTION
Fix for #458.

To test this, added a new input to `example1_docker.json` that takes a list of files. Published a new version of this file on Zenodo: https://zenodo.org/record/2634310. 

