### PR TITLE
Fixed #522

### DIFF
--- a/tools/python/boutiques/tests/boutiques_mocks.py
+++ b/tools/python/boutiques/tests/boutiques_mocks.py
@@ -18,7 +18,7 @@ class MockZenodoRecord:
 
 # Mock object representing the current version of Example Boutiques Tool
 # on Zenodo
-example_boutiques_tool = MockZenodoRecord(2634310, "Example Boutiques Tool",
+example_boutiques_tool = MockZenodoRecord(2644621, "Example Boutiques Tool",
                                           "", "https://zenodo.org/api/files/"
                                           "009cc264-76f6-459c-a824-"
                                           "5db6241a979f/example1_docker.json")

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -18,6 +18,7 @@ except ImportError:
     from urllib2 import urlopen
     from urllib import urlretrieve
 
+
 def mock_urlretrieve(*args, **kwargs):
     print "ARGHH!"
     mock_record1 = example_boutiques_tool

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -29,11 +29,11 @@ def mock_urlretrieve(*args, **kwargs):
     if str(example_boutiques_tool.id) in args[0]:
         json.dump(mock_zenodo_search([mock_record1]).mock_json, temp)
         temp.close()
-        return urlretrieve(temp.name, args[1])
+        return urlretrieve("file://%s" % temp.name, args[1])
     if "makeblastdb.json" in args[0]:
         json.dump(mock_zenodo_search([mock_record2]).mock_json, temp)
         temp.close()
-        return urlretrieve(temp.name, args[1])
+        return urlretrieve("file://%s" % temp.name, args[1])
     return urlretrieve(args[0], args[1])
 
 

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -25,7 +25,7 @@ def mock_urlretrieve(*args, **kwargs):
                                     "https://zenodo.org/api/files/"
                                     "d861b2cd-ec68-4613-9847-1911904a1218/"
                                     "makeblastdb.json")
-    temp = tempfile.NamedTemporaryFile(delete=False)
+    temp = tempfile.NamedTemporaryFile(delete=False, mode='w+t')
     if str(example_boutiques_tool.id) in args[0]:
         json.dump(mock_zenodo_search([mock_record1]).mock_json, temp)
         temp.close()

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -3,34 +3,56 @@ from unittest import TestCase
 from boutiques.puller import ZenodoError
 import os
 import mock
+import tempfile
+import json
+
 from boutiques_mocks import mock_zenodo_search, MockZenodoRecord,\
     example_boutiques_tool
 
+try:
+    # Python 3
+    from urllib.request import urlopen
+    from urllib.request import urlretrieve
+except ImportError:
+    # Python 2
+    from urllib2 import urlopen
+    from urllib import urlretrieve
 
-def mock_get(*args, **kwargs):
+def mock_urlretrieve(*args, **kwargs):
+    print "ARGHH!"
     mock_record1 = example_boutiques_tool
-    mock_record2 = MockZenodoRecord(2587160, "makeblastdb", "",
+    mock_record2 = MockZenodoRecord(2587160, "makeblastdb_foo", "",
                                     "https://zenodo.org/api/files/"
                                     "d861b2cd-ec68-4613-9847-1911904a1218/"
                                     "makeblastdb.json")
+    print args[0]
+    temp = tempfile.NamedTemporaryFile(delete=False)
+    print temp.name
     if str(example_boutiques_tool.id) in args[0]:
-        return mock_zenodo_search([mock_record1])
-    if "2587160" in args[0]:
-        return mock_zenodo_search([mock_record2])
-    return mock_zenodo_search([])
+        json.dump(mock_zenodo_search([mock_record1]).mock_json, temp)
+        temp.close()
+        return urlretrieve(temp.name, args[1])
+    if "makeblastdb.json" in args[0]:
+        json.dump(mock_zenodo_search([mock_record2]).mock_json, temp)
+        temp.close()
+        myurl = urlretrieve(temp.name, args[1])
+        print myurl
+        return myurl
+    return urlretrieve(args[0], args[1])
 
 
 class TestPull(TestCase):
 
-    @mock.patch('requests.get', side_effect=mock_get)
-    def test_pull(self, mock_get):
+    @mock.patch('boutiques.puller.urlretrieve', side_effect=mock_urlretrieve)
+    def test_pull(self, mock_urlretrieve):
         bosh(["pull", "zenodo." + str(example_boutiques_tool.id)])
         cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")
         self.assertTrue(os.path.exists(os.path.join(
             cache_dir, "zenodo-" + str(example_boutiques_tool.id) + ".json")))
 
-    @mock.patch('requests.get', side_effect=mock_get)
-    def test_pull_multi(self, mock_get):
+    @mock.patch('boutiques.puller.urlretrieve', side_effect=mock_urlretrieve)
+    def test_pull_multi(self, mock_urlretrieve):
+        print "TEST"
         results = bosh(["pull", "zenodo." +
                         str(example_boutiques_tool.id), "zenodo.2587160"])
         cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")
@@ -40,15 +62,15 @@ class TestPull(TestCase):
                                                     "zenodo-2587160.json")))
         self.assertEqual(len(results), 2, results)
 
-    @mock.patch('requests.get', side_effect=mock_get)
-    def test_pull_duplicate_collapses(self, mock_get):
+    @mock.patch('boutiques.puller.urlretrieve', side_effect=mock_urlretrieve)
+    def test_pull_duplicate_collapses(self, mock_urlretrieve):
         results = bosh(["pull", "zenodo." +
                         str(example_boutiques_tool.id), "zenodo.2587160",
                         "zenodo.2587160"])
         self.assertEqual(len(results), 2, results)
 
-    @mock.patch('requests.get', side_effect=mock_get)
-    def test_pull_missing_raises_exception(self, mock_get):
+    @mock.patch('boutiques.puller.urlretrieve', side_effect=mock_urlretrieve)
+    def test_pull_missing_raises_exception(self, mock_urlretrieve):
         good1 = "zenodo." + str(example_boutiques_tool.id)
         good2 = "zenodo.2587160"
         bad1 = "zenodo.9999990"
@@ -58,15 +80,15 @@ class TestPull(TestCase):
             bad1.split(".")[1]),
             str(e.exception))
 
-    @mock.patch('requests.get', side_effect=mock_get)
-    def test_pull_missing_prefix(self, mock_get):
+    @mock.patch('boutiques.puller.urlretrieve', side_effect=mock_urlretrieve)
+    def test_pull_missing_prefix(self, mock_urlretrieve):
         with self.assertRaises(ZenodoError) as e:
             bosh(["pull", str(example_boutiques_tool.id)])
         self.assertIn("Zenodo ID must be prefixed by 'zenodo'",
                       str(e.exception))
 
-    @mock.patch('requests.get', side_effect=mock_get)
-    def test_pull_not_found(self, mock_get):
+    @mock.patch('boutiques.puller.urlretrieve', side_effect=mock_urlretrieve)
+    def test_pull_not_found(self, mock_urlretrieve):
         with self.assertRaises(ZenodoError) as e:
             bosh(["pull", "zenodo.99999"])
         self.assertIn("Descriptor \"{0}\" not found".format("99999"),

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -20,15 +20,12 @@ except ImportError:
 
 
 def mock_urlretrieve(*args, **kwargs):
-    print "ARGHH!"
     mock_record1 = example_boutiques_tool
     mock_record2 = MockZenodoRecord(2587160, "makeblastdb_foo", "",
                                     "https://zenodo.org/api/files/"
                                     "d861b2cd-ec68-4613-9847-1911904a1218/"
                                     "makeblastdb.json")
-    print args[0]
     temp = tempfile.NamedTemporaryFile(delete=False)
-    print temp.name
     if str(example_boutiques_tool.id) in args[0]:
         json.dump(mock_zenodo_search([mock_record1]).mock_json, temp)
         temp.close()
@@ -36,9 +33,7 @@ def mock_urlretrieve(*args, **kwargs):
     if "makeblastdb.json" in args[0]:
         json.dump(mock_zenodo_search([mock_record2]).mock_json, temp)
         temp.close()
-        myurl = urlretrieve(temp.name, args[1])
-        print myurl
-        return myurl
+        return urlretrieve(temp.name, args[1])
     return urlretrieve(args[0], args[1])
 
 
@@ -53,7 +48,6 @@ class TestPull(TestCase):
 
     @mock.patch('boutiques.puller.urlretrieve', side_effect=mock_urlretrieve)
     def test_pull_multi(self, mock_urlretrieve):
-        print "TEST"
         results = bosh(["pull", "zenodo." +
                         str(example_boutiques_tool.id), "zenodo.2587160"])
         cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")


### PR DESCRIPTION
---
name: makeblastdb
about: Changed the mock.patch to mock urlretrieve, which was actually used 
title: 'Bug fix for issue #522 '
labels: enhancement


---

## Related issues
 - The wrong thing was being mocked, and it wasn't being patched properly anyway.
 - There seemed to be a change in the current example-tool version that was causing some test failure, so I changed it to use the newest id.

## Checklist
<!--- Make sure to check the following items -->
- Since this is a fix in the tests,  not the core codebase, I can confirm the fixed tests
- I am dubious about the changes to the example descriptor...

## Purpose
- This fixes a test so that makeblastdb will stop getting inflated numbers on zenodo

## Current behaviour
The makeblastdb entry on zenodo is downloaded every time while testing.

## New behaviour
A mock descriptor for makeblastdb is now used.
 
#### Does this introduce a major change?
- [ ] Yes
- [ x] No

## Implementation Detail
I switched to patching boutiques.puller.urlretrieve. I created a temp file with the desired content and called the actual urlretrieve on the local file to imitate the result of calling on a url. It gets cached just the same.
