### PR TITLE
Improve desc invoc outputs

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -18,7 +18,7 @@ from boutiques.localExec import ExecutorError
 from boutiques.exporter import ExportError
 from boutiques.importer import ImportError
 from boutiques.localExec import addDefaultValues
-from boutiques.util.utils import loadJson
+from boutiques.util.utils import loadJson, customSortInvocationByInput
 from boutiques.logger import raise_error
 from tabulate import tabulate
 
@@ -252,7 +252,9 @@ def execute(*params):
             executor.generateRandomParams(1)
 
         if results.json:
-            sout = [json.dumps(executor.in_dict, indent=4, sort_keys=True)]
+            sout = [json.dumps(
+                customSortInvocationByInput(executor.in_dict, descriptor),
+                indent=4)]
             print(sout[0])
         else:
             executor.printCmdLine()
@@ -450,7 +452,7 @@ def invocation(*params):
         if result.write_schema:
             descriptor["invocation-schema"] = invSchema
             with open(result.descriptor, "w") as f:
-                f.write(json.dumps(descriptor, indent=4, sort_keys=True))
+                f.write(json.dumps(descriptor, indent=4))
     if result.invocation:
         from boutiques.invocationSchemaHandler import validateSchema
         data = addDefaultValues(descriptor, loadJson(result.invocation))
@@ -601,7 +603,8 @@ def example(*params):
                               "skipDataCollect": True,
                               "requireComplete": results.complete})
     executor.generateRandomParams(1)
-    return json.dumps(executor.in_dict, indent=4, sort_keys=True)
+    return json.dumps(
+        customSortInvocationByInput(executor.in_dict, descriptor), indent=4)
 
 
 example.__doc__ = parser_example().format_help()

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -299,9 +299,12 @@ execute.__doc__ += parser_executePrepare().format_help()
 
 def parser_importer():
     parser = ArgumentParser("Imports old descriptor or BIDS app or CWL"
-                            " descriptor to spec.")
-    parser.add_argument("type", help="Type of import we are performing",
-                        choices=["bids", "0.4", "cwl", "dcpt"])
+                            " descriptor or docopt script to spec.")
+    parser.add_argument("type", help="Type of import we are performing."
+                        " Allowed values: {" +
+                        ", ".join(["bids", "0.4", "cwl", "docopt"]) + "}",
+                        choices=["bids", "0.4", "cwl", "docopt"],
+                        metavar='type')
     parser.add_argument("output_descriptor", help="Where the Boutiques"
                         " descriptor will be written.")
     parser.add_argument("input_descriptor", help="Input descriptor to be"

--- a/tools/python/boutiques/creator.py
+++ b/tools/python/boutiques/creator.py
@@ -10,6 +10,7 @@ from jsonschema import validate, ValidationError
 from argparse import ArgumentParser
 from boutiques import __file__ as bfile
 from boutiques.logger import raise_error, print_info, print_warning
+from boutiques.util.utils import customSortDescriptorByKey
 import subprocess
 
 
@@ -44,7 +45,8 @@ class CreateDescriptor(object):
 
     def save(self, filename):
         with open(filename, "w") as f:
-            f.write(json.dumps(self.descriptor, indent=4, sort_keys=True))
+            f.write(json.dumps(
+                customSortDescriptorByKey(self.descriptor), indent=4))
 
     def createInvocation(self, arguments):
         argdict = vars(arguments)

--- a/tools/python/boutiques/importer.py
+++ b/tools/python/boutiques/importer.py
@@ -3,7 +3,8 @@
 from argparse import ArgumentParser
 from jsonschema import ValidationError
 from boutiques.validator import validate_descriptor
-from boutiques.util.utils import loadJson
+from boutiques.util.utils import loadJson, customSortDescriptorByKey
+from boutiques.util.utils import customSortInvocationByInput
 from boutiques.logger import raise_error
 import boutiques
 import yaml
@@ -91,7 +92,8 @@ class Importer():
             del descriptor["walltime-estimate"]
 
         with open(self.output_descriptor, 'w') as fhandle:
-            fhandle.write(json.dumps(descriptor, indent=4, sort_keys=True))
+            fhandle.write(json.dumps(
+                customSortDescriptorByKey(descriptor), indent=4))
         validate_descriptor(self.output_descriptor)
 
     def get_entry_point(self, input_descriptor):
@@ -419,7 +421,8 @@ class Importer():
 
         # Write descriptor
         with open(self.output_descriptor, 'w') as f:
-            f.write(json.dumps(bout_desc, indent=4, sort_keys=True))
+            f.write(json.dumps(
+                customSortDescriptorByKey(bout_desc), indent=4))
         validate_descriptor(self.output_descriptor)
 
         if self.input_invocation is None:
@@ -441,7 +444,8 @@ class Importer():
                 input_value = cwl_inputs[input_name]['path']
             boutiques_invocation[input_name] = input_value
         with open(self.output_invocation, 'w') as f:
-            f.write(json.dumps(boutiques_invocation, indent=4, sort_keys=True))
+            f.write(json.dumps(customSortInvocationByInput(
+                    boutiques_invocation, json.dumps(bout_desc)), indent=4))
         boutiques.invocation(self.output_descriptor,
                              "-i", self.output_invocation)
 

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -156,8 +156,7 @@ class Publisher():
             self.zenodo_access_token, deposition_id, "Descriptor")
         self.descriptor['doi'] = self.doi
         with open(self.descriptor_file_name, "w") as f:
-            f.write(json.dumps(
-                 customSortDescriptorByKey(self.descriptor), indent=4))
+            f.write(json.dumps(self.descriptor, indent=4))
 
     def create_metadata(self):
         data = {

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -3,6 +3,7 @@
 from boutiques.validator import validate_descriptor, ValidationError
 from boutiques.logger import raise_error, print_info
 from boutiques.zenodoHelper import ZenodoError, ZenodoHelper
+from boutiques.util.utils import customSortDescriptorByKey
 import simplejson as json
 import requests
 import os
@@ -149,7 +150,8 @@ class Publisher():
             self.zenodo_access_token, deposition_id, "Descriptor")
         self.descriptor['doi'] = self.doi
         with open(self.descriptor_file_name, "w") as f:
-            f.write(json.dumps(self.descriptor, indent=4, sort_keys=True))
+            f.write(json.dumps(
+                 customSortDescriptorByKey(self.descriptor), indent=4))
 
     def create_metadata(self):
         data = {

--- a/tools/python/boutiques/templates/ordered_keys_desc.json
+++ b/tools/python/boutiques/templates/ordered_keys_desc.json
@@ -1,0 +1,63 @@
+{
+    "name": "", 
+    "tool-version": "",
+    "command-line": "", 
+    "shell": "",
+    "description": "",
+    "groups": [
+        {
+            "all-or-none": true,
+            "mutually-exclusive": true,
+            "one-is-required": true,
+            "id": "",
+            "name": "",
+            "members": []
+        }
+    ],
+    "inputs": [
+        {
+            "command-line-flag": "",
+            "id": "",
+            "name": "",
+            "type": "",
+            "list": true,
+            "integer": true,
+            "optional": true,
+            "value-key": "",
+            "value-choices": [],
+            "requires-inputs": []
+
+        }
+    ],
+    "output-files": [
+        {
+            "id": "",
+            "name": "",
+            "optional": false,
+            "path-template": "",
+            "optional-path-template": {},
+            "path-template-stripped-extensions": [],
+            "value-key": ""
+        }
+    ],
+    "container-image": {
+        "image": "",
+        "index": "",
+        "type": ""
+    },
+    "suggested-resources": {
+        "cpu-cores": 0,
+        "ram": 0,
+        "walltime-estimate": 0
+    },
+    "error-codes": [
+        {
+            "code": 0,
+            "description": ""
+        }
+    ],
+    "tags": {
+        "purpose": "",
+        "status": ""
+    }
+}

--- a/tools/python/boutiques/templates/ordered_keys_desc.json
+++ b/tools/python/boutiques/templates/ordered_keys_desc.json
@@ -1,28 +1,28 @@
 {
-    "name": "", 
-    "tool-version": "",
-    "command-line": "", 
-    "shell": "",
+    "name": "",
+    "author": "",
     "description": "",
-    "groups": [
-        {
-            "all-or-none": true,
-            "mutually-exclusive": true,
-            "one-is-required": true,
-            "id": "",
-            "name": "",
-            "members": []
-        }
-    ],
+    "descriptor-url": "",
+    "tool-version": "",
+    "schema-version": "",
+    "command-line": "",
+    "shell": "",
+    "container-image": {
+        "image": "",
+        "index": "",
+        "type": ""
+    },
     "inputs": [
         {
-            "command-line-flag": "",
-            "id": "",
             "name": "",
+            "id": "",
+            "description": "",
             "type": "",
             "list": true,
             "integer": true,
             "optional": true,
+            "default-value": "",
+            "command-line-flag": "",
             "value-key": "",
             "value-choices": [],
             "requires-inputs": []
@@ -31,19 +31,31 @@
     ],
     "output-files": [
         {
-            "id": "",
             "name": "",
+            "id": "",
+            "description": "",
+            "list": false,
             "optional": false,
             "path-template": "",
-            "optional-path-template": {},
+            "conditional-path-template": {},
             "path-template-stripped-extensions": [],
             "value-key": ""
         }
     ],
-    "container-image": {
-        "image": "",
-        "index": "",
-        "type": ""
+    "groups": [
+        {
+            "all-or-none": true,
+            "mutually-exclusive": true,
+            "one-is-required": true,
+            "name": "",
+            "id": "",
+            "members": []
+        }
+    ],
+    "tags": {
+        "domain": "",
+        "status": "",
+        "purpose": ""
     },
     "suggested-resources": {
         "cpu-cores": 0,
@@ -56,8 +68,5 @@
             "description": ""
         }
     ],
-    "tags": {
-        "purpose": "",
-        "status": ""
-    }
+    "custom": {}
 }

--- a/tools/python/boutiques/tests/test_import.py
+++ b/tools/python/boutiques/tests/test_import.py
@@ -23,7 +23,8 @@ class TestImport(TestCase):
     @pytest.fixture(scope='session', autouse=True)
     def clean_up(self):
         yield
-        os.remove("user-image.simg")
+        if os.path.isfile("user-image.simg"):
+            os.remove("user-image.simg")
 
     def test_import_bids_good(self):
         bids_app = opj(op.split(bfile)[0],
@@ -59,9 +60,10 @@ class TestImport(TestCase):
         if op.isfile(fout):
             os.remove(fout)
         self.assertFalse(bosh(["import", "0.4",  fout, fin]))
-        result = open(fout, "U").read().strip()
-        self.assertIn(result, [open(ref_file, "U").read().strip(),
-                               open(ref_file_p2, "U").read().strip()])
+        result = json.loads(open(fout, "U").read().strip())
+        self.assertIn(result,
+                      [json.loads(open(ref_file, "U").read().strip()),
+                       json.loads(open(ref_file_p2, "U").read().strip())])
         os.remove(fout)
 
     def test_upgrade_04_json_obj(self):
@@ -76,9 +78,10 @@ class TestImport(TestCase):
         if op.isfile(fout):
             os.remove(fout)
         self.assertFalse(bosh(["import", "0.4",  fout, fin]))
-        result = open(fout, "U").read().strip()
-        self.assertIn(result, [open(ref_file, "U").read().strip(),
-                               open(ref_file_p2, "U").read().strip()])
+        result = json.loads(open(fout, "U").read().strip())
+        self.assertIn(result,
+                      [json.loads(open(ref_file, "U").read().strip()),
+                       json.loads(open(ref_file_p2, "U").read().strip())])
         os.remove(fout)
 
     def test_import_cwl_valid(self):

--- a/tools/python/boutiques/util/utils.py
+++ b/tools/python/boutiques/util/utils.py
@@ -1,6 +1,7 @@
 import os
 import simplejson as json
 from boutiques.logger import raise_error
+from boutiques import __file__ as bfile
 
 
 # Parses absolute path into filename
@@ -63,3 +64,19 @@ def conditionalExpFormat(s):
             cleanedExpression += c
         idx += 1
     return cleanedExpression
+
+
+# Recursively sorts and returns a descriptor dictionary according to
+# the keys' order in a template descriptor
+def customSortDescriptorByKey(descriptor,
+                              template=os.path.join(
+                                  os.path.dirname(bfile),
+                                  "templates",
+                                  "ordered_keys_desc.json")):
+    template = loadJson(template)
+    # Add k:v to sortedDesc according to their order in template
+    sortedDesc = {key: descriptor[key] for key in template if
+                  key in descriptor}
+    # Add remaining k:v that are missing from template
+    sortedDesc.update(descriptor)
+    return sortedDesc

--- a/tools/python/boutiques/util/utils.py
+++ b/tools/python/boutiques/util/utils.py
@@ -66,7 +66,7 @@ def conditionalExpFormat(s):
     return cleanedExpression
 
 
-# Recursively sorts and returns a descriptor dictionary according to
+# Sorts and returns a descriptor dictionary according to
 # the keys' order in a template descriptor
 def customSortDescriptorByKey(descriptor,
                               template=os.path.join(
@@ -110,7 +110,7 @@ def customSortDescriptorByKey(descriptor,
     return sortedDesc
 
 
-# Recursively sorts tool invocations according to descriptor's inputs'
+# Sorts tool invocations according to descriptor's inputs'
 def customSortInvocationByInput(invocation, descriptor):
     descriptor = loadJson(descriptor)
     try:

--- a/tools/python/boutiques/util/utils.py
+++ b/tools/python/boutiques/util/utils.py
@@ -1,6 +1,6 @@
 import os
 import simplejson as json
-from boutiques.logger import raise_error
+from boutiques.logger import raise_error, print_warning
 from boutiques import __file__ as bfile
 
 
@@ -86,6 +86,8 @@ def customSortDescriptorByKey(descriptor,
             return objList
         for obj, sobj in zip(objList, sortedObjList):
             if obj != sobj:
+                print_warning("Sorted list does not represent"
+                              " original list.")
                 return objList
         return sortedObjList
 
@@ -102,6 +104,8 @@ def customSortDescriptorByKey(descriptor,
     # Add remaining k:v that are missing from template
     sortedDesc.update(descriptor)
     if sortedDesc != descriptor:
+        print_warning("Sorted descriptor does not represent"
+                      " original descriptor.")
         return descriptor
     return sortedDesc
 
@@ -115,5 +119,7 @@ def customSortInvocationByInput(invocation, descriptor):
                     if descriptor['inputs'] is not None]
                    if key in invocation}
     if sortedInvoc != invocation:
+        print_warning("Sorted invocation does not represent"
+                      " original invocation.")
         return invocation
     return sortedInvoc

--- a/tools/python/boutiques/util/utils.py
+++ b/tools/python/boutiques/util/utils.py
@@ -82,15 +82,11 @@ def customSortDescriptorByKey(descriptor,
             sortedObj.update(obj)
             sortedObjList.append(sortedObj)
 
-        # Safety: return original if sortedObjList is faulty
-        try:
-            for obj, sobj in zip(objList, sortedObjList):
-                if obj != sobj:
-                    sortedObjList = objList
-                    break
-        except Exception:
-            print("[ERROR] Sorted list does not represent original list.")
+        if len(objList) != len(sortedObjList):
             return objList
+        for obj, sobj in zip(objList, sortedObjList):
+            if obj != sobj:
+                return objList
         return sortedObjList
 
     template = loadJson(template)
@@ -113,16 +109,11 @@ def customSortDescriptorByKey(descriptor,
 # Sorts tool invocations according to descriptor's inputs'
 def customSortInvocationByInput(invocation, descriptor):
     descriptor = loadJson(descriptor)
-    try:
-        # sort invoc according to input's order in decsriptor
-        sortedInvoc = {key: invocation[key] for key in
-                       [inp['id'] for inp in descriptor['inputs']
-                        if descriptor['inputs'] is not None]
-                       if key in invocation}
-        if sortedInvoc != invocation:
-            return invocation
-    except Exception:
-        print("[ERROR] Sorted invocation does not"
-              " represent original invocation")
+    # sort invoc according to input's order in decsriptor
+    sortedInvoc = {key: invocation[key] for key in
+                   [inp['id'] for inp in descriptor['inputs']
+                    if descriptor['inputs'] is not None]
+                   if key in invocation}
+    if sortedInvoc != invocation:
         return invocation
     return sortedInvoc

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -8,6 +8,7 @@ from jsonschema import validate, ValidationError
 from argparse import ArgumentParser
 from boutiques import __file__ as bfile
 from boutiques.util.utils import loadJson, conditionalExpFormat
+from boutiques.util.utils import customSortDescriptorByKey
 from boutiques.logger import raise_error, print_info
 
 
@@ -507,7 +508,8 @@ def validate_descriptor(json_file, **kwargs):
     if errors is None:
         if kwargs.get('format_output'):
             with open(json_file, 'w') as fhandle:
-                fhandle.write(json.dumps(descriptor, indent=4, sort_keys=True))
+                fhandle.write(json.dumps(
+                    customSortDescriptorByKey(descriptor), indent=4))
         return descriptor
     else:
         raise DescriptorValidationError("\n".join(errors))


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#480 #520 

## Purpose
<!--- A clear and concise description of what the PR does. -->
Keep the preferred ordering of arguments to adhere to the principle of the least user astonishment. While ordering might be useful it is not what most users would expect, and obscure the fact that there is actual semantic change (added property).

## Current behaviour
<!--- Tell us what currently happens -->
Most descriptor/invocation outputs are alphabetically sorted.

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
Keep the preferred ordering of arguments according to a template or the original descriptor. 
Keep ordering of invocations according to the inputs of a descriptor.


## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Custom sort for descriptor: defaults to ordering given by _tools/python/boutiques/templates/ordered_keys_desc.json_
Custom sort for invocation: no default, all set to order by input descriptor.

