### PR TITLE
Docker used during sing exec

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -590,7 +590,7 @@ class LocalExecutor(object):
     def _chooseContainerTypeToUse(self, conType, forceSing=False,
                                   forceDocker=False):
         if ((conType == 'docker' and not forceSing or forceDocker) and
-            self._isCommandInstalled('docker')):
+           self._isCommandInstalled('docker')):
             return "docker"
 
         if self._isCommandInstalled('singularity'):

--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -589,9 +589,8 @@ class LocalExecutor(object):
     # descriptor, executor options and if Docker is installed.
     def _chooseContainerTypeToUse(self, conType, forceSing=False,
                                   forceDocker=False):
-        if (self._isCommandInstalled('docker') and
-                (conType == 'docker' and not forceSing or
-                 forceDocker)):
+        if ((conType == 'docker' and not forceSing or forceDocker) and
+            self._isCommandInstalled('docker')):
             return "docker"
 
         if self._isCommandInstalled('singularity'):


### PR DESCRIPTION
##  Related issues
<!-- List the issue(s) that are addressed by this PR -->
#629 

## Purpose
<!--- A clear and concise description of what the PR does. -->
Removed superfluous message for container engine versioning

## Current behaviour
<!--- Tell us what currently happens -->
Caused by docker installation check before choosing type of container to run.
```
/bin/sh: docker: command not found
singularity version 3.6.1
all done
```

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
stderr for docker is removed during singularity container exec
```
singularity version 3.6.1
all done
```

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Check docker/singularity installation AFTER choosing container type
