### PR TITLE
Bosh will no longer re-order keys in JSON objects.

### DIFF
--- a/tools/python/boutiques/deprecate.py
+++ b/tools/python/boutiques/deprecate.py
@@ -72,7 +72,7 @@ def deprecate(zenodo_id, by_zenodo_id=None, sandbox=False, verbose=False,
     # Save descriptor in temp file
     tmp = tempfile.NamedTemporaryFile(delete=False, mode='w', suffix=".json")
     content = json.dumps(descriptor_json, indent=4,
-                         sort_keys=True)
+                         sort_keys=False)
     tmp.write(content)
     tmp.close()
 

--- a/tools/python/boutiques/exporter.py
+++ b/tools/python/boutiques/exporter.py
@@ -85,4 +85,4 @@ class Exporter():
             carmin_desc['errorCodesAndMessages'].append(obj)
 
         with open(output_file, 'w') as fhandle:
-            fhandle.write(json.dumps(carmin_desc, indent=4, sort_keys=True))
+            fhandle.write(json.dumps(carmin_desc, indent=4, sort_keys=False))

--- a/tools/python/boutiques/nexusHelper.py
+++ b/tools/python/boutiques/nexusHelper.py
@@ -82,7 +82,7 @@ class NexusHelper(object):
         json_creds["nexus-organization"] = org
         json_creds["nexus-project"] = project
         with open(self.config_file, 'w') as f:
-            f.write(json.dumps(json_creds, indent=4, sort_keys=True))
+            f.write(json.dumps(json_creds, indent=4, sort_keys=False))
         if self.verbose:
             print_info("Nexus access token, organization and project"
                        " saved in {0}".format(self.config_file))

--- a/tools/python/boutiques/zenodoHelper.py
+++ b/tools/python/boutiques/zenodoHelper.py
@@ -45,7 +45,7 @@ class ZenodoHelper(object):
         json_creds = self.read_credentials()
         json_creds[self.config_token_property_name()] = access_token
         with open(self.config_file, 'w') as f:
-            f.write(json.dumps(json_creds, indent=4, sort_keys=True))
+            f.write(json.dumps(json_creds, indent=4, sort_keys=False))
         if (self.verbose):
             print_info("Zenodo access token saved in {0}".
                        format(self.config_file))


### PR DESCRIPTION
---
name: No re-ordering of keys in JSON objects
about: Not re-ordering keys in JSON objects.
title: 'See the PR title'
labels: enhancement
assignees: ''

---

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.
- [ ] **TRY** If new API function, documented it (refer to
[PEP 257](https://www.python.org/dev/peps/pep-0257/)).

## Purpose
Bosh no longer re-orders the keys in the JSON objects it creates.

## Current behaviour
Bosh re-orders the keys in JSON objects and it's very annoying.

## New behaviour
Do I really have to explain it again?
 
#### Does this introduce a major change?
- [ ] Yes
- [X] No

## Implementation Detail
Changed four True to False.

