### PR TITLE
Added specific error message when trying to update a tool authored by a different user

### DIFF
--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -150,7 +150,12 @@ class Publisher():
                           '/api/deposit/depositions/%s/actions/newversion'
                           % deposition_id,
                           params={'access_token': self.zenodo_access_token})
-        if(r.status_code != 201):
+        if r.status_code == 403:
+            raise_error(ZenodoError, "You do not have permission to access "
+                                     "this resource. Note that you cannot "
+                                     "publish an update to a tool belonging "
+                                     "to someone else.", r)
+        elif(r.status_code != 201):
             raise_error(ZenodoError, "Deposition of new version failed. Check "
                                      "that the Zenodo ID is correct (if one "
                                      "was provided).", r)

--- a/tools/python/boutiques/tests/boutiques_mocks.py
+++ b/tools/python/boutiques/tests/boutiques_mocks.py
@@ -106,3 +106,7 @@ def mock_zenodo_search(mock_records):
         mock_results.append(mock_result)
     mock_json = {"hits": {"hits": mock_results, "total": len(mock_results)}}
     return MockHttpResponse(200, mock_json)
+
+
+def mock_zenodo_no_permission():
+    return MockHttpResponse(403)


### PR DESCRIPTION
#402 

Attempting to update a tool published by a different user results in a 403 (forbidden) error from Zenodo when sending the new deposition. When `bosh publish` sees this 403, it returns an error message telling the user that they do not have permission to access the resource and that they cannot update tools that belong to someone else.

Also removed some test code that didn't make sense anymore now that we use mocks, such as checking that a valid Zenodo token works.