### PR TITLE
Freeze base image used in example1 to CentOS7

### DIFF
--- a/tools/python/boutiques/schema/examples/example1/Dockerfile
+++ b/tools/python/boutiques/schema/examples/example1/Dockerfile
@@ -1,3 +1,3 @@
-from centos
+from centos:7
 ADD exampleTool1.py /bin
 ADD exampleTool1_nonutf8.py /bin


### PR DESCRIPTION
Tests involving `example1.json` are failing because Docker image `centos:latest` is now CentOS8, and the CentOS8 Docker image doesn't come with a Python interpreter. This freezes the Docker image used in `example1.json` to CentOS7.