### PR TITLE
Fixed #553

### DIFF
--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -17,14 +17,20 @@ class Searcher():
         if query is not None:
             self.query = query
             if not exact_match:
-                self.query_line = \
-                    ' AND keywords:(/.*%s.*/)' % self.query
+                terms = self.query.split(" ")
+                self.query_line = ''
+                for t in terms:
+                    self.query_line = self.query_line + \
+                        ' AND keywords:(/.*%s.*/)' % t
             else:
-                self.query_line = \
-                    ' AND keywords:(/%s/)' % self.query
+                self.query_line =\
+                        ' AND keywords:(/%s/)' % self.query
         else:
             self.query_line = ''
             self.query = ''
+
+        if(verbose):
+            print_info("Using Query Line: " + self.query_line)
 
         self.verbose = verbose
         self.sandbox = sandbox

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -54,10 +54,12 @@ class Searcher():
 
     def zenodo_search(self):
         # Get all results
-        r = requests.get(self.zenodo_endpoint + '/api/records/?q=%s&'
-                         'keywords=boutiques&keywords=schema&'
-                         'keywords=version&file_type=json&type=software'
-                         '&page=1&size=%s' % (self.query, 9999))
+        r = requests.get(self.zenodo_endpoint + '/api/records/?q='
+                         'keywords:(/Boutiques/) AND '
+                         'keywords:(/schema-version.*/) AND '
+                         'keywords:(/.*%s.*/)&'
+                         'file_type=json&type=software&'
+                         'page=1&size=%s' % (self.query, 9999))
         if(r.status_code != 200):
             raise_error(ZenodoError, "Error searching Zenodo", r)
         if(self.verbose):

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -14,7 +14,7 @@ class Searcher():
     def __init__(self, query, verbose=False, sandbox=False, max_results=None,
                  no_trunc=False, exact_match=False):
 
-        if self.query is not None:
+        if query is not None:
             self.query = query
             if not exact_match:
                 self.query_line = \

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -13,13 +13,18 @@ class Searcher():
 
     def __init__(self, query, verbose=False, sandbox=False, max_results=None,
                  no_trunc=False, exact_match=False):
-        if query is not None:
-            self.query = query
-        else:
-            self.query = 'boutiques'
 
-        if not exact_match:
-            self.query = '*' + self.query + '*'
+        if self.query is not None:
+            self.query = query
+            if not exact_match:
+                self.query_line = \
+                    ' AND keywords:(/.*%s.*/)' % self.query
+            else:
+                self.query_line = \
+                    ' AND keywords:(/%s/)' % self.query
+        else:
+            self.query_line = ''
+            self.query = ''
 
         self.verbose = verbose
         self.sandbox = sandbox
@@ -56,10 +61,10 @@ class Searcher():
         # Get all results
         r = requests.get(self.zenodo_endpoint + '/api/records/?q='
                          'keywords:(/Boutiques/) AND '
-                         'keywords:(/schema-version.*/) AND '
-                         'keywords:(/.*%s.*/)&'
-                         'file_type=json&type=software&'
-                         'page=1&size=%s' % (self.query, 9999))
+                         'keywords:(/schema-version.*/)'
+                         '%s'
+                         '&file_type=json&type=software&'
+                         'page=1&size=%s' % (self.query_line, 9999))
         if(r.status_code != 200):
             raise_error(ZenodoError, "Error searching Zenodo", r)
         if(self.verbose):


### PR DESCRIPTION

---
name: #553 
about: I changed the way the records api was queries in searcher
title: 'Bug fix for issue #553'

---

## Checklist
<!--- Make sure to check the following items -->
- [x ] **DO** Unit tests pass. /well, as much as they pass on my [dev docker](https://hub.docker.com/r/ramou/boutiques_test_env)

## Purpose
This replaces the old query approach with one that appears consistent with the very limited documentation (and it now works)

## Current behaviour
It seems that Zenodo updated things Oct. 30 (https://github.com/zenodo/zenodo/commit/9e95b2893c509bddc52a9ee8acc1dd24e72a721b) and I think this represents their having deployed a bunch of updates, some of which related to bringing their ElasticSearch up to date, which may have caused what we were doing previously to break.

## New behaviour
Things should now work as they used to.
 
#### Does this introduce a major change?
- [ ] Yes
- [ x] No

## Implementation Detail
I swtiched to putting all the keyword queries inline according to the ElasticSearch query syntax. I moved the query-string formatting earlier in the code. I kinda don't like that and think maybe I should turn self.query into a list of terms, with the exact term just being the unsplit query and build query_line just before using it... but I have a meeting and this fixes an immediate problem well enough.

The biggest difference is that this does not send query terms to anything other than keyword fields. I don't know what was intended by the last version, but this is now more exact. It means it won't search authors, for example. If I had a better idea what was desired, we could do that, though I had trouble specifically accessing stuff other than the keywords field, but I think that's just a matter of me getting used to ES.