### PR TITLE
Bexample return error #529

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -763,7 +763,6 @@ class LocalExecutor(object):
             # Fill in all possible optional inputs
             opts = [p for p in self.inputs if
                     self.safeGet(p['id'], 'optional') in [None, True]]
-            random.shuffle(opts)
             # Loop a random number of times, each time
             #  attempting to fill a random parameter
             for option in opts:

--- a/tools/python/boutiques/tests/test_example.py
+++ b/tools/python/boutiques/tests/test_example.py
@@ -21,10 +21,8 @@ class TestExample(TestCase):
                                    stdout=subprocess.PIPE)
         output = json.loads(process.stdout.read())
 
-        self.assertTrue("a1" in output or "a2" in output)
-        self.assertTrue("a2" in output or "b2" in output)
+        self.assertTrue(("a1" in output and "b2" in output) or "a2" in output)
         self.assertIn("b1", output)
-        self.assertIn("b2", output)
         self.assertIn("c1", output)
         self.assertIn("c2", output)
         self.assertIn("d1", output)

--- a/tools/python/boutiques/tests/test_example.py
+++ b/tools/python/boutiques/tests/test_example.py
@@ -21,10 +21,14 @@ class TestExample(TestCase):
                                    stdout=subprocess.PIPE)
         output = json.loads(process.stdout.read())
 
-        self.assertDictEqual({"a1": "a1",
-                              "b1": "b1", "b2": "b2",
-                              "c1": "c1", "c2": "c2",
-                              "d1": True, "d2": True}, output)
+        self.assertTrue("a1" in output or "a2" in output)
+        self.assertTrue("a2" in output or "b2" in output)
+        self.assertIn("b1", output)
+        self.assertIn("b2", output)
+        self.assertIn("c1", output)
+        self.assertIn("c2", output)
+        self.assertIn("d1", output)
+        self.assertIn("d2", output)
 
     def test_example_required_only(self):
         descriptor = op.join(op.split(bfile)[0], 'schema/examples/'

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -181,5 +181,5 @@ class TestSimulate(TestCase):
                                    stdout=subprocess.PIPE)
         output = str(process.stdout.read())
         command = re.search(r"(test[ \da-z]+)", output).group(0)
-        
+
         self.assertNotIn("  ", command)

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -169,7 +169,7 @@ class TestSimulate(TestCase):
         output = str(process.stdout.read())
         command = re.search(r"(test[ \da-z]+)", output).group(0)
 
-        self.assertEqual("test a1 b1 b2 c1 c2", command)
+        self.assertNotIn("  ", command)
 
     def test_collapsing_whitespace_requireds(self):
         descriptor = os.path.join(os.path.split(bfile)[0],
@@ -181,4 +181,5 @@ class TestSimulate(TestCase):
                                    stdout=subprocess.PIPE)
         output = str(process.stdout.read())
         command = re.search(r"(test[ \da-z]+)", output).group(0)
-        self.assertEqual("test b1 c2", command)
+        
+        self.assertNotIn("  ", command)

--- a/tools/python/config.txt
+++ b/tools/python/config.txt
@@ -1,0 +1,3 @@
+# This is a demo configuration file
+numInput=4
+strInput=str_str_input_Zf


### PR DESCRIPTION
Bug caused by optional inputs being added before group restrictions are checked. (#529)

#### Before
```
~$ bosh example boutiques/schema/examples/tests_good.json -c
An error occurred in validation
Previously saved issues
        Input num_input should be disabled by flag_input
[ ERROR ] Problems found with prospective input:
        Input num_input should be disabled by flag_input
```

#### After
```
~$ bosh example boutiques/schema/examples/tests_good.json -c
{
    "config_num": 4,
    "file_input": "f_file_input_15.mnc",
    "list_int_input": [
        46,
        -38,
        45
    ],
    "num_input": 0.264,
    "str_input": "str_str_input_Zf",
    "str_input_list": [
        "str_str_input_list_MM",
        "str_str_input_list_mX",
        "str_str_input_list_5a"
    ]
}
```