### PR TITLE
Extra line separator #577

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1028,19 +1028,16 @@ class LocalExecutor(object):
             if param_id in list(in_out_dict.keys()):  # param has a value
                 val = in_out_dict[param_id]
                 if type(val) is list:
-                    s_val = ""
                     list_sep = self.safeGet(param_id, 'list-separator')
                     if list_sep is None:
                         list_sep = ' '
+                    escaped_val = []
                     for x in val:
-                        s = str(x)
                         if escape:
-                            s = escape_string(str(x))
-                        if val.index(x) == len(val)-1:
-                            s_val += s
+                            escaped_val.append(escape_string(str(x)))
                         else:
-                            s_val += s + list_sep
-                    val = s_val
+                            escaped_val.append(str(x))
+                    val = list_sep.join(escaped_val)
                 elif escape:
                     val = escape_string(val)
                 # Add flags and separator if necessary

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1033,10 +1033,8 @@ class LocalExecutor(object):
                         list_sep = ' '
                     escaped_val = []
                     for x in val:
-                        if escape:
-                            escaped_val.append(escape_string(str(x)))
-                        else:
-                            escaped_val.append(str(x))
+                        escaped_val.append(escape_string(str(x)) if
+                                           escape else str(x))
                     val = list_sep.join(escaped_val)
                 elif escape:
                     val = escape_string(val)

--- a/tools/python/boutiques/schema/examples/list_separator.json
+++ b/tools/python/boutiques/schema/examples/list_separator.json
@@ -1,5 +1,5 @@
 {
-    "command-line": "[INPUT_LIST_NUMBER] [INPUT_LIST_FILE]",
+    "command-line": "[INPUT_LIST_NUMBER] [INPUT_LIST_FILE] [INPUT_LIST_STRING]",
     "description": "A command with custom list separators",
     "inputs": [
         {
@@ -19,6 +19,16 @@
             "list-separator": ",",
             "min-list-entries": 2,
             "value-key": "[INPUT_LIST_FILE]"
+        },
+        {
+            "id": "input_list_string",
+            "name": "Input string list",
+            "type": "String",
+            "list": true,
+            "min-list-entries": 4,
+            "list-separator": "', !",
+            "value-choices": ["string1", "string2"],
+            "value-key": "[INPUT_LIST_STRING]"
         }
     ],
     "name": "list separator",

--- a/tools/python/boutiques/schema/examples/list_separator_inv.json
+++ b/tools/python/boutiques/schema/examples/list_separator_inv.json
@@ -1,4 +1,5 @@
 {
   "input_list_number": [1, 2, 3],
-  "input_list_file":["foo.txt", "bar.m"]
+  "input_list_file":["foo.txt", "bar.m"],
+  "input_list_string": ["string1", "string2", "string2", "string1"]
 }


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#577 

## Purpose
<!--- A clear and concise description of what the PR does. -->
List separators should only be added between items, not before the first item or after the last.

## Current behaviour
<!--- Tell us what currently happens -->
When simulating inputs for an input of type list and list contains repeating value, an extra list separator is added to the end of the list.

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
List separator is added only between items, even if list contains repeating items.

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Bug caused by the following condition falsely passing if the list 'val' contains repeating items
```python3
if val.index(x) == len(val)-1:
    s_val += s
```

