### PR TITLE
Bosh data search pull

### DIFF
--- a/tools/python/boutiques/tests/test_data_handler.py
+++ b/tools/python/boutiques/tests/test_data_handler.py
@@ -5,12 +5,26 @@ from boutiques.bosh import bosh
 from unittest import TestCase, skipIf
 from boutiques_mocks import *
 from boutiques.nexusHelper import NexusError
+from boutiques.puller import ZenodoError
+from boutiques_mocks import mock_zenodo_search, MockZenodoRecord,\
+    example_boutiques_tool
 import sys
 import os
 import mock
 import shutil
 import pytest
 import boutiques
+import tempfile
+import json
+
+try:
+    # Python 3
+    from urllib.request import urlopen
+    from urllib.request import urlretrieve
+except ImportError:
+    # Python 2
+    from urllib2 import urlopen
+    from urllib import urlretrieve
 
 
 def setup():
@@ -94,7 +108,132 @@ def mock_empty_function():
     return
 
 
+def mock_get(query, *args, **kwargs):
+    max_results = 5
+
+    # Long description text to test truncation
+    long_description = ("Lorem ipsum dolor sit amet, consectetur adipiscing "
+                        "elit, sed do eiusmod tempor incididunt ut labore et "
+                        "dolore magna aliqua. Ut enim ad minim veniam, quis "
+                        "nostrud exercitation ullamco laboris nisi ut aliquip "
+                        "ex ea commodo consequat.")
+
+    mock_records = []
+    # Return an arbitrary list of results with length max_results
+    if query == "boutiques":
+        for i in range(0, int(max_results)):
+            mock_records.append(MockZenodoRecord(i, "Example Tool %s" % i,
+                                                 long_description,
+                                                 "exampleTool%s.json" % i, i))
+    # Return only records containing the query
+    else:
+        mock_records.append(MockZenodoRecord(1234567, query))
+
+    return mock_zenodo_search(mock_records)
+
+
+def mock_urlretrieve(*args, **kwargs):
+    mock_record1 = MockZenodoRecord(2636983, "fsl_bet-2019-04-11T215451.747382.json_foo", "",
+                                    "https://zenodo.org/api/files/"
+                                    "aae134af-9b9b-4613-b7b9-d5c5adcc7e61/"
+                                    "fsl_bet-2019-04-11T215451.747382.json")
+    mock_record2 = MockZenodoRecord(2636975, "MCFLIRT_2019-10-18T141903.880238_foo", "",
+                                    "https://zenodo.org/api/files/"
+                                    "151ef721-9f86-49bd-ae3d-045ae1766ee8/"
+                                    "MCFLIRT-2019-04-11T213108.473348.json")
+
+
+    temp = tempfile.NamedTemporaryFile(delete=False, mode='w+t')
+    if "sl_bet-2019-04-11T215451.747382.json" in args[0]:
+        json.dump(mock_zenodo_search([mock_record1]).mock_json, temp)
+        temp.close()
+        return urlretrieve("file://%s" % temp.name, args[1])
+    if "MCFLIRT-2019-04-11T213108.473348.json" in args[0]:
+        json.dump(mock_zenodo_search([mock_record2]).mock_json, temp)
+        temp.close()
+        return urlretrieve("file://%s" % temp.name, args[1])
+    return urlretrieve(args[0], args[1])
+
+
 class TestDataHandler(TestCase):
+
+    @mock.patch('requests.get')
+    def test_search_all(self, mymockget):
+        mymockget.side_effect = lambda *args, **kwargs: \
+            mock_get("", False, *args, **kwargs)
+        results = bosh(["data", "search"])
+        self.assertGreater(len(results), 0)
+        self.assertEqual(list(results[0].keys()),
+                         ["ID", "TITLE", "DESCRIPTION",
+                          "DOWNLOADS"])
+
+
+    @mock.patch('requests.get')
+    def test_search_sorts_by_num_downloads(self, mymockget):
+        mymockget.side_effect = lambda *args, **kwargs:\
+            mock_get("boutiques",  *args, **kwargs)
+        results = bosh(["data", "search"])
+        downloads = []
+        for r in results:
+            downloads.append(r["DOWNLOADS"])
+        self.assertEqual(sorted(downloads, reverse=True), downloads)
+
+    @mock.patch('boutiques.dataHandler.urlretrieve', side_effect=mock_urlretrieve)
+    def test_pull(self, mock_urlretrieve):
+        print(example_boutiques_tool.id)
+        bosh(["data", "pull", "zenodo." + "2636975"])
+        cache_dir = os.path.join(
+            os.path.expanduser('~'), ".cache", "boutiques", "production")
+        self.assertTrue(os.path.exists(os.path.join(
+            cache_dir, "zenodo." + "2636975")))
+
+    @mock.patch('boutiques.dataHandler.urlretrieve', side_effect=mock_urlretrieve)
+    def test_pull_multi(self, mock_urlretrieve):
+        results = bosh(["data", "pull", "zenodo.2636983", "zenodo.2636975"])
+        cache_dir = os.path.join(os.path.expanduser('~'),
+                                 ".cache", "boutiques", "production")
+        # self.assertTrue(os.path.exists(os.path.join(
+        #     cache_dir, "zenodo" +"2636983" + ".json")))
+        # self.assertTrue(os.path.exists(os.path.join(cache_dir,
+        #                                             "zenodo-3563099.json")))
+        self.assertTrue(os.path.exists(os.path.join(
+            cache_dir, "zenodo." +"2636983")))
+        self.assertTrue(os.path.exists(os.path.join(cache_dir,
+                                                    "zenodo.2636975")))
+        self.assertEqual(len(results), 2, results)
+
+    @mock.patch('boutiques.dataHandler.urlretrieve', side_effect=mock_urlretrieve)
+    def test_pull_duplicate_collapses(self, mock_urlretrieve):
+        results = bosh(["data", "pull", "zenodo.2636983", "zenodo.2636975",
+                        "zenodo.2636975"])
+        self.assertEqual(len(results), 2, results)
+
+    @mock.patch('boutiques.dataHandler.urlretrieve', side_effect=mock_urlretrieve)
+    def test_pull_missing_raises_exception(self, mock_urlretrieve):
+        good1 = "zenodo.2636983"
+        good2 = "zenodo.2636975"
+        bad1 = "zenodo.9999990"
+        with self.assertRaises(ZenodoError) as e:
+            bosh(["data", "pull", good1, good2, bad1])
+        self.assertIn("Execution record \"{0}\" not found".format(
+            bad1.split(".")[1]),
+            str(e.exception))
+
+    @mock.patch('boutiques.dataHandler.urlretrieve', side_effect=mock_urlretrieve)
+    def test_pull_missing_prefix(self, mock_urlretrieve):
+        with self.assertRaises(ZenodoError) as e:
+            bosh(["data", "pull", "2636983"])
+        self.assertIn("Zenodo ID must be prefixed by 'zenodo'",
+                      str(e.exception))
+
+    @mock.patch('boutiques.dataHandler.urlretrieve', side_effect=mock_urlretrieve)
+    def test_pull_not_found(self, mock_urlretrieve):
+        with self.assertRaises(ZenodoError) as e:
+            bosh(["data", "pull", "zenodo.99999"])
+        self.assertIn("Execution record \"{0}\" not found".format("99999"),
+                      str(e.exception))
+
+
 
     @mock.patch('boutiques.dataHandler.getDataCacheDir',
                 return_value=mock_get_data_cache())


### PR DESCRIPTION

## Related issues
No related issue
<!-- List the issue(s) that are addressed by this PR -->

## Checklist
<!--- Make sure to check the following items -->
- [x] **DO** Unit tests pass.
- [x] **DO** If new feature, created unit test.
- [ ] **TRY** If new API function, documented it (refer to

[PEP 257](https://www.python.org/dev/peps/pep-0257/)).

## Purpose

Adding search and pull feature for data provenance records to Boutiques.
#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Implementation Detail
-"bosh data search" search Zenodo for all data provenance records of Boutiques. ( with 2 keywords: Boutiques AND "boutiques-execution-record").
-"bosh data pull Zenodo.* " pull Boutiques data provenance records according to their Zenodo.ID, create a folder with Zenodo.ID name and store files with exact name in system cache.
- Add "boutiques-execution-record" as a new keyword to the publish function.
- Add a prompt to inspect function to print the directory of cached files.

