### PR TITLE
Added publication date to bosh search --verbose

### DIFF
--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -119,6 +119,7 @@ class Searcher():
             (id, title, description, downloads) = self.parse_basic_info(hit)
             author = hit["metadata"]["creators"][0]["name"]
             version = hit["metadata"]["version"]
+            publication_date = hit["metadata"]['publication_date']
             doi = hit["doi"]
             keyword_data = self.get_keyword_data(hit["metadata"]["keywords"])
             schema_version = keyword_data["schema-version"]
@@ -127,6 +128,7 @@ class Searcher():
             result_dict = OrderedDict([("ID", id),
                                       ("TITLE", title),
                                       ("DESCRIPTION", description),
+                                      ("PUBLICATION DATE", publication_date),
                                       ("DEPRECATED", 'deprecated' in
                                        keyword_data['other']),
                                       ("DOWNLOADS", downloads),

--- a/tools/python/boutiques/tests/boutiques_mocks.py
+++ b/tools/python/boutiques/tests/boutiques_mocks.py
@@ -92,6 +92,7 @@ def get_zenodo_record(record):
                 }
             ],
             "description": record.description,
+            "publication_date": "2020-04-15",
             "relations": {
                 'version': [
                     {

--- a/tools/python/boutiques/tests/test_search.py
+++ b/tools/python/boutiques/tests/test_search.py
@@ -70,10 +70,9 @@ class TestSearch(TestCase):
         results = bosh(["search", "-v"])
         self.assertGreater(len(results), 0)
         self.assertEqual(list(results[0].keys()),
-                         ["ID", "TITLE", "DESCRIPTION", "DEPRECATED",
-                          "DOWNLOADS", "AUTHOR", "VERSION",
-                          "DOI", "SCHEMA VERSION",
-                          "CONTAINER", "TAGS"])
+                         ["ID", "TITLE", "DESCRIPTION", "PUBLICATION DATE",
+                          "DEPRECATED", "DOWNLOADS", "AUTHOR", "VERSION",
+                          "DOI", "SCHEMA VERSION", "CONTAINER", "TAGS"])
 
     @mock.patch('requests.get')
     def test_search_specify_max_results(self, mymockget):


### PR DESCRIPTION
Related issues
<!-- List the issue(s) that are addressed by this PR -->
#604

## Purpose
<!--- A clear and concise description of what the PR does. -->
`bosh search` should return the upload date next to the other fields returned when using the verbose option.

## Current behaviour
<!--- Tell us what currently happens -->
The following columns are shown in `bosh search [INPUT] --verbose`
`ID, TITLE, DESCRIPTION, DEPRECATED, DOWNLOADS, AUTHOR, VERSION, DOI, SCHEMA, VERSION, CONTAINER, TAGS`

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
`ID, TITLE, DESCRIPTION, PUBLICATION DATE, DEPRECATED, DOWNLOADS, AUTHOR, VERSION, DOI, SCHEMA, VERSION, CONTAINER, TAGS`
![Screenshot from 2020-04-17 14-34-43](https://user-images.githubusercontent.com/6406509/79602649-dbe86600-80b8-11ea-9684-26d4ec002796.png)

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Date located in `hit["metadata"]['publication_date']`, there's also `hit['created']` which contains datetime if needed.