### PR TITLE
Publisher crash forwardslash

### DIFF
--- a/tools/python/boutiques/schema/examples/test_forward_slash_toolName.json
+++ b/tools/python/boutiques/schema/examples/test_forward_slash_toolName.json
@@ -1,0 +1,27 @@
+{
+    "name": "beforeSlash/afterSlash",
+    "container-image": {
+        "image": "user/image",
+        "index": "docker://",
+        "type": "singularity"
+    },
+    "author": "test",
+    "tool-version": "1",
+    "description": "a tool",
+    "command-line": "tool_cli [VALUE]",
+    "schema-version": "0.5",
+    "inputs": [
+        {
+            "id": "value",
+            "name": "value",
+            "type": "String",
+            "value-key": "[VALUE]",
+            "value-choices": [
+                "yes",
+                "no"
+            ],
+            "default-value": "no",
+            "optional": true
+        }
+    ]
+}

--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -14,26 +14,22 @@ class Searcher():
 
     def __init__(self, query, verbose=False, sandbox=False, max_results=None,
                  no_trunc=False, exact_match=False):
-
         if query is not None:
             self.query = query
-            if not exact_match:
-                terms = self.query.split(" ")
-                self.query_line = ''
-                for t in terms:
-                    uncased_term = ''
-                    for ch in t:
-                        uncased_term = uncased_term + "[" + ch.upper() +\
-                            ch.lower() + "]"
-                    uncased_term = quote(uncased_term)
-                    self.query_line = self.query_line + \
-                        ' AND (/.*%s.*/)' % uncased_term
-            else:
-                self.query_line =\
-                        ' AND (/%s/)' % self.query
-        else:
             self.query_line = ''
+            if not exact_match:
+                terms = self.query.replace('/', '.').split(" ")
+                for t in terms:
+                    uncased_term = ["[{0}]".format(ch.upper() + ch.lower()
+                                                   if ch.isalpha() else ch)
+                                    for ch in t]
+                    uncased_term = quote("".join(uncased_term))
+                    self.query_line += ' AND (/.*%s.*/)' % uncased_term
+            else:
+                self.query_line = ' AND (/%s/)' % self.query.replace('/', '.')
+        else:
             self.query = ''
+            self.query_line = ''
 
         if(verbose):
             print_info("Using Query Line: " + self.query_line)

--- a/tools/python/boutiques/tests/test_publisher.py
+++ b/tools/python/boutiques/tests/test_publisher.py
@@ -11,6 +11,7 @@ import sys
 import mock
 from boutiques_mocks import *
 from unittest import TestCase
+from boutiques.util.utils import loadJson
 
 
 def mock_get_publish_then_update():
@@ -298,3 +299,25 @@ class TestPublisher(TestCase):
                   "-y", "-v", "--zenodo-token", "12345"])
         self.assertIn("You do not have permission to access this "
                       "resource.", str(e.exception))
+
+    @mock.patch('requests.post', side_effect=mock_post_publish_then_update())
+    @mock.patch('requests.put', return_value=mock_put())
+    @mock.patch('requests.delete', return_value=mock_delete())
+    def test_publication_toolname_forwardslash(self,  mock_post,
+                                               mock_put, mock_delete):
+        test_desc = op.join(self.get_examples_dir(),
+                            'test_forward_slash_toolName.json')
+        with open(test_desc, 'r') as fhandle:
+            descriptor = json.load(fhandle)
+
+        # Publish an updated version of an already published descriptor
+        doi = bosh(["publish",
+                    test_desc,
+                    "--sandbox", "-y", "-v",
+                    "--zenodo-token", "hAaW2wSBZMskxpfigTYHcuDrC"
+                                      "PWr2VeQZgBLErKbfF5RdrKhzzJi8i2hnN8r"])
+
+        with open(test_desc, 'w') as fhandle:
+            fhandle.write(json.dumps(descriptor, indent=4))
+
+        self.assertEqual('10.5281/zenodo.1234567', doi)

--- a/tools/python/boutiques/tests/test_search.py
+++ b/tools/python/boutiques/tests/test_search.py
@@ -28,9 +28,6 @@ def mock_get(query, exact, *args, **kwargs):
             mock_records.append(MockZenodoRecord(1234568, "foo-" + query))
             mock_records.append(MockZenodoRecord(1234569, query + "-bar"))
 
-    if 'mock_records' in kwargs:
-        mock_records.extend(kwargs['mock_records'])
-
     return mock_zenodo_search(mock_records)
 
 
@@ -118,17 +115,3 @@ class TestSearch(TestCase):
                 continue
             break
         self.assertTrue(has_no_trunc)
-
-    @mock.patch('requests.get')
-    def test_search_forward_slash(self, mymockget):
-        mock_record = MockZenodoRecord(
-            9999, "Before_slash/After_Slash 9999",
-            description="Lorem ipsum dolor sit amet, consectetur ...",
-            downloads=9999)
-
-        mymockget.side_effect = lambda *args, **kwargs:\
-            mock_get("slash", False, *args, **kwargs,
-                     mock_records=[mock_record])
-        results = bosh(["search", "Before_slash/After_Slash"])
-        self.assertEqual(mock_record.__dict__['title'],
-                         dict(results[0])['TITLE'])

--- a/tools/python/boutiques/tests/test_search.py
+++ b/tools/python/boutiques/tests/test_search.py
@@ -28,6 +28,9 @@ def mock_get(query, exact, *args, **kwargs):
             mock_records.append(MockZenodoRecord(1234568, "foo-" + query))
             mock_records.append(MockZenodoRecord(1234569, query + "-bar"))
 
+    if 'mock_records' in kwargs:
+        mock_records.extend(kwargs['mock_records'])
+
     return mock_zenodo_search(mock_records)
 
 
@@ -115,3 +118,17 @@ class TestSearch(TestCase):
                 continue
             break
         self.assertTrue(has_no_trunc)
+
+    @mock.patch('requests.get')
+    def test_search_forward_slash(self, mymockget):
+        mock_record = MockZenodoRecord(
+            9999, "Before_slash/After_Slash 9999",
+            description="Lorem ipsum dolor sit amet, consectetur ...",
+            downloads=9999)
+
+        mymockget.side_effect = lambda *args, **kwargs:\
+            mock_get("slash", False, *args, **kwargs,
+                     mock_records=[mock_record])
+        results = bosh(["search", "Before_slash/After_Slash"])
+        self.assertEqual(mock_record.__dict__['title'],
+                         dict(results[0])['TITLE'])


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#617

## Current behaviour
<!--- Tell us what currently happens -->
Publishing tool with name containing a '/' will cause:
`[ ERROR (400) ] Error searching Zenodo`

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
OK (returns doi)

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Replaced '/' in query with '.' wildcard.
