### PR TITLE
Pprint fixes#491

### DIFF
--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -16,14 +16,13 @@ class PrettyPrinter():
     def createHelpText(self):
         self.createLUT()
         self.descMetadata()
+        self.parser = ArgumentParser(description=self.helptext,
+                                     formatter_class=RawTextHelpFormatter,
+                                     add_help=False)
 
         # Add container information - if applicable
         if self.desc.get("container-image"):
             self.descContainer()
-
-        # Add output information - if applicable
-        if self.desc.get("output-files"):
-            self.descOutputs()
 
         # Add group information - if applicable
         if self.desc.get("groups"):
@@ -36,6 +35,10 @@ class PrettyPrinter():
         # Add error codes - if applicable
         if self.desc.get("error-codes"):
             self.descErrors()
+
+        # Add output information - if applicable
+        if self.desc.get("output-files"):
+            self.descOutputs()
 
         self.descInputs()
 
@@ -117,8 +120,8 @@ class PrettyPrinter():
                                 "".format("\n\t ".join(
                                                     output["file-template"]
                                                   )))
-            output_info += "\n"
-        self._addSegment(output_info)
+
+        self.parser.epilog = "\n\n{0}\n\n{1}".format(self.sep, output_info)
 
     def descGroups(self):
         groups = self.desc["groups"]
@@ -161,9 +164,6 @@ class PrettyPrinter():
         self._addSegment(ecod_info)
 
     def descInputs(self):
-        self.parser = ArgumentParser(description=self.helptext,
-                                     formatter_class=RawTextHelpFormatter,
-                                     add_help=False)
         inputs = self.CLfields
 
         # For every command-line key (i.e. input)...

--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -294,7 +294,7 @@ class PrettyPrinter():
             inp_kwargs['help'] = textwrap.dedent(inp_descr)
             if inp_descr.split("\n")[4].find("Optional: False") is not -1:
                 required = self.parser.add_argument_group('required arguments')
-                required.add_argument(*inp_args, **inp_kwargs, required=True)
+                required.add_argument(*inp_args, **inp_kwargs)
             else:
                 self.parser.add_argument(*inp_args, **inp_kwargs)
 

--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -290,9 +290,14 @@ class PrettyPrinter():
                                                            )
                 inp_descr += inp_desc_footer
 
-            # Add the newly created argument to parser
-            inp_kwargs['help'] = textwrap.dedent(inp_descr)
-            self.parser.add_argument(*inp_args, **inp_kwargs)
+            # Add the newly created argument to parser depending on optionality
+            if inp_descr.split("\n")[4].find("Optional: False") is not -1:
+                required = self.parser.add_argument_group('required arguments')
+                inp_kwargs['help'] = textwrap.dedent(inp_descr)
+                required.add_argument(*inp_args, **inp_kwargs, required=True)
+            else:
+                inp_kwargs['help'] = textwrap.dedent(inp_descr)
+                self.parser.add_argument(*inp_args, **inp_kwargs)
 
     def _addSegment(self, segment):
         self.helptext += "\n\n{0}\n\n{1}".format(segment, self.sep)

--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -94,33 +94,36 @@ class PrettyPrinter():
     def descOutputs(self):
         outputs = self.desc["output-files"]
         output_info = "Output Files:"
+        config_info = "Config Files:"
         for output in outputs:
             required = "Optional" if output.get("optional") else "Required"
-            output_info += "\n\tName: {0} ({1})".format(output["name"],
-                                                        required)
-            output_info += "\n\tFormat: {0}".format(output["path-template"])
+            temp_info = "\n\tName: {0} ({1})".format(output["name"], required)
+            temp_info += "\n\tFormat: {0}".format(output["path-template"])
 
             # Identifies input dependencies based on filename
             depids = ["/".join(self.lut[inp])
                       for inp in self.lut.keys()
                       if inp in output["path-template"]]
             if depids:
-                output_info += ("\n\tFilename depends on Input IDs: "
-                                "{0}".format(", ".join(depids)))
+                temp_info += ("\n\tFilename depends on Input IDs: "
+                              "{0}".format(", ".join(depids)))
 
             # Gets stripped extensions
             if output.get("path-template-stripped-extensions"):
                 exts = ", ".join(output["path-template-stripped-extensions"])
-                output_info += ("\n\tStripped extensions (before substitution):"
-                                " {0}".format(exts))
+                temp_info += ("\n\tStripped extensions (before substitution):"
+                              " {0}".format(exts))
 
             # If a config file, add the template
             if output.get("file-template"):
-                output_info += ("\n\tTemplate:\n\t {0}"
-                                "".format("\n\t ".join(
-                                                    output["file-template"]
-                                                  )))
+                temp_info += ("\n\tTemplate:\n\t {0}"
+                              "".format("\n\t ".join(output["file-template"])))
+                config_info += temp_info
+            else:
+                output_info += temp_info
 
+        self.parser.epilog = "\n\n{0}\n\n{1}".format(self.sep, config_info) \
+            if config_info is not None else ""
         self.parser.epilog = "\n\n{0}\n\n{1}".format(self.sep, output_info)
 
     def descGroups(self):

--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -291,12 +291,11 @@ class PrettyPrinter():
                 inp_descr += inp_desc_footer
 
             # Add the newly created argument to parser depending on optionality
+            inp_kwargs['help'] = textwrap.dedent(inp_descr)
             if inp_descr.split("\n")[4].find("Optional: False") is not -1:
                 required = self.parser.add_argument_group('required arguments')
-                inp_kwargs['help'] = textwrap.dedent(inp_descr)
                 required.add_argument(*inp_args, **inp_kwargs, required=True)
             else:
-                inp_kwargs['help'] = textwrap.dedent(inp_descr)
                 self.parser.add_argument(*inp_args, **inp_kwargs)
 
     def _addSegment(self, segment):

--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -11,22 +11,16 @@ class PrettyPrinter():
     def __init__(self, descriptor):
         self.sep = "".join(["="] * 80)
         self.desc = descriptor
+        self.epilog = ""
         self.createHelpText()
 
     def createHelpText(self):
         self.createLUT()
         self.descMetadata()
-        self.parser = ArgumentParser(description=self.helptext,
-                                     formatter_class=RawTextHelpFormatter,
-                                     add_help=False)
 
         # Add container information - if applicable
         if self.desc.get("container-image"):
             self.descContainer()
-
-        # Add group information - if applicable
-        if self.desc.get("groups"):
-            self.descGroups()
 
         # Add system requirements - if applicable
         if self.desc.get("suggested-resources"):
@@ -36,12 +30,16 @@ class PrettyPrinter():
         if self.desc.get("error-codes"):
             self.descErrors()
 
+        # Add group information - if applicable
+        if self.desc.get("groups"):
+            self.descGroups()
+
         # Add output information - if applicable
         if self.desc.get("output-files"):
             self.descOutputs()
 
         self.descInputs()
-
+        self.parser.epilog = self.epilog
         self.docstring = self.parser.format_help()
         self.docstring = "\n\n".join(self.docstring.split("\n\n")[1:])
 
@@ -122,9 +120,9 @@ class PrettyPrinter():
             else:
                 output_info += temp_info
 
-        self.parser.epilog = "\n\n{0}\n\n{1}".format(self.sep, config_info) \
+        self.epilog = "\n\n{0}\n\n{1}".format(self.sep, config_info) \
             if config_info is not "Config Files:" else ""
-        self.parser.epilog += "\n\n{0}\n\n{1}".format(self.sep, output_info)
+        self.epilog += "\n\n{0}\n\n{1}".format(self.sep, output_info)
 
     def descGroups(self):
         groups = self.desc["groups"]
@@ -167,6 +165,9 @@ class PrettyPrinter():
         self._addSegment(ecod_info)
 
     def descInputs(self):
+        self.parser = ArgumentParser(description=self.helptext,
+                                     formatter_class=RawTextHelpFormatter,
+                                     add_help=False)
         inputs = self.CLfields
         required = self.parser.add_argument_group('required arguments')
 

--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -97,7 +97,7 @@ class PrettyPrinter():
         config_info = "Config Files:"
         for output in outputs:
             required = "Optional" if output.get("optional") else "Required"
-            temp_info = "\n\tName: {0} ({1})".format(output["name"], required)
+            temp_info = "\n  Name: {0} ({1})".format(output["name"], required)
             temp_info += "\n\tFormat: {0}".format(output["path-template"])
 
             # Identifies input dependencies based on filename
@@ -123,8 +123,8 @@ class PrettyPrinter():
                 output_info += temp_info
 
         self.parser.epilog = "\n\n{0}\n\n{1}".format(self.sep, config_info) \
-            if config_info is not None else ""
-        self.parser.epilog = "\n\n{0}\n\n{1}".format(self.sep, output_info)
+            if config_info is not "Config Files:" else ""
+        self.parser.epilog += "\n\n{0}\n\n{1}".format(self.sep, output_info)
 
     def descGroups(self):
         groups = self.desc["groups"]
@@ -168,6 +168,7 @@ class PrettyPrinter():
 
     def descInputs(self):
         inputs = self.CLfields
+        required = self.parser.add_argument_group('required arguments')
 
         # For every command-line key (i.e. input)...
         for clkey in self.lut.keys():
@@ -314,7 +315,6 @@ class PrettyPrinter():
             # Add args for required inputs
             if req_inp_descr is not "":
                 inp_kwargs['help'] = textwrap.dedent(req_inp_descr)
-                required = self.parser.add_argument_group('required arguments')
                 required.add_argument(*inp_args, **inp_kwargs)
 
             # Add args for optional inputs

--- a/tools/python/boutiques/tests/test_pprint.py
+++ b/tools/python/boutiques/tests/test_pprint.py
@@ -15,3 +15,17 @@ class TestPPrint(TestCase):
                       'schema/examples/test_pretty_print.json')
         prettystring = bosh.prettyprint(fil)
         self.assertIsInstance(prettystring, string_types)
+
+    def test_order(self):
+        fil = op.join(op.split(bfile)[0],
+                      'schema/examples/test_pretty_print.json')
+        prettystring = bosh.prettyprint(fil)
+        i_pos_args = prettystring.index("positional arguments")
+        i_opt_args = prettystring.index("optional arguments")
+        i_req_args = prettystring.index("required arguments")
+        i_conf_fil = prettystring.index("Config Files")
+        i_out_fil = prettystring.index("Output Files")
+        self.assertTrue(i_pos_args < i_opt_args)
+        self.assertTrue(i_opt_args < i_req_args)
+        self.assertTrue(i_req_args < i_conf_fil)
+        self.assertTrue(i_conf_fil < i_out_fil)

--- a/tools/python/boutiques/tests/test_pprint.py
+++ b/tools/python/boutiques/tests/test_pprint.py
@@ -53,3 +53,16 @@ class TestPPrint(TestCase):
         self.assertFalse("Optional: False" in positional_inputs)
         self.assertFalse("Optional: False" in optional_inputs)
         self.assertFalse("Optional: True" in required_inputs)
+
+    def test_output_config_separation(self):
+        self.maxDiff = None
+        fil = op.join(op.split(bfile)[0],
+                      'schema/examples/test_pretty_print.json')
+        prettystring = bosh.prettyprint(fil)
+        categories = prettystring.split("=" * 80)
+        configs = categories[7]
+        outputs = categories[8]
+        self.assertTrue("Config Files:" in configs)
+        self.assertTrue("Template:" in configs)
+        self.assertTrue("Output Files:" in outputs)
+        self.assertFalse("Template:" in outputs)

--- a/tools/python/boutiques/tests/test_pprint.py
+++ b/tools/python/boutiques/tests/test_pprint.py
@@ -16,16 +16,40 @@ class TestPPrint(TestCase):
         prettystring = bosh.prettyprint(fil)
         self.assertIsInstance(prettystring, string_types)
 
-    def test_order(self):
+    def test_categories_and_order(self):
         fil = op.join(op.split(bfile)[0],
                       'schema/examples/test_pretty_print.json')
         prettystring = bosh.prettyprint(fil)
+        i_tl_descs = prettystring.index("Tool name")
+        i_con_info = prettystring.index("Container Information")
+        i_sugg_res = prettystring.index("Suggested Resources")
+        i_er_codes = prettystring.index("Error Codes")
+        i_inp_grps = prettystring.index("Input Groups")
         i_pos_args = prettystring.index("positional arguments")
         i_opt_args = prettystring.index("optional arguments")
         i_req_args = prettystring.index("required arguments")
         i_conf_fil = prettystring.index("Config Files")
-        i_out_fil = prettystring.index("Output Files")
+        i_out_file = prettystring.index("Output Files")
+
+        # Fluff asserts for easy debugging
+        self.assertTrue(i_tl_descs < i_con_info)
+        self.assertTrue(i_con_info < i_sugg_res)
+        self.assertTrue(i_sugg_res < i_er_codes)
+        self.assertTrue(i_er_codes < i_inp_grps)
+        self.assertTrue(i_inp_grps < i_pos_args)
         self.assertTrue(i_pos_args < i_opt_args)
         self.assertTrue(i_opt_args < i_req_args)
         self.assertTrue(i_req_args < i_conf_fil)
-        self.assertTrue(i_conf_fil < i_out_fil)
+        self.assertTrue(i_conf_fil < i_out_file)
+
+    def test_input_optionality_separation(self):
+        fil = op.join(op.split(bfile)[0],
+                      'schema/examples/test_pretty_print.json')
+        prettystring = bosh.prettyprint(fil)
+        inputs = prettystring.split("=" * 80)[6].split("arguments:")
+        positional_inputs = inputs[1]
+        optional_inputs = inputs[2]
+        required_inputs = inputs[3]
+        self.assertFalse("Optional: False" in positional_inputs)
+        self.assertFalse("Optional: False" in optional_inputs)
+        self.assertFalse("Optional: True" in required_inputs)


### PR DESCRIPTION
Required input arguments (if present) are separated from optional ones. Required arguments were grouped with optional arguments but have the parameter "Optional" at False.
```
=========================================
positional arguments:
  [...]
optional arguments:
  [...]
required arguments:
  [...]
=========================================
```
Config files are listed separate from the output files & output files are listed last. Config files were printed 3rd and had config files listed under output files.
```
=========================================
Config Files:
  Name: [...]
=========================================
Output Files:
  Name: [...]
```