### PR TITLE
Travis pyyaml py3.4

### DIFF
--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -14,7 +14,8 @@ DEPS = [
          "requests",
          "pytest",
          "termcolor",
-         "pyyaml",
+         "pyyaml==5.2; python_version == '3.4'",
+         "pyyaml; python_version != '3.4'"
          "jsonschema",
          "tabulate",
          "mock",

--- a/tools/python/setup.py
+++ b/tools/python/setup.py
@@ -15,7 +15,7 @@ DEPS = [
          "pytest",
          "termcolor",
          "pyyaml==5.2; python_version == '3.4'",
-         "pyyaml; python_version != '3.4'"
+         "pyyaml; python_version != '3.4'",
          "jsonschema",
          "tabulate",
          "mock",


### PR DESCRIPTION
---
name: Fix travis for Python 3.4 jobs
title: Bug fix for issue #571 
---

Specify PyYAML for python version 3.4 because PyYAML dropped support for Py3.4