### PR TITLE
Singularity mounts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ env:
 
 before_install:
 - sudo apt-get update -qq
-- sudo apt-get install -y -qq python dh-autoreconf squashfs-tools build-essential
+- sudo apt-get install -y -qq python dh-autoreconf squashfs-tools build-essential libarchive-dev
 - npm install jsonlint -g 
 - docker build -t boutiques/example1:test ./tools/python/boutiques/schema/examples/example1
 - docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}:/output --privileged -t --rm singularityware/docker2singularity boutiques/example1:test

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ node_js:
 - 5
 
 env:
-- SINGVER=2.6.1
+- SINGVER=2.6.1  # the version of docker2singularity used below should match this one
 
 before_install:
 - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ node_js:
 - 5
 
 env:
-- SINGVER=2.4.6
+- SINGVER=2.6.1
 
 before_install:
 - sudo apt-get update -qq

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -304,39 +304,7 @@ class LocalExecutor(object):
                     for (key, val) in list(envVars.items()):
                         envString += "SINGULARITYENV_{0}='{1}' ".format(key,
                                                                         val)
-                # TODO: Singularity 2.4.6 default configuration binds: /proc,
-                # /sys, /dev, ${HOME}, /tmp, /var/tmp, /etc/localtime, and
-                # /etc/hosts. This means that any path down-stream shouldn't
-                # be bound on the command-line, as this will currently raise
-                # an exception. See:
-                #   https://github.com/singularityware/singularity/issues/1469
-                #
-                # Previous bind string:
-                #   singularity_mounts = " -B ".join(m for m in mount_strings)
-
-                def_mounts = ["/proc", "/sys", "/dev", "/tmp", "/var/tmp",
-                              "/etc/localtime", "/etc/hosts",
-                              op.realpath(op.expanduser('~')),
-                              op.expanduser('~')]
-
-                # Ensures the set of paths provided has no overlap
-                compaths = list()
-                for idxm, m in enumerate(mount_strings):
-                    for n in mount_strings[idxm:]:
-                        if n != m:
-                            tmp = op.dirname(op.commonprefix([n, m]))
-                            if tmp != '/':
-                                compaths += [tmp]
-                    if not any(m.startswith(c) for c in compaths):
-                        compaths += [m]
-                mount_strings = set(compaths)
-
-                # Only adds mount points for those not already included
-                singularity_mounts = ""
-                for m in mount_strings:
-                    if not any(d in m for d in def_mounts):
-                        singularity_mounts += "-B {0} ".format(m)
-
+                singularity_mounts = " -B ".join(m for m in mount_strings)
                 container_command = (envString + 'singularity exec '
                                      '--cleanenv ' +
                                      singularity_mounts +

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -304,7 +304,7 @@ class LocalExecutor(object):
                     for (key, val) in list(envVars.items()):
                         envString += "SINGULARITYENV_{0}='{1}' ".format(key,
                                                                         val)
-                singularity_mounts = " -B ".join(m for m in mount_strings)
+                singularity_mounts = '-B ' + ' '.join(mount_strings)
                 container_command = (envString + 'singularity exec '
                                      '--cleanenv ' +
                                      singularity_mounts +


### PR DESCRIPTION
#477 

This:
- Updates the version of Singularity used on Travis from 2.4 to 2.6, the version currently used on Compute Canada.
- Removes the complex mount path logic meant to work around sylabs/singularity#1469 that has been fixed in Singularity 2.5. 