### PR TITLE
Missing doc for `bosh import dcpt`

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -297,9 +297,9 @@ execute.__doc__ += parser_executePrepare().format_help()
 
 def parser_importer():
     parser = ArgumentParser("Imports old descriptor or BIDS app or CWL"
-                            " descriptor to spec.")
+                            " descriptor or docopt script to spec.")
     parser.add_argument("type", help="Type of import we are performing."
-                        "Allowed values: {" +
+                        " Allowed values: {" +
                         ", ".join(["bids", "0.4", "cwl", "docopt"]) + "}",
                         choices=["bids", "0.4", "cwl", "docopt"],
                         metavar='type')

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -760,7 +760,7 @@ TOOL CREATION
 * create: create a Boutiques descriptor from scratch.
 * export: export a descriptor to other formats.
 * import: create a descriptor for a BIDS app or update a descriptor from \
-an older version of the schema.
+an older version of the schema. Options: "bids", "0.4", "cwl", "docopt"
 * validate: validate an existing boutiques descriptor.
 
 TOOL USAGE & EXECUTION

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -299,12 +299,12 @@ def parser_importer():
     parser = ArgumentParser("Imports old descriptor or BIDS app or CWL"
                             " descriptor to spec.")
     parser.add_argument("type", help="Type of import we are performing",
-                        choices=["bids", "0.4", "cwl", "dcpt"])
+                        choices=["bids", "0.4", "cwl", "docopt"])
     parser.add_argument("output_descriptor", help="Where the Boutiques"
                         " descriptor will be written.")
     parser.add_argument("input_descriptor", help="Input descriptor to be"
                         " converted. For '0.4', is JSON descriptor,"
-                        " for 'dcpt' is JSON descriptor,"
+                        " for 'docopt' is JSON descriptor,"
                         " for 'bids' is base directory of BIDS app,"
                         " for 'cwl' is YAML descriptor.")
     parser.add_argument("-o", "--output-invocation", help="Where to write "
@@ -329,7 +329,7 @@ def importer(*params):
         importer.import_bids()
     elif results.type == "cwl":
         importer.import_cwl()
-    elif results.type == "dcpt":
+    elif results.type == "docopt":
         create(params[1])
         importer.import_docopt(params[1])
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -298,8 +298,11 @@ execute.__doc__ += parser_executePrepare().format_help()
 def parser_importer():
     parser = ArgumentParser("Imports old descriptor or BIDS app or CWL"
                             " descriptor to spec.")
-    parser.add_argument("type", help="Type of import we are performing",
-                        choices=["bids", "0.4", "cwl", "docopt"])
+    parser.add_argument("type", help="Type of import we are performing."
+                        "Allowed values: {" +
+                        ", ".join(["bids", "0.4", "cwl", "docopt"]) + "}",
+                        choices=["bids", "0.4", "cwl", "docopt"],
+                        metavar='type')
     parser.add_argument("output_descriptor", help="Where the Boutiques"
                         " descriptor will be written.")
     parser.add_argument("input_descriptor", help="Input descriptor to be"

--- a/tools/python/boutiques/importer.py
+++ b/tools/python/boutiques/importer.py
@@ -128,17 +128,17 @@ class Importer():
         docstring = imp.load_source(
             'docopt_pyscript', self.input_descriptor).__doc__
 
-        dcptImptr = Docopt_Importer(docstring, template_file)
+        docoptImporter = Docopt_Importer(docstring, template_file)
         # The order matters
-        dcptImptr.loadDocoptDescription()
-        dcptImptr.loadDescriptionAndType()
-        dcptImptr.generateInputsAndCommandLine(dcptImptr.pattern)
-        dcptImptr.addInputsRecursive(dcptImptr.dependencies)
-        dcptImptr.determineOptionality()
-        dcptImptr.createRootOneIsRequiredGroup()
+        docoptImporter.loadDocoptDescription()
+        docoptImporter.loadDescriptionAndType()
+        docoptImporter.generateInputsAndCommandLine(docoptImporter.pattern)
+        docoptImporter.addInputsRecursive(docoptImporter.dependencies)
+        docoptImporter.determineOptionality()
+        docoptImporter.createRootOneIsRequiredGroup()
 
         with open(self.output_descriptor, "w") as output:
-            output.write(json.dumps(dcptImptr.descriptor, indent=4))
+            output.write(json.dumps(docoptImporter.descriptor, indent=4))
 
     def import_bids(self):
         path, fil = os.path.split(__file__)

--- a/tools/python/boutiques/tests/test_import.py
+++ b/tools/python/boutiques/tests/test_import.py
@@ -142,7 +142,7 @@ class TestImport(TestCase):
         pydocopt_input = op.join(base_path, "test_valid.py")
         descriptor_output = op.join(base_path, "test_valid_output.json")
 
-        import_args = ["import", "dcpt", descriptor_output, pydocopt_input]
+        import_args = ["import", "docopt", descriptor_output, pydocopt_input]
         bosh(import_args)
 
         test_invocation = op.join(base_path, "valid_invoc_mutex.json")
@@ -156,7 +156,7 @@ class TestImport(TestCase):
         pydocopt_input = op.join(base_path, "test_options.py")
         descriptor_output = op.join(base_path, "test_options_output.json")
 
-        import_args = ["import", "dcpt", descriptor_output, pydocopt_input]
+        import_args = ["import", "docopt", descriptor_output, pydocopt_input]
         bosh(import_args)
 
         test_invocation = op.join(base_path, "test_options_invocation.json")
@@ -170,7 +170,7 @@ class TestImport(TestCase):
         pydocopt_input = op.join(base_path, "test_invalid.py")
         descriptor_output = op.join(base_path, "foobar.json")
 
-        args = ["import", "dcpt", descriptor_output, pydocopt_input]
+        args = ["import", "docopt", descriptor_output, pydocopt_input]
 
         with pytest.raises(ImportError, match="Invalid docopt script"):
             bosh(args)
@@ -185,7 +185,7 @@ class TestImport(TestCase):
         pydocopt_input = op.join(base_path, "naval_fate.py")
         descriptor_output = op.join(base_path, "naval_fate_descriptor.json")
 
-        import_args = ["import", "dcpt", descriptor_output, pydocopt_input]
+        import_args = ["import", "docopt", descriptor_output, pydocopt_input]
         bosh(import_args)
 
         test_invocation = op.join(base_path, "nf_invoc_new.json")


### PR DESCRIPTION
---
name: Missing doc for `bosh import dcpt`
about: Clarification of help text
title: Bug fix for issue #579
labels: bug
---
## Purpose
<!--- A clear and concise description of what the PR does. -->
Clarify `bosh` & `bosh import`'s help text.

## Changes
Renamed `dcpt` to `docopt` in `bosh import` and modified help text + refactored accordingly.
Added list of available options in the help text of `bosh -h`

## Previous Behaviour
```
usage: Imports old descriptor or BIDS app or CWL descriptor to spec.
       [-h] [-o OUTPUT_INVOCATION] [-i INPUT_INVOCATION]
       {bids,0.4,cwl,dcpt} output_descriptor input_descriptor

positional arguments:
  {bids,0.4,cwl,dcpt}   Type of import we are performing
```

## New Behaviour
```
usage: Imports old descriptor or BIDS app or CWL descriptor or docopt script to spec.
       [-h] [-o OUTPUT_INVOCATION] [-i INPUT_INVOCATION]
       type output_descriptor input_descriptor

positional arguments:
  type                  Type of import we are performing. Allowed values:
                        {bids, 0.4, cwl, docopt}
```
