### PR TITLE
Zenodo cache dir

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -27,6 +27,9 @@ def parser_pprint():
     parser = ArgumentParser("Boutiques pretty-print for generating help text")
     parser.add_argument("descriptor", action="store",
                         help="The Boutiques descriptor.")
+    parser.add_argument("--sandbox", action="store_true",
+                        help="Get descriptor from Zenodo's sandbox instead of "
+                        "production server.")
     return parser
 
 
@@ -35,7 +38,7 @@ def pprint(*params):
     results = parser.parse_args(params)
 
     from boutiques.prettyprint import PrettyPrinter
-    desc = loadJson(results.descriptor)
+    desc = loadJson(results.descriptor, sandbox=results.sandbox)
     prettyclass = PrettyPrinter(desc)
     return prettyclass.docstring
 

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -83,6 +83,9 @@ def parser_validate():
     parser.add_argument("--format", "-f", action="store_true",
                         help="If descriptor is valid, rewrite it with sorted"
                         " keys.")
+    parser.add_argument("--sandbox", action="store_true",
+                        help="Get descriptor from Zenodo's sandbox instead of "
+                        "production server.")
     return parser
 
 
@@ -92,7 +95,8 @@ def validate(*params):
 
     from boutiques.validator import validate_descriptor
     descriptor = validate_descriptor(results.descriptor,
-                                     format_output=results.format)
+                                     format_output=results.format,
+                                     sandbox=results.sandbox)
     if results.bids:
         from boutiques.bids import validate_bids
         validate_bids(descriptor, valid=True)
@@ -151,6 +155,9 @@ def parser_executeLaunch():
                         help="Launch invocation on the host computer, with "
                         "no container. If 'container-image' appears in the "
                         "descriptor, it is ignored.")
+    parser.add_argument("--sandbox", action="store_true",
+                        help="Get descriptor from Zenodo's sandbox instead of "
+                        "production server.")
     force_group = parser.add_mutually_exclusive_group()
     force_group.add_argument("--force-docker", action="store_true",
                              help="Tries to run Singularity images with "
@@ -173,6 +180,9 @@ def parser_executeSimulate():
                         help="Flag to generate invocation in JSON format.")
     parser.add_argument("-c", "--complete", action="store_true",
                         help="Include optional parameters.")
+    parser.add_argument("--sandbox", action="store_true",
+                        help="Get descriptor from Zenodo's sandbox instead of "
+                        "production server.")
     return parser
 
 
@@ -192,6 +202,9 @@ def parser_executePrepare():
     parser.add_argument("--imagepath", action="store",
                         help="Path to Singularity image. "
                         "If not specified, will use current directory.")
+    parser.add_argument("--sandbox", action="store_true",
+                        help="Get descriptor from Zenodo's sandbox instead of "
+                        "production server.")
     return parser
 
 
@@ -355,6 +368,9 @@ def parser_exporter():
     parser.add_argument("descriptor", help="Boutiques descriptor to export.")
     parser.add_argument("--identifier", help="Identifier to use in"
                                              "CARMIN export.")
+    parser.add_argument("--sandbox", action="store_true",
+                        help="Get descriptor from Zenodo's sandbox instead of "
+                        "production server.")
     parser.add_argument("output", help="Output file where to write the"
                         " converted descriptor.")
     return parser
@@ -445,14 +461,17 @@ def parser_invocation():
                         help="If descriptor doesn't have an invocation "
                         "schema, creates one and writes it to the descriptor"
                         " file ")
+    parser.add_argument("--sandbox", action="store_true",
+                        help="Get descriptor from Zenodo's sandbox instead of "
+                        "production server.")
     return parser
 
 
 def invocation(*params):
     parser = parser_invocation()
     result = parser.parse_args(params)
-    validate(result.descriptor)
-    descriptor = loadJson(result.descriptor)
+    validate(result.descriptor, "--sandbox")
+    descriptor = loadJson(result.descriptor, sandbox=result.sandbox)
     if descriptor.get("invocation-schema"):
         invSchema = descriptor.get("invocation-schema")
     else:
@@ -593,6 +612,9 @@ def parser_example():
                         "JSON string or Zenodo ID (prefixed by 'zenodo.').")
     parser.add_argument("-c", "--complete", action="store_true",
                         help="Include optional parameters.")
+    parser.add_argument("--sandbox", action="store_true",
+                        help="Get descriptor from Zenodo's sandbox instead of "
+                        "production server.")
     return parser
 
 
@@ -601,7 +623,7 @@ def example(*params):
     results = parser.parse_args(params)
 
     descriptor = results.descriptor
-    valid = invocation(descriptor)
+    valid = invocation(descriptor, "--sandbox")
 
     # Generate object that will perform the commands
     from boutiques.localExec import LocalExecutor

--- a/tools/python/boutiques/exporter.py
+++ b/tools/python/boutiques/exporter.py
@@ -13,9 +13,10 @@ class ExportError(Exception):
 
 class Exporter():
 
-    def __init__(self, descriptor, identifier):
+    def __init__(self, descriptor, identifier, sandbox=False):
         self.descriptor = descriptor
         self.identifier = identifier
+        self.sandbox = sandbox
 
     def convert_type(self, boutiques_type, is_integer=False, is_list=False):
         if is_list:
@@ -48,7 +49,7 @@ class Exporter():
 
     def carmin(self, output_file):
         carmin_desc = {}
-        descriptor = loadJson(self.descriptor)
+        descriptor = loadJson(self.descriptor, sandbox=self.sandbox)
 
         if descriptor.get('doi'):
             self.identifier = descriptor.get('doi')

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -147,7 +147,7 @@ class LocalExecutor(object):
             setattr(self, option, options.get(option))
 
         # Parse JSON descriptor
-        self.desc_dict = loadJson(desc, self.debug)
+        self.desc_dict = loadJson(desc, self.debug, sandbox=self.sandbox)
 
         # Set the shell
         self.shell = self.desc_dict.get("shell")
@@ -922,8 +922,10 @@ class LocalExecutor(object):
                 print_info("Input: " + str(self.in_dict))
             # Check results (as much as possible)
             try:
-                boutiques.invocation(
-                    self.desc_path, "-i", json.dumps(self.in_dict))
+                args = [self.desc_path, "-i", json.dumps(self.in_dict)]
+                if self.sandbox:
+                    args.append("--sandbox")
+                boutiques.invocation(*args)
             # If an error occurs, print out the problems already
             # encountered before blowing up
             except Exception as e:  # Avoid BaseExceptions like SystemExit
@@ -966,7 +968,10 @@ class LocalExecutor(object):
         addDefaultValues(self.desc_dict, self.in_dict)
         # Check results (as much as possible)
         try:
-            boutiques.invocation(self.desc_path, "-i", json.dumps(self.in_dict))
+            args = [self.desc_path, "-i", json.dumps(self.in_dict)]
+            if self.sandbox:
+                args.append("--sandbox")
+            boutiques.invocation(*args)
         except Exception:  # Avoid catching BaseExceptions like SystemExit
             sys.stderr.write("An error occurred in validation\n"
                              "Previously saved issues\n")

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -20,8 +20,9 @@ class Puller():
     def __init__(self, zids, verbose=False, sandbox=False):
         # remove zenodo prefix
         self.zenodo_entries = []
-        self.cache_dir = os.path.join(os.path.expanduser('~'), ".cache",
-                                      "boutiques")
+        self.cache_dir = os.path.join(
+            os.path.expanduser('~'), ".cache", "boutiques",
+            "sandbox" if sandbox else "production")
         discarded_zids = zids
         # This removes duplicates, should maintain order
         zids = list(dict.fromkeys(zids))

--- a/tools/python/boutiques/tests/test_example.py
+++ b/tools/python/boutiques/tests/test_example.py
@@ -48,7 +48,8 @@ class TestExample(TestCase):
                                   "destroyTempScripts": True,
                                   "changeUser": True,
                                   "skipDataCollect": True,
-                                  "requireComplete": True})
+                                  "requireComplete": True,
+                                  "sandbox": False})
 
         # Can't create descriptors with mutex group but only one valid example
         # Bosh example is inherently random,

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -50,7 +50,8 @@ class TestPull(TestCase):
     def test_pull_multi(self, mock_urlretrieve):
         results = bosh(["pull", "zenodo." +
                         str(example_boutiques_tool.id), "zenodo.2587160"])
-        cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")
+        cache_dir = os.path.join(os.path.expanduser('~'),
+                                 ".cache", "boutiques", "production")
         self.assertTrue(os.path.exists(os.path.join(
             cache_dir, "zenodo-" + str(example_boutiques_tool.id) + ".json")))
         self.assertTrue(os.path.exists(os.path.join(cache_dir,

--- a/tools/python/boutiques/tests/test_pull.py
+++ b/tools/python/boutiques/tests/test_pull.py
@@ -42,7 +42,8 @@ class TestPull(TestCase):
     @mock.patch('boutiques.puller.urlretrieve', side_effect=mock_urlretrieve)
     def test_pull(self, mock_urlretrieve):
         bosh(["pull", "zenodo." + str(example_boutiques_tool.id)])
-        cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")
+        cache_dir = os.path.join(
+            os.path.expanduser('~'), ".cache", "boutiques", "production")
         self.assertTrue(os.path.exists(os.path.join(
             cache_dir, "zenodo-" + str(example_boutiques_tool.id) + ".json")))
 

--- a/tools/python/boutiques/util/utils.py
+++ b/tools/python/boutiques/util/utils.py
@@ -20,14 +20,14 @@ class LoadError(Exception):
 
 # Helper function that loads the JSON object coming from either a string,
 # a local file or a file pulled from Zenodo
-def loadJson(userInput, verbose=False):
+def loadJson(userInput, verbose=False, sandbox=False):
     # Check for JSON file (local or from Zenodo)
     json_file = None
     if os.path.isfile(userInput):
         json_file = userInput
     elif userInput.split(".")[0].lower() == "zenodo":
         from boutiques.puller import Puller
-        puller = Puller([userInput], verbose)
+        puller = Puller([userInput], verbose, sandbox)
         json_file = puller.pull()[0]
     if json_file is not None:
         with open(json_file, 'r') as f:

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -35,7 +35,7 @@ def validate_descriptor(json_file, **kwargs):
     allowed_comparators = ['==', '!=', '<', '>', '<=', '>=']
 
     # Load descriptor
-    descriptor = loadJson(json_file)
+    descriptor = loadJson(json_file, sandbox=kwargs.get('sandbox'))
 
     # Validate basic JSON schema compliance for descriptor
     # Note: if it fails basic schema compliance we don"t do more checks


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#444 

## Purpose
<!--- A clear and concise description of what the PR does. -->
Cache Zenodo descriptors into different directories depending on their source (prod or sandbox).

## Current behaviour
<!--- Tell us what currently happens -->
Cache directory for zenodo descriptors are the same regardless from where the descriptor is pulled from Zenodo (prod/sandbox). Might cause boutiques to fetch the wrong descriptor if there's are descriptors with duplicated ZIDs (ZIDs are not guaranteed to be distinct across prod and sandbox).

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
Zenodo descriptors are pulled into separate directories depending on their origin:
`~/.cache/boutiques/production`
`~/.cache/boutiques/sandbox`
Descriptors that are currently cached in the old directory `~/.cache/boutiques/` will be ignored.

All bosh functions that take in a descriptor (json string or zenodo id) will have a `--sandbox` flag added so in the event a zenodo ID is passed, the user can specify if the descriptor is located in prof or sandbox.
 
## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Added `sandbox` param in `loadJson` to change pull location to sandbox if param is True.

