### PR TITLE
Btest use imagepath

### DIFF
--- a/tools/python/boutiques/bosh.py
+++ b/tools/python/boutiques/bosh.py
@@ -570,6 +570,9 @@ def parser_test():
     parser.add_argument("--sandbox", action="store_true",
                         help="Get descriptor from Zenodo's sandbox instead of "
                         "production server.")
+    parser.add_argument("--imagepath", action="store",
+                        help="Path to Singularity image. "
+                        "If not specified, will use current directory.")
     return parser
 
 
@@ -603,7 +606,10 @@ def test(*params):
 
     # Invocations have been properly validated. We can launch the actual tests.
     test_path = op.join(op.dirname(op.realpath(__file__)), "test.py")
-    return pytest.main([test_path, "--descriptor", results.descriptor])
+    test_args = [test_path, "--descriptor", results.descriptor]
+    if results.imagepath:
+        test_args.extend(["--imagepath", results.imagepath])
+    return pytest.main(args=test_args)
 
 
 test.__doc__ = parser_test().format_help()

--- a/tools/python/boutiques/conftest.py
+++ b/tools/python/boutiques/conftest.py
@@ -6,9 +6,10 @@ from boutiques.util.utils import loadJson
 
 def pytest_addoption(parser):
     parser.addoption("--descriptor", action="append", default=[])
+    parser.addoption("--imagepath", action="append", default=['./'])
 
 
-def fetch_tests(descriptor_input):
+def fetch_tests(descriptor_input, imagepath):
 
     descriptor = loadJson(descriptor_input)
 
@@ -25,7 +26,7 @@ def fetch_tests(descriptor_input):
         temp_invocation_JSON.seek(0)
 
         # Now we setup the necessary elements for the testing function.
-        tests.append([descriptor_input, test, temp_invocation_JSON])
+        tests.append([descriptor_input, test, temp_invocation_JSON, imagepath])
 
     return (descriptor["name"], tests)
 
@@ -33,6 +34,7 @@ def fetch_tests(descriptor_input):
 # This function will be executed by pytest before the actual testing
 def pytest_generate_tests(metafunc):
     descriptor_filename = metafunc.config.getoption('descriptor')[0]
+    imagepath = metafunc.config.getoption('imagepath')[0]
 
     # Each element in 'tests' will hold the necessary informations
     # for a single test
@@ -42,7 +44,7 @@ def pytest_generate_tests(metafunc):
     #                         (more convenient, no need to extract
     #                          again from descriptor)
     #                         .The invocation file needed for the test
-    descriptor_name, tests = fetch_tests(descriptor_filename)
+    descriptor_name, tests = fetch_tests(descriptor_filename, imagepath)
 
     # Generate the test ids for each of the test cases.
     # An id is created by concatenaning the name of the descriptor
@@ -50,4 +52,5 @@ def pytest_generate_tests(metafunc):
     names = ["{0}_{1}".format(op.basename(descriptor_filename),
              params[1]["name"].replace(' ', '-')) for params in tests]
 
-    metafunc.parametrize("descriptor, test, invocation", tests, ids=names)
+    metafunc.parametrize("descriptor, test, invocation, imagepath",
+                         tests, ids=names)

--- a/tools/python/boutiques/conftest.py
+++ b/tools/python/boutiques/conftest.py
@@ -6,11 +6,12 @@ from boutiques.util.utils import loadJson
 
 def pytest_addoption(parser):
     parser.addoption("--descriptor", action="append", default=[])
-    parser.addoption("--imagepath", action="append", default=['./'])
+
+    # Additional options during bosh exec launch:
+    parser.addoption("--imagepath", action="store")
 
 
-def fetch_tests(descriptor_input, imagepath):
-
+def fetch_tests(descriptor_input, paramsDict):
     descriptor = loadJson(descriptor_input)
 
     tests = []
@@ -26,7 +27,7 @@ def fetch_tests(descriptor_input, imagepath):
         temp_invocation_JSON.seek(0)
 
         # Now we setup the necessary elements for the testing function.
-        tests.append([descriptor_input, test, temp_invocation_JSON, imagepath])
+        tests.append([descriptor_input, test, temp_invocation_JSON, paramsDict])
 
     return (descriptor["name"], tests)
 
@@ -34,17 +35,20 @@ def fetch_tests(descriptor_input, imagepath):
 # This function will be executed by pytest before the actual testing
 def pytest_generate_tests(metafunc):
     descriptor_filename = metafunc.config.getoption('descriptor')[0]
-    imagepath = metafunc.config.getoption('imagepath')[0]
+    additional_params = {"--skip-data-collection": None}
 
+    if metafunc.config.option.imagepath is not None:
+        additional_params['--imagepath'] = metafunc.config.option.imagepath
     # Each element in 'tests' will hold the necessary informations
     # for a single test
     # Those informations are:
-    #                         . The descriptor (common to all)
-    #                         . The related JSON data, describing the test
-    #                         (more convenient, no need to extract
-    #                          again from descriptor)
-    #                         .The invocation file needed for the test
-    descriptor_name, tests = fetch_tests(descriptor_filename, imagepath)
+    #     . The descriptor (common to all)
+    #     . The related JSON data, describing the test
+    #       (more convenient, no need to extract
+    #        again from descriptor)
+    #     . The invocation file needed for the test
+    #     . Any additional options listed in conftest.pytest_addoption()
+    descriptor_name, tests = fetch_tests(descriptor_filename, additional_params)
 
     # Generate the test ids for each of the test cases.
     # An id is created by concatenaning the name of the descriptor
@@ -52,5 +56,5 @@ def pytest_generate_tests(metafunc):
     names = ["{0}_{1}".format(op.basename(descriptor_filename),
              params[1]["name"].replace(' ', '-')) for params in tests]
 
-    metafunc.parametrize("descriptor, test, invocation, imagepath",
+    metafunc.parametrize("descriptor, test, invocation, paramsDict",
                          tests, ids=names)

--- a/tools/python/boutiques/test.py
+++ b/tools/python/boutiques/test.py
@@ -2,7 +2,6 @@ import os.path as op
 from boutiques import __file__ as bfile
 import boutiques as bosh
 import hashlib
-import pytest
 
 
 def compute_md5(filename):
@@ -10,10 +9,17 @@ def compute_md5(filename):
         return hashlib.md5(open(filename, 'rb').read()).hexdigest()
 
 
-def test(descriptor, test, invocation, imagepath):
+def test(descriptor, test, invocation, paramsDict):
+    arguments = ["launch", descriptor, invocation.name]
+
+    # Add any additional params to arguments
+    for flag, value in paramsDict.items():
+        arguments.append(flag)
+        if value is not None:
+            arguments.append(value)
+
+    print(arguments)
     # Run pipeline.
-    arguments = ["launch", descriptor, invocation.name,
-                 "--skip-data-collection", "--imagepath", imagepath]
     ret = bosh.execute(*arguments)
     print(ret)
 

--- a/tools/python/boutiques/test.py
+++ b/tools/python/boutiques/test.py
@@ -10,12 +10,11 @@ def compute_md5(filename):
         return hashlib.md5(open(filename, 'rb').read()).hexdigest()
 
 
-def test(descriptor, test, invocation):
+def test(descriptor, test, invocation, imagepath):
     # Run pipeline.
-    ret = bosh.execute("launch",
-                       descriptor,
-                       invocation.name,
-                       "--skip-data-collection")
+    arguments = ["launch", descriptor, invocation.name,
+                 "--skip-data-collection", "--imagepath", imagepath]
+    ret = bosh.execute(*arguments)
     print(ret)
 
     # Choose appropriate assertion scenario


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#463 #5 

## Purpose
<!--- A clear and concise description of what the PR does. -->
Enable imagepath for `bosh test` to speed up testing within a tool.

## Current behaviour
<!--- Tell us what currently happens -->
`bosh test` uses `bosh exec launch` but does not have the `--imagepath` option enabled.

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
`--imagepath` option is added to `bosh test` so the image path is passed to `bosh exec launch` during individual tests.

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
During `bosh test`, additional options such as `--skip-data-collection` and `--imagepath` are added to a dict and passed to `test` in test.py. These additional options are appended to launch arguments.
