### PR TITLE
Improved output substitution

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -936,9 +936,10 @@ class LocalExecutor(object):
                         self.safeGet(param_id, 'type') == 'String'):
                     for extension in stripped_extensions:
                         val = val.replace(extension, '')
-                    # Remove path if not the first item in the template for
-                    # output files specifically
-                    if template.find(clk) > 0 and is_output:
+                    # Remove path if a) a file, b) not the first item in the
+                    # template; for output files specifically
+                    if (self.safeGet(param_id, 'type') == 'File' and
+                        template.find(clk) > 0 and is_output):
                         val = op.basename(val)
                 # Here val can be a number so we need to cast it
                 if val is not None and val is not "":

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -939,7 +939,7 @@ class LocalExecutor(object):
                     # Remove path if a) a file, b) not the first item in the
                     # template; for output files specifically
                     if (self.safeGet(param_id, 'type') == 'File' and
-                        template.find(clk) > 0 and is_output):
+                       template.find(clk) > 0 and is_output):
                         val = op.basename(val)
                 # Here val can be a number so we need to cast it
                 if val is not None and val is not "":

--- a/tools/python/boutiques/schema/examples/example3/example3.json
+++ b/tools/python/boutiques/schema/examples/example3/example3.json
@@ -1,11 +1,10 @@
 {
-    "command-line": "echo '[STRING_INPUT]' &> [LOG]",
-    "description": "This property describes the tool or application",
+    "command-line": "echo '[STRING_INPUT]' [FILE_INPUT] &> [LOG]",
     "container-image": {
-        "image": "ubuntu:latest", 
+        "image": "ubuntu:latest",
         "type": "docker"
     },
-    "shell": "/bin/bash",
+    "description": "This property describes the tool or application",
     "inputs": [
         {
             "default-value": "aStringValue",
@@ -17,6 +16,14 @@
             "name": "A string input",
             "type": "String",
             "value-key": "[STRING_INPUT]"
+        },
+        {
+            "default-value": "/path/to/a/FileValue.txt",
+            "description": "Describe the use and meaning of the parameter",
+            "id": "file_input",
+            "name": "A file input",
+            "type": "File",
+            "value-key": "[FILE_INPUT]"
         }
     ],
     "invocation-schema": {
@@ -38,7 +45,8 @@
             }
         },
         "required": [
-            "str_input"
+            "str_input",
+            "file_input"
         ],
         "title": "Example Boutiques Tool.invocationSchema",
         "type": "object"
@@ -49,7 +57,7 @@
             "description": "The output log file from the example tool",
             "id": "logfile",
             "name": "Log file",
-            "path-template": "log.txt",
+            "path-template": "log-[FILE_INPUT].txt",
             "path-template-stripped-extensions": [
                 ".txt",
                 ".csv"
@@ -58,5 +66,6 @@
         }
     ],
     "schema-version": "0.5",
+    "shell": "/bin/bash",
     "tool-version": "0.0.1"
 }

--- a/tools/python/boutiques/tests/test_example3.py
+++ b/tools/python/boutiques/tests/test_example3.py
@@ -16,3 +16,9 @@ class TestExample3(BaseTest):
                          self.get_file_path("invocation.json"),
                          "--skip-data-collection"),
             aditional_assertions=self.assert_no_output)
+
+    def test_example3_filepathrenaming(self):
+        self.assertEquals(bosh.evaluate(self.get_file_path("example3.json"),
+                                        self.get_file_path("invocation.json"),
+                                        "output-files/"),
+                          {'logfile': 'log-FileValue.txt'})

--- a/tools/python/cleanup_tests.sh
+++ b/tools/python/cleanup_tests.sh
@@ -9,7 +9,7 @@ rm -r temp-*.sh log*.txt config*.txt file.txt creator_output.json \
       test-created-argparse-descriptor.json test-created-argparse-inputs.json \
       .pytest_cache/ bar.dat baz.txt cwl_inv_out.json cwl_out.json \
       example.conf foo.txt goodbye.txt hello.js hello.tar stdout.txt \
-      output-dir boutiques/tests/test-data-cache
+      output-dir boutiques/tests/test-data-cache subdir1/subdir2/config.txt
 git checkout boutiques/schema/examples/good.json
 git checkout boutiques/schema/examples/example1/example1_docker.json
 git checkout boutiques/schema/examples/example1/example1_sing.json

--- a/tools/python/config.txt
+++ b/tools/python/config.txt
@@ -1,3 +1,0 @@
-# This is a demo configuration file
-numInput=4
-strInput=str_str_input_kz

--- a/tools/python/subdir1/subdir2/config.txt
+++ b/tools/python/subdir1/subdir2/config.txt
@@ -1,3 +1,0 @@
-# This is a demo configuration file
-numInput=4
-strInput=str_str_input_Qe


### PR DESCRIPTION
Addresses #397 

Previous behaviour:
- No truncation of values beyond stripping file extensions

Current behaviour:
- For `output-files` which contain `value-key` substitutions: inputs of `type="File"` used for these substitutions that do not *start* the `path-template` (i.e. `template.find(value-key)` does not return location `0`) will be modified to only insert the `os.path.basename` of the value, rather than the complete path.