### PR TITLE
Added camel case option for descriptor inputs

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -56,6 +56,8 @@ def parser_create():
     parser.add_argument("--use-singularity", '-u', action="store_true",
                         help="When --docker-image is used. Specify to "
                              "use singularity to run it.")
+    parser.add_argument("--camel-case", action="store_true",
+                        help="All input IDs will be written in camelCase.")
     return parser
 
 
@@ -66,7 +68,8 @@ def create(*params):
     from boutiques.creator import CreateDescriptor
     new = CreateDescriptor(parser=None,
                            docker_image=results.docker_image,
-                           use_singularity=results.use_singularity)
+                           use_singularity=results.use_singularity,
+                           camel_case=results.camel_case)
     new.save(results.descriptor)
     return None
 

--- a/tools/python/boutiques/creator.py
+++ b/tools/python/boutiques/creator.py
@@ -10,7 +10,7 @@ from jsonschema import validate, ValidationError
 from argparse import ArgumentParser
 from boutiques import __file__ as bfile
 from boutiques.logger import raise_error, print_info, print_warning
-from boutiques.util.utils import customSortDescriptorByKey
+from boutiques.util.utils import customSortDescriptorByKey, camelCaseInputIds
 import subprocess
 
 
@@ -42,6 +42,10 @@ class CreateDescriptor(object):
             if type(parser) is not argparse.ArgumentParser:
                 raise_error(CreatorError, "Invalid argument parser")
             self.parseParser(**kwargs)
+
+        self.camelCase = kwargs.get('camel_case')
+        if self.camelCase:
+            self.descriptor = camelCaseInputIds(self.descriptor)
 
     def save(self, filename):
         with open(filename, "w") as f:

--- a/tools/python/boutiques/templates/basic.json
+++ b/tools/python/boutiques/templates/basic.json
@@ -17,8 +17,8 @@
             "all-or-none": true,
             "id": "group1",
             "members": [
-                "param1",
-                "flag1"
+                "basic_param1",
+                "basic_flag1"
             ],
             "mutually-exclusive": false,
             "name": "the param group",
@@ -27,14 +27,14 @@
     ],
     "inputs": [
         {
-            "id": "param1",
+            "id": "basic_param1",
             "name": "The first parameter",
             "optional": true,
             "type": "File",
             "value-key": "[PARAM1]"
         },
         {
-            "id": "param2",
+            "id": "basic_param2",
             "name": "The second parameter",
             "optional": false,
             "type": "String",
@@ -46,7 +46,7 @@
         },
         {
             "command-line-flag": "-f",
-            "id": "flag1",
+            "id": "basic_flag1",
             "name": "The first flag",
             "optional": true,
             "type": "Flag",
@@ -56,7 +56,7 @@
     "name": "tool name",
     "output-files": [
         {
-            "id": "output1",
+            "id": "basic_output1",
             "name": "The first output",
             "optional": false,
             "path-template": "[PARAM2].txt",

--- a/tools/python/boutiques/tests/test_creator.py
+++ b/tools/python/boutiques/tests/test_creator.py
@@ -4,6 +4,7 @@ from argparse import ArgumentParser
 from unittest import TestCase
 from boutiques.bosh import bosh
 from boutiques import __file__ as bfile
+from boutiques.util.utils import loadJson
 import boutiques.creator as bc
 import subprocess
 import os.path as op
@@ -86,3 +87,23 @@ class TestCreator(TestCase):
 
         self.assertIsNone(bosh(['validate', fil]))
         self.assertIsNone(bosh(['invocation', fil, '-i', invof]))
+
+    def test_success_template_camel_case(self):
+        template = './boutiques/templates/basic.json'
+        fil = 'creator_output.json'
+        bosh(['create', fil, '--camel-case'])
+        self.assertIsNone(bosh(['validate', fil]))
+
+        desc = loadJson(fil)
+        template = loadJson(template)
+
+        # Check "_" in all instances of input indices (inputs + groups)
+        for inp, camelInp in zip(template['inputs'], desc['inputs']):
+            self.assertTrue("_" in inp['id'])
+            self.assertFalse("_" in camelInp['id'])
+
+        for mbrs, camelMbrs in [(grp['members'], camelGrp['members']) for
+                                grp, camelGrp in
+                                zip(template['groups'], desc['groups'])]:
+            self.assertTrue(all([("_" in mbr) for mbr in mbrs]))
+            self.assertFalse(all([("_" in camelMbr) for camelMbr in camelMbrs]))

--- a/tools/python/boutiques/util/utils.py
+++ b/tools/python/boutiques/util/utils.py
@@ -134,12 +134,21 @@ def snakeCaseToCamelCase(id):
 
 
 def camelCaseInputIds(descriptor):
+    conversion_dict = {}
     if 'inputs' in descriptor:
         for inp in descriptor['inputs']:
-            inp['id'] = snakeCaseToCamelCase(inp['id'])
-    if 'groups' in descriptor:
-        for members in [g['members'] for g in descriptor['groups']
-                        if 'members' in g]:
-            for idx, member in enumerate(members):
-                members[idx] = snakeCaseToCamelCase(member)
+            camelCaseId = snakeCaseToCamelCase(inp['id'])
+            conversion_dict[inp['id']] = camelCaseId
+
+    # Find all instances of old input ids
+    # and replace them with camelCase ids
+    plainTextDesc = json.dumps(descriptor, indent=2)
+    for k, v in conversion_dict.items():
+        # Only replace ids surrounded by single/double quotes,
+        # in case the the old input ids are used in other strings
+        plainTextDesc = plainTextDesc.replace("\"{0}\"".format(k),
+                                              "\"{0}\"".format(v))
+        plainTextDesc = plainTextDesc.replace("\'{0}\'".format(k),
+                                              "\'{0}\'".format(v))
+    descriptor = json.loads(plainTextDesc)
     return descriptor

--- a/tools/python/boutiques/util/utils.py
+++ b/tools/python/boutiques/util/utils.py
@@ -123,3 +123,23 @@ def customSortInvocationByInput(invocation, descriptor):
                       " original invocation.")
         return invocation
     return sortedInvoc
+
+
+def snakeCaseToCamelCase(id):
+    words = id.split("_")
+    for idx, word in enumerate(words[1:]):
+        if word[0].islower():
+            words[idx+1] = word[0].upper() + word[1:]
+    return "".join(words)
+
+
+def camelCaseInputIds(descriptor):
+    if 'inputs' in descriptor:
+        for inp in descriptor['inputs']:
+            inp['id'] = snakeCaseToCamelCase(inp['id'])
+    if 'groups' in descriptor:
+        for members in [g['members'] for g in descriptor['groups']
+                        if 'members' in g]:
+            for idx, member in enumerate(members):
+                members[idx] = snakeCaseToCamelCase(member)
+    return descriptor


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#503 

## Purpose
<!--- A clear and concise description of what the PR does. -->
`boutiques.creator.CreateDescriptor` should have an option to convert all parameter names to CamelCase. When this option is used, all input IDs should be written in Camel Case.

## Current behaviour
<!--- Tell us what currently happens -->
NA

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
Added `--camel-case` option to `creator.CreateDescriptor` (regrettably not --camelCase for the sake of consistency).

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
1) Gets input ids from descriptor object
2) Util functions convert ids to camel case
3) All instances of input ids (within single/double quotes) are replaced in plain-text descriptor
4) Descriptor is reloaded
