### PR TITLE
Fixed version of docker2singularity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,14 @@ node_js:
 - 5
 
 env:
-- SINGVER=2.4.6
+- SINGVER=2.4.6  # the version of docker2singularity used below should match this one
 
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -y -qq python dh-autoreconf squashfs-tools build-essential
 - npm install jsonlint -g 
 - docker build -t boutiques/example1:test ./tools/python/boutiques/schema/examples/example1
-- docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}:/output --privileged -t --rm singularityware/docker2singularity boutiques/example1:test
+- docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}:/output --privileged -t --rm singularityware/docker2singularity:v2.4 boutiques/example1:test
 - IMGNAME=$(ls $HOME/boutiques_example1_test*.simg)
 - wget https://github.com/singularityware/singularity/releases/download/$SINGVER/singularity-$SINGVER.tar.gz
 - tar xvf singularity-$SINGVER.tar.gz


### PR DESCRIPTION
The version of docker2singularity used in Travis has to be fixed and consistent with the version of Singularity used. Otherwise, the boutiques/example:test image converted from Docker might not work.