### PR TITLE
Bosh deprecate

### DIFF
--- a/tools/python/boutiques/deprecate.py
+++ b/tools/python/boutiques/deprecate.py
@@ -44,9 +44,8 @@ def deprecate(zenodo_id, by_zenodo_id=None, sandbox=False, verbose=False,
 
     # Return if tool has a newer version
     record = zhelper.zenodo_get_record(record_id)
-    if not record['hits']['hits'][0]['metadata'][
-       'relations']['version'][0]['is_last']:
-        new_version = (record['hits']['hits'][0]['metadata']['relations']
+    if not record['metadata']['relations']['version'][0]['is_last']:
+        new_version = (record['metadata']['relations']
                        ['version'][0]['last_child']['pid_value'])
         raise_error(DeprecateError, 'Tool {0} has a newer version '
                                     '(zenodo.{1}), it cannot be deprecated.'

--- a/tools/python/boutiques/deprecate.py
+++ b/tools/python/boutiques/deprecate.py
@@ -1,0 +1,85 @@
+import json
+import tempfile
+from boutiques.util.utils import loadJson
+from boutiques.puller import Puller
+from boutiques.publisher import Publisher
+from boutiques.logger import print_info, raise_error, print_warning
+from boutiques.zenodoHelper import ZenodoHelper, ZenodoError
+from urllib.request import urlopen, urlretrieve
+
+
+class DeprecateError(Exception):
+    pass
+
+
+def deprecate(zenodo_id, by_zenodo_id=None, sandbox=False, verbose=False,
+              zenodo_token=None, download_function=urlretrieve):
+
+    # Get the descriptor and Zenodo id
+    puller = Puller([zenodo_id], verbose=verbose, sandbox=sandbox)
+    descriptor_fname = puller.pull()[0]
+    descriptor_json = loadJson(descriptor_fname, sandbox=sandbox)
+
+    # Return if tool is already deprecated
+    deprecated = descriptor_json.get('deprecated-by-doi')
+    if deprecated is not None:
+        if isinstance(deprecated, str):
+            print_info('Tool {0} is already deprecated by {1} '
+                       .format(zenodo_id, deprecated))
+        if by_zenodo_id is not None:
+            prompt = ("Tool {0} will be deprecated by {1}, "
+                      "this cannot be undone. Are you sure? (Y/n) ")\
+                          .format(zenodo_id, by_zenodo_id)
+            ret = input(prompt)
+            if ret.upper() != "Y":
+                return
+        else:
+            print_warning('Tool {0} is already deprecated'.format(zenodo_id))
+            return
+    # Set record id and Zenodo id
+    zhelper = ZenodoHelper(sandbox=sandbox, no_int=True, verbose=verbose)
+    zid = zhelper.get_zid_from_filename(descriptor_fname)
+    record_id = zhelper.get_record_id_from_zid(zid)
+
+    # Return if tool has a newer version
+    record = zhelper.zenodo_get_record(record_id)
+    if not record['hits']['hits'][0]['metadata'][
+       'relations']['version'][0]['is_last']:
+        new_version = (record['metadata']['relations']['version'][0]
+                             ['last_child']['pid_value'])
+        raise_error(DeprecateError, 'Tool {0} has a newer version '
+                                    '(zenodo.{1}), it cannot be deprecated.'
+                                    .format(zenodo_id, new_version))
+        return
+
+    # Add deprecated property
+    if by_zenodo_id is None:
+        descriptor_json['deprecated-by-doi'] = True
+    else:
+        # Check that by_zenodo_id exists
+        by_record_id = zhelper.get_record_id_from_zid(by_zenodo_id)
+        if zhelper.record_exists(by_record_id) is False:
+            raise_error(DeprecateError,
+                        "Tool does not exist: {0}".format(by_zenodo_id))
+        # Assign deprecated-by property
+        by_doi_id = zhelper.get_doi_from_zid(by_zenodo_id)
+        descriptor_json['deprecated-by-doi'] = by_doi_id
+
+    # Add doi to descriptor (mandatory for update)
+    if descriptor_json.get('doi') is None:
+        descriptor_json['doi'] = zhelper.get_doi_from_zid(zid)
+
+    # Save descriptor in temp file
+    tmp = tempfile.NamedTemporaryFile(delete=False, mode='w', suffix=".json")
+    content = json.dumps(descriptor_json, indent=4,
+                         sort_keys=True)
+    tmp.write(content)
+    tmp.close()
+
+    # Publish updated descriptor
+    publisher = Publisher(tmp.name, zenodo_token,
+                          replace=True,
+                          sandbox=sandbox,
+                          no_int=True,
+                          id="zenodo."+zid)
+    return publisher.publish()

--- a/tools/python/boutiques/deprecate.py
+++ b/tools/python/boutiques/deprecate.py
@@ -18,7 +18,8 @@ def deprecate(zenodo_id, by_zenodo_id=None, sandbox=False, verbose=False,
     # Get the descriptor and Zenodo id
     puller = Puller([zenodo_id], verbose=verbose, sandbox=sandbox)
     descriptor_fname = puller.pull()[0]
-    descriptor_json = loadJson(descriptor_fname, sandbox=sandbox)
+    descriptor_json = loadJson(descriptor_fname, sandbox=sandbox,
+                               verbose=verbose)
 
     # Return if tool is already deprecated
     deprecated = descriptor_json.get('deprecated-by-doi')
@@ -45,8 +46,8 @@ def deprecate(zenodo_id, by_zenodo_id=None, sandbox=False, verbose=False,
     record = zhelper.zenodo_get_record(record_id)
     if not record['hits']['hits'][0]['metadata'][
        'relations']['version'][0]['is_last']:
-        new_version = (record['metadata']['relations']['version'][0]
-                             ['last_child']['pid_value'])
+        new_version = (record['hits']['hits'][0]['metadata']['relations']
+                       ['version'][0]['last_child']['pid_value'])
         raise_error(DeprecateError, 'Tool {0} has a newer version '
                                     '(zenodo.{1}), it cannot be deprecated.'
                                     .format(zenodo_id, new_version))
@@ -81,5 +82,6 @@ def deprecate(zenodo_id, by_zenodo_id=None, sandbox=False, verbose=False,
                           replace=True,
                           sandbox=sandbox,
                           no_int=True,
-                          id="zenodo."+zid)
+                          id="zenodo."+zid,
+                          verbose=verbose)
     return publisher.publish()

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -151,6 +151,9 @@ class Publisher():
         self.descriptor['doi'] = self.doi
         with open(self.descriptor_file_name, "w") as f:
             f.write(json.dumps(self.descriptor, indent=4))
+        if os.path.isfile(self.descriptor_file_name):
+            return True
+        return False
 
     def create_metadata(self):
         data = {

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -152,7 +152,7 @@ class Publisher():
         with open(self.descriptor_file_name, "w") as f:
             f.write(json.dumps(self.descriptor, indent=4))
         if os.path.isfile(self.descriptor_file_name):
-            return True
+            return "OK"
         return False
 
     def create_metadata(self):

--- a/tools/python/boutiques/publisher.py
+++ b/tools/python/boutiques/publisher.py
@@ -104,10 +104,7 @@ class Publisher():
         if(not self.no_int):
             prompt = ("The descriptor will be published to Zenodo, "
                       "this cannot be undone. Are you sure? (Y/n) ")
-            try:
-                ret = raw_input(prompt)  # Python 2
-            except NameError:
-                ret = input(prompt)  # Python 3
+            ret = input(prompt)
             if ret.upper() != "Y":
                 return
 
@@ -134,10 +131,7 @@ class Publisher():
                               "would you like to update it? "
                               "(Y:Update existing / n:Publish new entry with "
                               "name {}) ".format(self.descriptor.get("name")))
-                    try:
-                        ret = raw_input(prompt)  # Python 2
-                    except NameError:
-                        ret = input(prompt)  # Python 3
+                    ret = input(prompt)
                     if ret.upper() == "Y":
                         publish_update = True
                 else:
@@ -180,7 +174,7 @@ class Publisher():
                 if isinstance(value, bool):
                     keywords.append(key)
                 # Tag is of form 'tag-name':'tag-value', it is a key-value pair
-                if self.is_str(value):
+                if isinstance(value, str):
                     keywords.append(key + ":" + value)
                 # Tag is of form 'tag-name': ['value1', 'value2'], it is a
                 # list of key-value pairs
@@ -190,30 +184,30 @@ class Publisher():
             keywords.append(self.descriptor['container-image']['type'])
         if self.descriptor.get('tests'):
             keywords.append('tested')
+        if self.descriptor.get('deprecated-by-doi'):
+            keywords.append('deprecated')
+            if isinstance(self.descriptor['deprecated-by-doi'], str):
+                keywords.append('deprecated-by-doi:' +
+                                self.descriptor['deprecated-by-doi'])
+            self.addRelatedIdentifiers(
+                data, self.descriptor['deprecated-by-doi'],
+                'isPreviousVersionOf')
+
         if self.url is not None:
-            self.addHasPart(data, self.url)
+            self.addRelatedIdentifiers(data, self.url, 'hasPart')
         if self.online_platforms is not None:
             for p in self.online_platforms:
-                self.addHasPart(data, p)
+                self.addRelatedIdentifiers(data, p, 'hasPart')
         if self.tool_doi is not None:
-            self.addHasPart(data, self.tool_doi)
+            self.addRelatedIdentifiers(data, self.tool_doi, 'hasPart')
         if self.descriptor_url is not None:
-            self.addHasPart(data, self.descriptor_url)
+            self.addRelatedIdentifiers(data, self.descriptor_url, 'hasPart')
         return data
 
-    # Check if value is a string
-    # try/except is needed for Python2/3 compatibility
-    def is_str(self, value):
-        try:
-            basestring
-        except NameError:
-            return isinstance(value, str)
-        return isinstance(value, basestring)
-
-    def addHasPart(self, data, identifier):
+    def addRelatedIdentifiers(self, data, identifier, relation):
         if data['metadata'].get('related_identifiers') is None:
             data['metadata']['related_identifiers'] = []
         data['metadata']['related_identifiers'].append({
             'identifier': identifier,
-            'relation': 'hasPart'
+            'relation': relation
         })

--- a/tools/python/boutiques/puller.py
+++ b/tools/python/boutiques/puller.py
@@ -62,7 +62,6 @@ class Puller():
             searcher = Searcher(entry["zid"], self.verbose, self.sandbox,
                                 exact_match=True)
             r = searcher.zenodo_search()
-
             if not len(r.json()["hits"]["hits"]):
                 raise_error(ZenodoError, "Descriptor \"{0}\" "
                             "not found".format(entry["zid"]))

--- a/tools/python/boutiques/schema/descriptor.schema.json
+++ b/tools/python/boutiques/schema/descriptor.schema.json
@@ -22,6 +22,12 @@
             "description": "Tool description.",
             "type": "string"
         },
+        "deprecated-by-doi": {
+            "id": "http://github.com/boutiques/boutiques-schema/deprecated-by-doi",
+            "minLength": 1,
+            "description": "doi of the tool that deprecates the current one. May be set to 'true' if the current tool is deprecated but no specific tool deprecates it.",
+            "type": ["string", "boolean"]
+        },
         "author": {
             "id": "http://github.com/boutiques/boutiques-schema/author",
             "minLength": 1,

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -7,13 +7,7 @@ import numbers
 from operator import itemgetter
 from boutiques.logger import raise_error, print_info
 from boutiques.publisher import ZenodoError
-
-try:
-    # Python 3
-    from urllib.parse import quote
-except ImportError:
-    # Python 2
-    from urllib import quote
+from urllib.parse import quote
 
 
 class Searcher():
@@ -66,14 +60,25 @@ class Searcher():
 
     def search(self):
         results = self.zenodo_search()
-        num_results = len(results.json()["hits"]["hits"])
         total_results = results.json()["hits"]["total"]
-        print_info("Showing %d of %d results."
+        total_deprecated = len([h['metadata']['keywords'] for h in
+                                results.json()['hits']['hits'] if
+                                'metadata' in h and
+                                'keywords' in h['metadata'] and
+                                'deprecated' in h['metadata']['keywords']])
+        results_list = self.create_results_list_verbose(results.json()) if\
+            self.verbose else\
+            self.create_results_list(results.json())
+        num_results = len(results_list)
+        print_info("Showing %d of %d result(s)%s"
                    % (num_results if num_results < self.max_results
-                      else self.max_results, total_results))
-        if self.verbose:
-            return self.create_results_list_verbose(results.json())
-        return self.create_results_list(results.json())
+                      else self.max_results,
+                      total_results if self.verbose
+                      else total_results - total_deprecated,
+                      "." if self.verbose
+                      else ", exluding %d deprecated result(s)."
+                      % total_deprecated))
+        return results_list
 
     def zenodo_search(self):
         # Get all results
@@ -93,6 +98,10 @@ class Searcher():
         results_list = []
         for hit in results["hits"]["hits"]:
             (id, title, description, downloads) = self.parse_basic_info(hit)
+            # skip hit if result is deprecated
+            keyword_data = self.get_keyword_data(hit["metadata"]["keywords"])
+            if 'deprecated' in keyword_data['other']:
+                continue
             result_dict = OrderedDict([("ID", id), ("TITLE", title),
                                       ("DESCRIPTION", description),
                                       ("DOWNLOADS", downloads)])
@@ -118,6 +127,8 @@ class Searcher():
             result_dict = OrderedDict([("ID", id),
                                       ("TITLE", title),
                                       ("DESCRIPTION", description),
+                                      ("Deprecated", 'deprecated' in
+                                       keyword_data['other']),
                                       ("DOWNLOADS", downloads),
                                       ("AUTHOR", author),
                                       ("VERSION", version),

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -127,7 +127,7 @@ class Searcher():
             result_dict = OrderedDict([("ID", id),
                                       ("TITLE", title),
                                       ("DESCRIPTION", description),
-                                      ("Deprecated", 'deprecated' in
+                                      ("DEPRECATED", 'deprecated' in
                                        keyword_data['other']),
                                       ("DOWNLOADS", downloads),
                                       ("AUTHOR", author),

--- a/tools/python/boutiques/tests/boutiques_mocks.py
+++ b/tools/python/boutiques/tests/boutiques_mocks.py
@@ -9,13 +9,14 @@ class MockHttpResponse:
 
 class MockZenodoRecord:
     def __init__(self, id, title, description="", filename="", downloads=1,
-                 keywords=[]):
+                 keywords=[], is_last_version=True):
         self.id = id
         self.title = title
         self.filename = filename
         self.downloads = downloads
         self.description = description
         self.keywords = keywords
+        self.is_last_version = is_last_version
 
 
 # Mock object representing the current version of Example Boutiques Tool
@@ -98,7 +99,8 @@ def mock_zenodo_search(mock_records):
                               {
                                 'count': 4,
                                 'index': 3,
-                                'is_last': {'pid_value': '33333'}
+                                'is_last': record.is_last_version,
+                                'last_child': {'pid_value': '33333'}
                               }
                             ]
                           },

--- a/tools/python/boutiques/tests/boutiques_mocks.py
+++ b/tools/python/boutiques/tests/boutiques_mocks.py
@@ -8,12 +8,14 @@ class MockHttpResponse:
 
 
 class MockZenodoRecord:
-    def __init__(self, id, title, description="", filename="", downloads=1):
+    def __init__(self, id, title, description="", filename="", downloads=1,
+                 keywords=[]):
         self.id = id
         self.title = title
         self.filename = filename
         self.downloads = downloads
         self.description = description
+        self.keywords = keywords
 
 
 # Mock object representing the current version of Example Boutiques Tool
@@ -91,6 +93,15 @@ def mock_zenodo_search(mock_records):
                             }
                           ],
                           "description": record.description,
+                          "relations": {
+                            'version': [
+                              {
+                                'count': 4,
+                                'index': 3,
+                                'is_last': {'pid_value': '33333'}
+                              }
+                            ]
+                          },
                           "doi": "10.5281/zenodo.%s" % record.id,
                           "keywords": [
                             "schema-version:0.5",

--- a/tools/python/boutiques/tests/boutiques_mocks.py
+++ b/tools/python/boutiques/tests/boutiques_mocks.py
@@ -74,49 +74,52 @@ def mock_zenodo_delete_files():
     return MockHttpResponse(204)
 
 
+def get_zenodo_record(record):
+    return {
+        "doi": "10.5281/zenodo.%s" % record.id,
+        "files": [
+            {
+                "links": {
+                    "self": record.filename
+                }
+            }
+        ],
+        "id": record.id,
+        "metadata": {
+            "creators": [
+                {
+                    "name": "Test author"
+                }
+            ],
+            "description": record.description,
+            "relations": {
+                'version': [
+                    {
+                        'count': 4,
+                        'index': 3,
+                        'is_last': record.is_last_version,
+                        'last_child': {'pid_value': '33333'}
+                    }
+                ]
+            },
+            "doi": "10.5281/zenodo.%s" % record.id,
+            "keywords": [
+                "schema-version:0.5",
+                "docker"
+            ],
+            "title": record.title,
+            "version": "0.0.1"
+        },
+        "stats": {
+            "version_downloads": record.downloads
+        }
+    }
+
+
 def mock_zenodo_search(mock_records):
     mock_results = []
     for record in mock_records:
-        mock_result = {
-                        "doi": "10.5281/zenodo.%s" % record.id,
-                        "files": [
-                          {
-                            "links": {
-                              "self": record.filename
-                            }
-                          }
-                        ],
-                        "id": record.id,
-                        "metadata": {
-                          "creators": [
-                            {
-                              "name": "Test author"
-                            }
-                          ],
-                          "description": record.description,
-                          "relations": {
-                            'version': [
-                              {
-                                'count': 4,
-                                'index': 3,
-                                'is_last': record.is_last_version,
-                                'last_child': {'pid_value': '33333'}
-                              }
-                            ]
-                          },
-                          "doi": "10.5281/zenodo.%s" % record.id,
-                          "keywords": [
-                            "schema-version:0.5",
-                            "docker"
-                          ],
-                          "title": record.title,
-                          "version": "0.0.1"
-                        },
-                        "stats": {
-                          "version_downloads": record.downloads
-                        }
-                      }
-        mock_results.append(mock_result)
+        mock_results.append(get_zenodo_record(record))
     mock_json = {"hits": {"hits": mock_results, "total": len(mock_results)}}
     return MockHttpResponse(200, mock_json)
 

--- a/tools/python/boutiques/tests/test_deprecate.py
+++ b/tools/python/boutiques/tests/test_deprecate.py
@@ -80,36 +80,26 @@ def mock_download_deprecated(url, file_path):
     return [f.name]
 
 
+@mock.patch('requests.get', side_effect=mock_get)
+@mock.patch('requests.post', side_effect=mock_post)
+@mock.patch('requests.put', side_effect=mock_put)
+@mock.patch('requests.delete', side_effect=mock_delete)
 class TestDeprecate(TestCase):
-
-    @mock.patch('requests.get', side_effect=mock_get)
-    @mock.patch('requests.post', side_effect=mock_post)
-    @mock.patch('requests.put', side_effect=mock_put)
-    @mock.patch('requests.delete', side_effect=mock_delete)
-    def test_deprecate(self, mock_get, mock_post, mock_put, mock_delete):
+    def test_deprecate(self, *args):
         new_doi = bosh(["deprecate", "--verbose", "--by", "zenodo.12345",
                         "zenodo." + str(example_boutiques_tool.id),
                         "--zenodo-token", "hAaW2wSBZMskxpfigTYHcuDrC"
                         "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r"])
         self.assertTrue(new_doi)
 
-    @mock.patch('requests.get', side_effect=mock_get)
-    @mock.patch('requests.post', side_effect=mock_post)
-    @mock.patch('requests.put', side_effect=mock_put)
-    @mock.patch('requests.delete', side_effect=mock_delete)
-    def test_deprecate_no_by(self, mock_get, mock_post, mock_put, mock_delete):
+    def test_deprecate_no_by(self, *args):
         new_doi = bosh(["deprecate", "--verbose",
                         "zenodo." + str(example_boutiques_tool.id),
                         "--zenodo-token", "hAaW2wSBZMskxpfigTYHcuDrC"
                         "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r"])
         self.assertTrue(new_doi)
 
-    @mock.patch('requests.get', side_effect=mock_get)
-    @mock.patch('requests.post', side_effect=mock_post)
-    @mock.patch('requests.put', side_effect=mock_put)
-    @mock.patch('requests.delete', side_effect=mock_delete)
-    def test_deprecate_by_inexistent(self, mock_get, mock_post, mock_put,
-                                     mock_delete):
+    def test_deprecate_by_inexistent(self, *args):
         with self.assertRaises(DeprecateError) as e:
             new_doi = bosh(["deprecate", "--verbose", "--by", "zenodo.00000",
                             "zenodo." + str(example_boutiques_tool.id),
@@ -117,12 +107,7 @@ class TestDeprecate(TestCase):
                             "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r"])
         self.assertTrue("Tool does not exist" in str(e.exception))
 
-    @mock.patch('requests.get', side_effect=mock_get)
-    @mock.patch('requests.post', side_effect=mock_post)
-    @mock.patch('requests.put', side_effect=mock_put)
-    @mock.patch('requests.delete', side_effect=mock_delete)
-    def test_deprecate_deprecated(self, mock_get, mock_post, mock_put,
-                                  mock_delete):
+    def test_deprecate_deprecated(self, *args):
         new_doi = deprecate(zenodo_id="zenodo.11111",
                             sandbox=True,
                             verbose=True,
@@ -131,12 +116,7 @@ class TestDeprecate(TestCase):
                             download_function=mock_download_deprecated)
         self.assertTrue(new_doi)
 
-    @mock.patch('requests.get', side_effect=mock_get)
-    @mock.patch('requests.post', side_effect=mock_post)
-    @mock.patch('requests.put', side_effect=mock_put)
-    @mock.patch('requests.delete', side_effect=mock_delete)
-    def test_deprecate_previous_version(self, mock_get, mock_post, mock_put,
-                                        mock_delete):
+    def test_deprecate_previous_version(self, *args):
         with self.assertRaises(DeprecateError) as e:
             new_doi = bosh(["deprecate", "--verbose",
                             "zenodo.22222",

--- a/tools/python/boutiques/tests/test_deprecate.py
+++ b/tools/python/boutiques/tests/test_deprecate.py
@@ -28,7 +28,8 @@ def mock_get(*args, **kwargs):
         mock_record1.id = int(record_id)
         if record_id == "22222":
             mock_record1.is_last_version = False
-        return mock_zenodo_search([mock_record1])
+        mock_hits = mock_zenodo_search([mock_record1]).json()
+        return MockHttpResponse(200, mock_hits['hits']['hits'][0])
 
     # Deposit command
     if command == "deposit":

--- a/tools/python/boutiques/tests/test_deprecate.py
+++ b/tools/python/boutiques/tests/test_deprecate.py
@@ -126,7 +126,7 @@ class TestDeprecate(TestCase):
                             zenodo_token="hAaW2wSBZMskxpfigTYHcuDrC"
                             "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r",
                             download_function=mock_download_deprecated)
-        self.assertFalse(new_doi)
+        self.assertTrue(new_doi)
 
     @mock.patch('requests.get', side_effect=mock_get)
     @mock.patch('requests.post', side_effect=mock_post)

--- a/tools/python/boutiques/tests/test_deprecate.py
+++ b/tools/python/boutiques/tests/test_deprecate.py
@@ -1,0 +1,143 @@
+from boutiques.bosh import bosh
+from unittest import TestCase
+import os
+import mock
+import json
+from boutiques import __file__ as bfile
+from boutiques.util.utils import loadJson
+from boutiques.deprecate import DeprecateError, deprecate
+from boutiques_mocks import MockZenodoRecord,\
+    example_boutiques_tool, MockHttpResponse, mock_zenodo_search
+
+
+def mock_get(*args, **kwargs):
+
+    # Check that URL looks good
+    split = args[0].split('/')
+    assert(len(split) >= 5)
+
+    command = split[4]
+    # Records command
+    if command == "records":
+        assert(len(split) >= 6)
+        record_id = split[10] if len(split) > 6 else split[5]
+        if record_id == "00000":
+            # Inexistent tool
+            return MockHttpResponse(404)
+        mock_record1 = example_boutiques_tool
+        mock_record1.id = int(record_id)
+        if record_id == "22222":
+            mock_record1.is_last_version = False
+        return mock_zenodo_search([mock_record1])
+
+    # Deposit command
+    if command == "deposit":
+        # Check auth
+        if kwargs.get('params') and kwargs.get('params').get('access_token'):
+            return MockHttpResponse(200)
+        else:
+            return MockHttpResponse(401)
+
+
+def mock_post(*args, **kwargs):
+    # Check that URL looks good
+    split = args[0].split('/')
+    assert(len(split) >= 5)
+    command = split[4]
+    # Deposit command
+    if command == "deposit":
+        json = {"links": {"latest_draft": "plop/coin/pan/12345"},
+                "doi": "foo/bar", "files": [{"id": "qwerty"}]}
+        if args[0].endswith("actions/publish"):
+            return MockHttpResponse(202, json)
+        else:
+            return MockHttpResponse(201, json)
+
+
+def mock_delete(*args, **kwargs):
+    return MockHttpResponse(204)
+
+
+def mock_put(*args, **kwargs):
+    return MockHttpResponse(200)
+
+
+def mock_download_deprecated(url, file_path):
+    # Mocks the download and save of a deprecated descriptor
+    example_1_path = os.path.join(
+                        os.path.join(
+                            os.path.dirname(bfile), "schema", "examples",
+                            "example1", "example1_docker.json"))
+    example_1_json = loadJson(example_1_path)
+    example_1_json['deprecated-by-doi'] = "a_doi"
+    cache_dir = os.path.join(os.path.expanduser('~'), ".cache",
+                             "boutiques", "production")
+    with open(file_path, 'w') as f:
+        f.write(json.dumps(example_1_json))
+    return [f.name]
+
+
+class TestDeprecate(TestCase):
+
+    @mock.patch('requests.get', side_effect=mock_get)
+    @mock.patch('requests.post', side_effect=mock_post)
+    @mock.patch('requests.put', side_effect=mock_put)
+    @mock.patch('requests.delete', side_effect=mock_delete)
+    def test_deprecate(self, mock_get, mock_post, mock_put, mock_delete):
+        new_doi = bosh(["deprecate", "--verbose", "--by", "zenodo.12345",
+                        "zenodo." + str(example_boutiques_tool.id),
+                        "--zenodo-token", "hAaW2wSBZMskxpfigTYHcuDrC"
+                        "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r"])
+        self.assertTrue(new_doi)
+
+    @mock.patch('requests.get', side_effect=mock_get)
+    @mock.patch('requests.post', side_effect=mock_post)
+    @mock.patch('requests.put', side_effect=mock_put)
+    @mock.patch('requests.delete', side_effect=mock_delete)
+    def test_deprecate_no_by(self, mock_get, mock_post, mock_put, mock_delete):
+        new_doi = bosh(["deprecate", "--verbose",
+                        "zenodo." + str(example_boutiques_tool.id),
+                        "--zenodo-token", "hAaW2wSBZMskxpfigTYHcuDrC"
+                        "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r"])
+        self.assertTrue(new_doi)
+
+    @mock.patch('requests.get', side_effect=mock_get)
+    @mock.patch('requests.post', side_effect=mock_post)
+    @mock.patch('requests.put', side_effect=mock_put)
+    @mock.patch('requests.delete', side_effect=mock_delete)
+    def test_deprecate_by_inexistent(self, mock_get, mock_post, mock_put,
+                                     mock_delete):
+        with self.assertRaises(DeprecateError) as e:
+            new_doi = bosh(["deprecate", "--verbose", "--by", "zenodo.00000",
+                            "zenodo." + str(example_boutiques_tool.id),
+                            "--zenodo-token", "hAaW2wSBZMskxpfigTYHcuDrC"
+                            "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r"])
+        self.assertTrue("Tool does not exist" in str(e.exception))
+
+    @mock.patch('requests.get', side_effect=mock_get)
+    @mock.patch('requests.post', side_effect=mock_post)
+    @mock.patch('requests.put', side_effect=mock_put)
+    @mock.patch('requests.delete', side_effect=mock_delete)
+    def test_deprecate_deprecated(self, mock_get, mock_post, mock_put,
+                                  mock_delete):
+        new_doi = deprecate(zenodo_id="zenodo.11111",
+                            sandbox=True,
+                            verbose=True,
+                            zenodo_token="hAaW2wSBZMskxpfigTYHcuDrC"
+                            "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r",
+                            download_function=mock_download_deprecated)
+        self.assertFalse(new_doi)
+
+    @mock.patch('requests.get', side_effect=mock_get)
+    @mock.patch('requests.post', side_effect=mock_post)
+    @mock.patch('requests.put', side_effect=mock_put)
+    @mock.patch('requests.delete', side_effect=mock_delete)
+    def test_deprecate_previous_version(self, mock_get, mock_post, mock_put,
+                                        mock_delete):
+        with self.assertRaises(DeprecateError) as e:
+            new_doi = bosh(["deprecate", "--verbose",
+                            "zenodo.22222",
+                            "--zenodo-token", "hAaW2wSBZMskxpfigTYHcuDrC"
+                            "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r"])
+        self.assertTrue("Tool zenodo.22222 has a newer version"
+                        in str(e.exception))

--- a/tools/python/boutiques/tests/test_deprecate.py
+++ b/tools/python/boutiques/tests/test_deprecate.py
@@ -6,8 +6,8 @@ import json
 from boutiques import __file__ as bfile
 from boutiques.util.utils import loadJson
 from boutiques.deprecate import DeprecateError, deprecate
-from boutiques_mocks import MockZenodoRecord,\
-    example_boutiques_tool, MockHttpResponse, mock_zenodo_search
+from boutiques_mocks import MockZenodoRecord, mock_zenodo_search,\
+    example_boutiques_tool, MockHttpResponse, get_zenodo_record
 
 
 def mock_get(*args, **kwargs):
@@ -28,8 +28,10 @@ def mock_get(*args, **kwargs):
         mock_record1.id = int(record_id)
         if record_id == "22222":
             mock_record1.is_last_version = False
-        mock_hits = mock_zenodo_search([mock_record1]).json()
-        return MockHttpResponse(200, mock_hits['hits']['hits'][0])
+        mock_get = get_zenodo_record(mock_record1)
+        if "?q=keywords:" in args[0]:
+            return mock_zenodo_search([mock_record1])
+        return MockHttpResponse(200, mock_get)
 
     # Deposit command
     if command == "deposit":

--- a/tools/python/boutiques/tests/test_search.py
+++ b/tools/python/boutiques/tests/test_search.py
@@ -70,7 +70,7 @@ class TestSearch(TestCase):
         results = bosh(["search", "-v"])
         self.assertGreater(len(results), 0)
         self.assertEqual(list(results[0].keys()),
-                         ["ID", "TITLE", "DESCRIPTION",
+                         ["ID", "TITLE", "DESCRIPTION", "DEPRECATED",
                           "DOWNLOADS", "AUTHOR", "VERSION",
                           "DOI", "SCHEMA VERSION",
                           "CONTAINER", "TAGS"])


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#428 #402 

## Purpose
<!--- A clear and concise description of what the PR does. -->
Allow original publisher of tool on Zenodo to deprecate it so newer versions (as separate record) can be published by a different user.

## Current behaviour
<!--- Tell us what currently happens -->
No way to remove outdated zenodo tools from `bosh search` results. 
No official way to link old version of tool to a newer tool (as separate record).

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
`bosh deprecate [ZID1] --zenodo-token [ZTOKEN]` 
Optional: `--by [ZID2]`

Will add deprecate keyword to the newest version of the tool ZID1 and it will no longer appear in `bosh search` (can be made visible with `--verbose` search).

If argument `--by [ZID2]` is added, tool ZID1 will have an additional `deprecated-by-doi:[ZID2]` keyword. As well as a "New versions" related identifier pointing to tool ZID2.

Tool descriptor will contain field `'deprecated-by-doi': [True OR ZID2]` depending on whether ZID2 is specified with `--by` flag. 

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Added deprecate function to `bosh.py` (should update Docs).
Checks existing deprecation and prompts with (Y/n) confirmation.
Uses publisher to update tool with new Keywords and Related identifier.
Added `"deprecated-by-doi": {..."type": ["string", "boolean"]...}` field to descriptor schema.
Searcher in verbose mode displays deprecated status as a new results column.
