### PR TITLE
pprint fix for duplicate flags

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -31,7 +31,6 @@ def prettyprint(*params):
     from boutiques.prettyprint import PrettyPrinter
     desc = loadJson(results.descriptor)
     prettyclass = PrettyPrinter(desc)
-
     return prettyclass.docstring
 
 

--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -326,7 +326,6 @@ class PrettyPrinter():
                 for i in range(0, len(parsed_flags)):
                     if "_DUP" in parsed_flags[i]:
                         parsed_flags[i] = parsed_flags[i][0:-5]
-                print(parsed_flags)
                 if inp_args[0] in parsed_flags:
                     inp_args[0] = "{0}_DUP{1}".format(
                         inp_args[0], parsed_flags.count(inp_args[0]))

--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -3,6 +3,7 @@
 from argparse import ArgumentParser, RawTextHelpFormatter
 from tabulate import tabulate
 import textwrap
+import simplejson as json
 
 
 class PrettyPrinter():
@@ -321,6 +322,14 @@ class PrettyPrinter():
             # Add args for optional inputs
             if opt_inp_descr is not "":
                 inp_kwargs['help'] = textwrap.dedent(opt_inp_descr)
+                parsed_flags = list(self.parser._option_string_actions.keys())
+                for i in range(0, len(parsed_flags)):
+                    if "_DUP" in parsed_flags[i]:
+                        parsed_flags[i] = parsed_flags[i][0:-5]
+                print(parsed_flags)
+                if inp_args[0] in parsed_flags:
+                    inp_args[0] = "{0}_DUP{1}".format(
+                        inp_args[0], parsed_flags.count(inp_args[0]))
                 self.parser.add_argument(*inp_args, **inp_kwargs)
 
     def _addSegment(self, segment):

--- a/tools/python/boutiques/schema/examples/good_dupFlags.json
+++ b/tools/python/boutiques/schema/examples/good_dupFlags.json
@@ -1,0 +1,50 @@
+{
+    "author": "Test author",
+    "command-line": "test [PARAM1] [FLAG1] [FLAG2] [FLAG3]",
+    "container-image": {
+        "image": "boutiques/example1:test",
+        "type": "docker"
+    },
+    "description": "Tests duplicate flags for pprint.",
+    "inputs": [
+        {
+            "description": "A file",
+            "id": "input",
+            "name": "Input File",
+            "optional": true,
+            "type": "File",
+            "value-key": "[PARAM1]"
+        },
+        {
+            "command-line-flag": "-duplicate",
+            "description": "A flag",
+            "id": "flag1",
+            "name": "Flag 1",
+            "optional": true,
+            "type": "Flag",
+            "value-key": "[FLAG1]"
+        },
+        {
+            "command-line-flag": "-duplicate",
+            "description": "A number",
+            "id": "number1",
+            "name": "Number 1",
+            "optional": true,
+            "type": "Number",
+            "value-key": "[FLAG2]"
+        },
+        {
+            "command-line-flag": "-duplicate",
+            "description": "A string",
+            "id": "string1",
+            "name": "String 1",
+            "optional": true,
+            "type": "String",
+            "value-key": "[FLAG3]"
+        }
+    ],
+    "name": "Example Boutiques Tool",
+    "schema-version": "0.5",
+    "tool-doi": "00.0000/example.0000000",
+    "tool-version": "0.0.1"
+}

--- a/tools/python/boutiques/tests/test_pprint.py
+++ b/tools/python/boutiques/tests/test_pprint.py
@@ -66,3 +66,11 @@ class TestPPrint(TestCase):
         self.assertTrue("Template:" in configs)
         self.assertTrue("Output Files:" in outputs)
         self.assertFalse("Template:" in outputs)
+
+    def test_duplcate_flags(self):
+        fil = op.join(op.split(bfile)[0],
+                      'schema/examples/good_dupFlags.json')
+        prettystring = bosh.prettyprint(fil)
+        self.assertIn("-duplicate", prettystring)
+        self.assertIn("-duplicate_DUP1", prettystring)
+        self.assertIn("-duplicate_DUP2", prettystring)


### PR DESCRIPTION
name: "descriptor2func can't handle duplicate command-line flags"
about: pprint error when there are duplicate flags in a valid descriptor
title: 'Bug fix for issue #548 #516 '

## Related issues
#548 #516
<!-- List the issue(s) that are addressed by this PR -->

## Purpose
<!--- A clear and concise description of what the PR does. -->
Fixed failing execution for pprint (in descriptor2func.py) descriptor contains duplicate flags even if descriptor can be executed by bosh.

## Current behaviour
<!--- Tell us what currently happens -->
```
File "boutiques/tools/python/boutiques/prettyprint.py", line 325, in descInputs
    self.parser.add_argument(*inp_args, **inp_kwargs)
[...]
argparse.ArgumentError: argument -duplicate: conflicting option string: -duplicate
```

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
```
positional arguments:
  [PARAM1]              ID: input
                        Value Key: [PARAM1]
                        Type: File
                        List: False
                        Optional: True
                        Description: A file

optional arguments:
  -duplicate [FLAG1]    ID: flag1
                        Value Key: [FLAG1]
                        Type: Flag
                        List: False
                        Optional: True
                        Description: A flag
  -duplicate_DUP1 [FLAG2]
                        ID: number1
                        Value Key: [FLAG2]
                        Type: Number
                        List: False
                        Optional: True
                        Integer: False
                        Range: [N/A, N/A]
                        Description: A number
  -duplicate_DUP2 [FLAG3]
                        ID: string1
                        Value Key: [FLAG3]
                        Type: String
                        List: False
                        Optional: True
                        Description: A string
```

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
naming scheme for duplicate flags: ```[FLAG]_DUP[OCCURENCE+1]```
