### PR TITLE
Changed bosh search to get and sort all results

### DIFF
--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -4,7 +4,6 @@ import requests
 import sys
 from collections import OrderedDict
 import numbers
-import json
 from operator import itemgetter
 from boutiques.logger import raise_error, print_info
 from boutiques.publisher import ZenodoError
@@ -27,7 +26,7 @@ class Searcher():
         self.no_trunc = no_trunc
         self.max_results = max_results
 
-        # Return max 10 results by default
+        # Display top 10 results by default
         if max_results is None:
             self.max_results = 10
 
@@ -44,18 +43,21 @@ class Searcher():
 
     def search(self):
         results = self.zenodo_search()
+        num_results = len(results.json()["hits"]["hits"])
+        total_results = results.json()["hits"]["total"]
         print_info("Showing %d of %d results."
-                   % (len(results.json()["hits"]["hits"]),
-                      results.json()["hits"]["total"]))
+                   % (num_results if num_results < self.max_results
+                      else self.max_results, total_results))
         if self.verbose:
             return self.create_results_list_verbose(results.json())
         return self.create_results_list(results.json())
 
     def zenodo_search(self):
+        # Get all results
         r = requests.get(self.zenodo_endpoint + '/api/records/?q=%s&'
                          'keywords=boutiques&keywords=schema&'
                          'keywords=version&file_type=json&type=software'
-                         '&page=1&size=%s' % (self.query, self.max_results))
+                         '&page=1&size=%s' % (self.query, 9999))
         if(r.status_code != 200):
             raise_error(ZenodoError, "Error searching Zenodo", r)
         if(self.verbose):
@@ -74,7 +76,8 @@ class Searcher():
             results_list.append(result_dict)
         results_list = sorted(results_list, key=itemgetter('DOWNLOADS'),
                               reverse=True)
-        return results_list
+        # Truncate the list according to the desired maximum number of results
+        return results_list[:self.max_results]
 
     def create_results_list_verbose(self, results):
         results_list = []
@@ -111,7 +114,8 @@ class Searcher():
             results_list.append(result_dict)
         results_list = sorted(results_list, key=itemgetter('DOWNLOADS'),
                               reverse=True)
-        return results_list
+        # Truncate the list according to the desired maximum number of results
+        return results_list[:self.max_results]
 
     def parse_basic_info(self, hit):
         id = "zenodo." + str(hit["id"])


### PR DESCRIPTION
#450 

Set the search to always return a maximum of 9999 results. Right now there are 33 descriptors and I can't imagine we'll ever have so many that this API call will become too slow (maybe one day :stuck_out_tongue:). It then sorts all the results by number of downloads and truncates the results list according to `max_results`. 