### PR TITLE
Zenodo search query support empty string

### DIFF
--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -13,7 +13,7 @@ class Searcher():
 
     def __init__(self, query, verbose=False, sandbox=False, max_results=None,
                  no_trunc=False, exact_match=False):
-        if query is not None:
+        if len(query or '') > 0 :
             self.query = query
         else:
             self.query = 'boutiques'

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -13,7 +13,7 @@ class Searcher():
 
     def __init__(self, query, verbose=False, sandbox=False, max_results=None,
                  no_trunc=False, exact_match=False):
-        if len(query or '') > 0 :
+        if len(query or '') > 0:
             self.query = query
         else:
             self.query = 'boutiques'


### PR DESCRIPTION
This fixes the query string in searcher when an empty string was passed to the function.
Since '' is different than None the empty string remained and the request query string was **~ resulting in something like ...?q=**&keyword...`. A 500 Error was returned by Zenodo.