### PR TITLE
FileExistsError during concurrent boutiques instances

### DIFF
--- a/tools/python/boutiques/dataHandler.py
+++ b/tools/python/boutiques/dataHandler.py
@@ -303,7 +303,7 @@ def getDataCacheDir():
     cache_dir = os.path.join(os.path.expanduser('~'), ".cache", "boutiques")
     data_cache_dir = os.path.join(cache_dir, "data")
     if not os.path.exists(cache_dir):
-        os.makedirs(cache_dir)
+        os.makedirs(cache_dir, exist_ok=True)
     if not os.path.exists(data_cache_dir):
-        os.makedirs(data_cache_dir)
+        os.makedirs(data_cache_dir, exist_ok=True)
     return data_cache_dir


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#610 

## Current behaviour
<!--- Tell us what currently happens -->
`FileExistsError` when running Boutiques in a multiprocessing environment (Travis).

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Added `exists_ok=True` to os.makedirs (default: `exists_ok=False`, docs: ```If the target directory already exists, raise an OSError if exist_ok is False. Otherwise no exception is raised. This is recursive.```)
