### PR TITLE
Support image name with index

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -523,11 +523,12 @@ class LocalExecutor(object):
     def _pullSingImage(self, conName, conIndex, conImage, imageDir, lockDir):
         # Give the file a temporary name while it's building
         conNameTmp = conName + ".tmp"
+        conImgHasIndex = re.search(r"^[a-zA-Z0-9]+://", conImage) is not None
         # Set the pull directory to the specified imagePath
         if self.imagePath:
             os.environ["SINGULARITY_PULLFOLDER"] = imageDir
         pull_loc = "\"{0}\" {1}{2}".format(conNameTmp,
-                                           conIndex,
+                                           conIndex if not conImgHasIndex else "",
                                            conImage)
         container_location = ("Pulled from {1}{2} ({0} not found "
                               "in current working "

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -534,7 +534,8 @@ class LocalExecutor(object):
                               "in current working "
                               "directory or specified "
                               "image path)").format(conName,
-                                                    conIndex,
+                                                    conIndex if not
+                                                    conImgHasIndex else "",
                                                     conImage)
         # Pull the singularity image
         sing_command = "singularity pull --name " + pull_loc

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -459,6 +459,10 @@ class LocalExecutor(object):
                                            conIndex != "" and
                                            conIndex != "docker://") else "")
 
+            # If present, assign index in conImage to conIndex
+            if re.search(r"^[a-zA-Z0-9]+://", conImage) is not None:
+                conIndex = re.match(r"^[a-zA-Z0-9]+://", conImage).group()
+                conImage = conImage.replace(conIndex, "")
             if not conIndex:
                 conIndex = "shub://"
             if not conIndex.endswith("/"):
@@ -523,19 +527,15 @@ class LocalExecutor(object):
     def _pullSingImage(self, conName, conIndex, conImage, imageDir, lockDir):
         # Give the file a temporary name while it's building
         conNameTmp = conName + ".tmp"
-        conImgHasIndex = re.search(r"^[a-zA-Z0-9]+://", conImage) is not None
         # Set the pull directory to the specified imagePath
         if self.imagePath:
             os.environ["SINGULARITY_PULLFOLDER"] = imageDir
-        pull_loc = "\"{0}\" {1}{2}".format(conNameTmp,
-                                           conIndex if not conImgHasIndex
-                                           else "", conImage)
+        pull_loc = "\"{0}\" {1}{2}".format(conNameTmp, conIndex, conImage)
         container_location = ("Pulled from {1}{2} ({0} not found "
                               "in current working "
                               "directory or specified "
                               "image path)").format(conName,
-                                                    conIndex if not
-                                                    conImgHasIndex else "",
+                                                    conIndex,
                                                     conImage)
         # Pull the singularity image
         sing_command = "singularity pull --name " + pull_loc

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -528,8 +528,8 @@ class LocalExecutor(object):
         if self.imagePath:
             os.environ["SINGULARITY_PULLFOLDER"] = imageDir
         pull_loc = "\"{0}\" {1}{2}".format(conNameTmp,
-                                           conIndex if not conImgHasIndex else "",
-                                           conImage)
+                                           conIndex if not conImgHasIndex
+                                           else "", conImage)
         container_location = ("Pulled from {1}{2} ({0} not found "
                               "in current working "
                               "directory or specified "

--- a/tools/python/boutiques/schema/examples/bad_conIndexImage.json
+++ b/tools/python/boutiques/schema/examples/bad_conIndexImage.json
@@ -1,0 +1,28 @@
+{
+    "command-line": "echo [INPUT] > file.txt", 
+    "description": "a tool with no container image",
+    "container-image": {
+        "type": "docker",
+        "image": "docker://index.docker.io",
+        "index": "shub://"
+    },
+    "inputs": [
+        {
+            "id": "param", 
+            "name": "param", 
+            "type": "String", 
+            "value-key": "[INPUT]"
+        }
+    ],
+    "name": "test_container_index", 
+    "output-files": [
+        {
+            "id": "output_file", 
+            "name": "output file", 
+            "path-template": "file.txt"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "tool-version": "0.1",
+    "author": "tester"
+}

--- a/tools/python/boutiques/schema/examples/example1/conImage_with_index.json
+++ b/tools/python/boutiques/schema/examples/example1/conImage_with_index.json
@@ -1,0 +1,27 @@
+{
+    "command-line": "echo [INPUT] > file.txt", 
+    "description": "a tool with no container image",
+    "container-image": {
+        "type": "singularity",
+        "image": "docker://boutiques/example1:test"
+    },
+    "inputs": [
+        {
+            "id": "input", 
+            "name": "input", 
+            "type": "String", 
+            "value-key": "[INPUT]"
+        }
+    ],
+    "name": "test_container_index", 
+    "output-files": [
+        {
+            "id": "output_file", 
+            "name": "output file", 
+            "path-template": "file.txt"
+        }
+    ], 
+    "schema-version": "0.5", 
+    "tool-version": "0.1",
+    "author": "tester"
+}

--- a/tools/python/boutiques/schema/examples/example1/input_invoc.json
+++ b/tools/python/boutiques/schema/examples/example1/input_invoc.json
@@ -1,0 +1,3 @@
+{
+    "input": "test string for input."
+}

--- a/tools/python/boutiques/tests/test_example1.py
+++ b/tools/python/boutiques/tests/test_example1.py
@@ -514,7 +514,7 @@ class TestExample1(BaseTest):
                            self.get_file_path("input_invoc.json"),
                            "--skip-data-collection")
 
-        self.assertIn("Pulled from docker://boutiques/example1",
+        self.assertIn("Local (boutiques-example1-test.simg)",
                       ret.container_location)
         self.assertIn("singularity exec", ret.container_command)
         self.clean_up()

--- a/tools/python/boutiques/tests/test_example1.py
+++ b/tools/python/boutiques/tests/test_example1.py
@@ -506,6 +506,19 @@ class TestExample1(BaseTest):
             if os.path.isfile(outFileList[0].split()[0]):
                 os.remove(outFileList[0].split()[0])
 
+    @pytest.mark.skipif(subprocess.Popen("type singularity", shell=True).wait(),
+                        reason="Singularity not installed")
+    def test_example1_exec_container_image_contains_index(self):
+        ret = bosh.execute("launch",
+                           self.get_file_path("conImage_with_index.json"),
+                           self.get_file_path("input_invoc.json"),
+                           "--skip-data-collection")
+
+        self.assertIn("Pulled from docker://boutiques/example1",
+                      ret.container_location)
+        self.assertIn("singularity exec", ret.container_command)
+        self.clean_up()
+
     # Captures the stdout and stderr during test execution
     # and returns them as a tuple in readouterr()
     @pytest.fixture(autouse=True)

--- a/tools/python/boutiques/tests/test_validator.py
+++ b/tools/python/boutiques/tests/test_validator.py
@@ -59,3 +59,16 @@ class TestValidator(TestCase):
     def test_invalid_groups(self):
         fil = op.join(op.split(bfile)[0], 'schema/examples/invalid_groups.json')
         self.assertRaises(DescriptorValidationError, bosh, ['validate', fil])
+
+    def test_invalid_container_index(self):
+        fil = op.join(op.split(bfile)[0],
+                      'schema/examples/bad_conIndexImage.json')
+        command = ("bosh validate " + fil)
+        process = subprocess.Popen(command, shell=True,
+                                   stdout=subprocess.PIPE)
+        stdout = process.stdout.read().decode("utf-8").strip()
+        self.assertEqual(stdout,
+                         ('ContainerError: container image'
+                          ' \"docker://index.docker.io\" is prepended by index'
+                          ' that doesn\'t match container index value'
+                          ' \"shub://\"'))

--- a/tools/python/boutiques/validator.py
+++ b/tools/python/boutiques/validator.py
@@ -504,6 +504,21 @@ def validate_descriptor(json_file, **kwargs):
                    for test_name in set(tests_names)
                    if (tests_names.count(test_name) > 1)]
 
+    # Verify container image
+    if "container-image" in descriptor.keys():
+        conImage = descriptor['container-image']['image']
+        conIndex = descriptor['container-image']['index'] if\
+            'index' in descriptor['container-image'] else None
+        conImageIndex = re.match(r"^[a-zA-Z0-9]+://", conImage)
+
+        # Verify index in container image is equal to container index value
+        if conIndex is not None and conImageIndex is not None and\
+           conIndex != conImageIndex.group():
+            msg_template = ("ContainerError: container image \"{0}\""
+                            " is prepended by index that doesn't match"
+                            " container index value \"{1}\"")
+            errors += [msg_template.format(conImage, conIndex)]
+
     errors = None if errors == [] else errors
     if errors is None:
         if kwargs.get('format_output'):

--- a/tools/python/cleanup_tests.sh
+++ b/tools/python/cleanup_tests.sh
@@ -10,7 +10,7 @@ rm -r temp-*.sh log*.txt config*.txt file.txt creator_output.json \
       .pytest_cache/ bar.dat baz.txt cwl_inv_out.json cwl_out.json \
       example.conf foo.txt goodbye.txt hello.js hello.tar stdout.txt \
       output-dir boutiques/tests/test-data-cache subdir1 \
-      TEST.one.three.two_out1.txt TEST_string1.txt
+      TEST.one.three.two_out1.txt TEST_string1.txt docker---boutiques-example1.simg
 git checkout boutiques/schema/examples/good.json
 git checkout boutiques/schema/examples/example1/example1_docker.json
 git checkout boutiques/schema/examples/example1/example1_sing.json

--- a/tools/python/cleanup_tests.sh
+++ b/tools/python/cleanup_tests.sh
@@ -10,7 +10,7 @@ rm -r temp-*.sh log*.txt config*.txt file.txt creator_output.json \
       .pytest_cache/ bar.dat baz.txt cwl_inv_out.json cwl_out.json \
       example.conf foo.txt goodbye.txt hello.js hello.tar stdout.txt \
       output-dir boutiques/tests/test-data-cache subdir1 \
-      TEST.one.three.two_out1.txt TEST_string1.txt docker---boutiques-example1.simg
+      TEST.one.three.two_out1.txt TEST_string1.txt
 git checkout boutiques/schema/examples/good.json
 git checkout boutiques/schema/examples/example1/example1_docker.json
 git checkout boutiques/schema/examples/example1/example1_sing.json


### PR DESCRIPTION
# Related issues
<!-- List the issue(s) that are addressed by this PR -->
#588 

## Purpose
<!--- A clear and concise description of what the PR does. -->
Various commands crash when the container image contains an index name

## Current behaviour
<!--- Tell us what currently happens -->
Commands crash because index is appended to the command name even though it's already present in the image name.

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
Index in image name is matched with regex and `container-image`'s `index` value will not be prepended to image name.
Validator raises error if an index is found in `container-image`'s `image` and it doesn't match the `index` value.
