### PR TITLE
-l flag only applied if shell path is /bin/sh

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -261,7 +261,10 @@ class LocalExecutor(object):
             (conPath, container_location) = self.prepare(conTypeToUse)
             # Generate command script
             # Get the supported shell by the docker or singularity
-            cmdString = "#!"+self.shell+" -l"+os.linesep+str(command)
+            cmdString = "#!{}".format(self.shell)
+            if self.shell == "/bin/sh":
+                cmdString += " -l"
+            cmdString += os.linesep + str(command)
             with open(dsname, "w") as scrFile:
                 scrFile.write(cmdString)
             # Ensure the script is executable


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
#630 

## Purpose
<!--- A clear and concise description of what the PR does. -->
To not append `-l` when calling a custom shell.

## Current behaviour
<!--- Tell us what currently happens -->
Boutiques always append " -l" (space dash ell) to the shell's path in that script, which won't work when the shell invoked doesn't have a -l option.

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
`-l` is only appended to script when calling the default `/bin/sh`
