### PR TITLE
Bosh simulate consistency patch

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -282,7 +282,7 @@ def execute(*params):
             # Add optional inputs with default-value to inputs_dict,
             # which is then populated with random params
             executor.in_dict = addDefaultValues(executor.desc_dict, {})
-            executor.generateRandomParams()
+            executor.generateRandomParams(generateCmdLineFromInDict=True)
 
         if results.json:
             sout = [json.dumps(

--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -279,7 +279,10 @@ def execute(*params):
                                   "requireComplete": results.complete,
                                   "sandbox": results.sandbox})
         if not inp:
-            executor.generateRandomParams(1)
+            # Add optional inputs with default-value to inputs_dict,
+            # which is then populated with random params
+            executor.in_dict = addDefaultValues(executor.desc_dict, {})
+            executor.generateRandomParams()
 
         if results.json:
             sout = [json.dumps(
@@ -674,7 +677,7 @@ def example(*params):
                               "skipDataCollect": True,
                               "requireComplete": results.complete,
                               "sandbox": results.sandbox})
-    executor.generateRandomParams(1)
+    executor.generateRandomParams()
     return json.dumps(
         customSortInvocationByInput(executor.in_dict, descriptor), indent=4)
 

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -938,7 +938,7 @@ class LocalExecutor(object):
         # encountered before blowing up
         except Exception as e:  # Avoid BaseExceptions like SystemExit
             sys.stderr.write("An error occurred in validation\n"
-                                "Previously saved issues\n")
+                             "Previously saved issues\n")
             for err in self.errs:
                 sys.stderr.write("\t" + str(err) + "\n")
             raise e  # Pass on (throw) the caught exception

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -914,7 +914,7 @@ class LocalExecutor(object):
     # Function to generate random parameter values
     # This fills the in_dict with random values, validates the input,
     # and generates the appropriate command line
-    def generateRandomParams(self):
+    def generateRandomParams(self, generateCmdLineFromInDict=False):
 
         '''
         The generateRandomParams method fills the in_dict field
@@ -942,8 +942,9 @@ class LocalExecutor(object):
             for err in self.errs:
                 sys.stderr.write("\t" + str(err) + "\n")
             raise e  # Pass on (throw) the caught exception
-        # Add new command line
-        self.cmd_line.append(self._generateCmdLineFromInDict())
+        if generateCmdLineFromInDict:
+            # Add new command line
+            self.cmd_line.append(self._generateCmdLineFromInDict())
 
     # Read in parameter input file or string
     def readInput(self, infile):

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -848,7 +848,8 @@ class LocalExecutor(object):
 
         # Start actual dictionary filling part
         # Clear the dictionary
-        self.in_dict = {}
+        self.in_dict = self.in_dict if hasattr(self, 'in_dict') and\
+            self.in_dict is not None else {}
         for params in [r for r in self.inputs if not r.get('optional')]:
             self.in_dict[params['id']] = makeParam(params)
 
@@ -913,38 +914,36 @@ class LocalExecutor(object):
     # Function to generate random parameter values
     # This fills the in_dict with random values, validates the input,
     # and generates the appropriate command line
-    def generateRandomParams(self, n):
+    def generateRandomParams(self):
 
         '''
         The generateRandomParams method fills the in_dict field
         with randomly generated values following the schema.
-        It then generates command line strings based on these
-        values (more than 1 if -n was given).
+        It then generates command line strings based on these values
         '''
 
         self.cmd_line = []
-        for i in range(0, n):
-            # Set in_dict with random values
-            self._randomFillInDict()
-            # Look at generated input, if debugging
-            if self.debug:
-                print_info("Input: " + str(self.in_dict))
-            # Check results (as much as possible)
-            try:
-                args = [self.desc_path, "-i", json.dumps(self.in_dict)]
-                if self.sandbox:
-                    args.append("--sandbox")
-                boutiques.invocation(*args)
-            # If an error occurs, print out the problems already
-            # encountered before blowing up
-            except Exception as e:  # Avoid BaseExceptions like SystemExit
-                sys.stderr.write("An error occurred in validation\n"
-                                 "Previously saved issues\n")
-                for err in self.errs:
-                    sys.stderr.write("\t" + str(err) + "\n")
-                raise e  # Pass on (throw) the caught exception
-            # Add new command line
-            self.cmd_line.append(self._generateCmdLineFromInDict())
+        # Set in_dict with random values
+        self._randomFillInDict()
+        # Look at generated input, if debugging
+        if self.debug:
+            print_info("Input: " + str(self.in_dict))
+        # Check results (as much as possible)
+        try:
+            args = [self.desc_path, "-i", json.dumps(self.in_dict)]
+            if self.sandbox:
+                args.append("--sandbox")
+            boutiques.invocation(*args)
+        # If an error occurs, print out the problems already
+        # encountered before blowing up
+        except Exception as e:  # Avoid BaseExceptions like SystemExit
+            sys.stderr.write("An error occurred in validation\n"
+                                "Previously saved issues\n")
+            for err in self.errs:
+                sys.stderr.write("\t" + str(err) + "\n")
+            raise e  # Pass on (throw) the caught exception
+        # Add new command line
+        self.cmd_line.append(self._generateCmdLineFromInDict())
 
     # Read in parameter input file or string
     def readInput(self, infile):

--- a/tools/python/boutiques/schema/examples/test_simulate_consistency.json
+++ b/tools/python/boutiques/schema/examples/test_simulate_consistency.json
@@ -1,0 +1,18 @@
+{
+    "name": "tool",
+    "tool-version": "1",
+    "description": "a tool",
+    "command-line": "tool_cli [VALUE]",
+    "schema-version": "0.5",
+    "inputs": [
+        {
+            "id": "value",
+            "name": "value",
+            "type": "String",
+            "value-key": "[VALUE]",
+            "value-choices": ["yes", "no"],
+            "default-value": "no",
+            "optional": true
+        }
+    ]
+}

--- a/tools/python/boutiques/schema/examples/test_simulate_consistency_configFile.json
+++ b/tools/python/boutiques/schema/examples/test_simulate_consistency_configFile.json
@@ -1,0 +1,31 @@
+{
+    "name": "tool",
+    "tool-version": "1",
+    "description": "a tool",
+    "command-line": "tool_cli [CONFIG_FILE]",
+    "schema-version": "0.5",
+    "inputs": [
+    {
+        "id": "value",
+        "name": "value",
+        "type": "String",
+        "value-key": "[VALUE]",
+        "value-choices": ["yes", "no"],
+        "default-value": "no",
+        "optional": true
+    }
+    ],
+    "output-files": [
+    {
+        "id": "config_file",
+        "name": "Configuration file",
+        "value-key": "[CONFIG_FILE]",
+        "path-template": "tmpConfig.toml",
+        "file-template": [
+            "hi__",
+            "value = [VALUE]",
+            "__bye"
+            ]
+        }
+    ]
+}

--- a/tools/python/boutiques/tests/test_example.py
+++ b/tools/python/boutiques/tests/test_example.py
@@ -55,5 +55,7 @@ class TestExample(TestCase):
         # Bosh example is inherently random,
         # Couldn't even inject prederemined input to executor.in_dict
         # because _randomFillInDict clears it
-        executor.generateRandomParams(100)
-        self.assertGreater(len(executor.in_dict), 0)
+        for _ in range(0, 100):
+            executor.generateRandomParams()
+            self.assertGreater(len(executor.in_dict), 0)
+            executor.in_dict = None

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -184,7 +184,7 @@ class TestSimulate(TestCase):
 
         self.assertNotIn("  ", command)
 
-    def test_consistency_withANDwithout_invoc(self):
+    def test_consistency_withAndWithout_invoc(self):
         descriptor = os.path.join(os.path.split(bfile)[0],
                                   'schema/examples/'
                                   'test_simulate_consistency.json')
@@ -192,3 +192,27 @@ class TestSimulate(TestCase):
         wInvoc = bosh.execute("simulate", descriptor, "-i",
                               bosh.example(descriptor)).stdout
         self.assertEqual(noInvoc, wInvoc)
+
+    def test_consistency_withAndWithout_invoc_withConfigFile(self):
+        descriptor = os.path.join(os.path.split(bfile)[0],
+                                  'schema/examples/'
+                                  'test_simulate_consistency_configFile.json')
+        invoc = "tmpInvoc.json"
+        config = "tmpConfig.toml"
+        wInvocCommand = (f"bosh example {descriptor}" +
+                         f" > {invoc} " +
+                         f" && bosh exec simulate {descriptor} -i {invoc}")
+        noInvocCommand = (f"bosh exec simulate {descriptor}")
+
+        subprocess.call(wInvocCommand, shell=True)
+        with open(config, "r+") as configFile:
+            wInvoc = configFile.readlines()
+            os.remove(config)
+            os.remove(invoc)
+
+        subprocess.call(noInvocCommand, shell=True)
+        with open(config, "r+") as configFile:
+            noInvoc = configFile.readlines()
+            os.remove(config)
+
+        self.assertEqual(wInvoc, noInvoc)

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -183,3 +183,12 @@ class TestSimulate(TestCase):
         command = re.search(r"(test[ \da-z]+)", output).group(0)
 
         self.assertNotIn("  ", command)
+
+    def test_consistency_withANDwithout_invoc(self):
+        descriptor = os.path.join(os.path.split(bfile)[0],
+                                  'schema/examples/'
+                                  'test_simulate_consistency.json')
+        noInvoc = bosh.execute("simulate", descriptor).stdout
+        wInvoc = bosh.execute("simulate", descriptor, "-i",
+                              bosh.example(descriptor)).stdout
+        self.assertEqual(noInvoc, wInvoc)

--- a/tools/python/boutiques/tests/test_simulate.py
+++ b/tools/python/boutiques/tests/test_simulate.py
@@ -199,10 +199,11 @@ class TestSimulate(TestCase):
                                   'test_simulate_consistency_configFile.json')
         invoc = "tmpInvoc.json"
         config = "tmpConfig.toml"
-        wInvocCommand = (f"bosh example {descriptor}" +
-                         f" > {invoc} " +
-                         f" && bosh exec simulate {descriptor} -i {invoc}")
-        noInvocCommand = (f"bosh exec simulate {descriptor}")
+        wInvocCommand = ("bosh example {0}" +
+                         " > {1} " +
+                         " && bosh exec simulate {0} -i {1}").format(descriptor,
+                                                                     invoc)
+        noInvocCommand = "bosh exec simulate {0}".format(descriptor, invoc)
 
         subprocess.call(wInvocCommand, shell=True)
         with open(config, "r+") as configFile:


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#578 

## Purpose
<!--- A clear and concise description of what the PR does. -->
`bosh exec simulate` should yield consistent results regardless of an invocation's presence through option `-i`.

## Current behaviour
<!--- Tell us what currently happens -->
Descriptor's `optional: true` inputs with `default-value` are not added to simulated command-line output, but are added when an invocation (created by bosh example) is supplied.

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
`optional: true` inputs with `default-value` are added to simulated command-line output consistently.

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
In `simulate`, `localExec.addDefaultValues` is called before `LocalExecutor.generateRandomParams`.

`LocalExecutor.generateRandomParams` no longer takes argument `n` for the number of iterations to attempt. This is to prevent the `LocalExecutor.in_dict` from clearing before each iteration (`in_dict` contains inputs to use when generating random param values).
