### PR TITLE
replaced op.exists with a glob so regexes can be matched

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -14,6 +14,7 @@ import datetime
 import hashlib
 import boutiques
 import os.path as op
+from glob import glob
 from termcolor import colored
 from boutiques.evaluate import evaluateEngine
 from boutiques.logger import raise_error, print_info, print_warning
@@ -387,9 +388,11 @@ class LocalExecutor(object):
         for f in all_files.keys():
             file_name = all_files[f]
             fd = FileDescription(f, file_name, False)
-            if op.exists(file_name):
+            f_glob = glob(file_name)
+            if f_glob:
+                fd = f_glob[0]
                 output_files.append(fd)
-                output_files_dict[f] = file_name
+                output_files_dict[f] = f_glob[0]
             else:  # file does not exist
                 if f in required_files.keys():
                     missing_files.append(fd)

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -390,7 +390,7 @@ class LocalExecutor(object):
             fd = FileDescription(f, file_name, False)
             f_glob = glob(file_name)
             if f_glob:
-                fd = f_glob[0]
+                fd.file_name = f_glob[0]
                 output_files.append(fd)
                 output_files_dict[f] = f_glob[0]
             else:  # file does not exist


### PR DESCRIPTION
## Purpose
<!--- A clear and concise description of what the PR does. -->
Enables finding files that match patterns rather than just have explicit filenames specified in the descriptor/invocation. To do this, I replaced an `op.exists` with a `glob`.

#### Does this introduce a major change?
- [ ] Yes
- [x] No
