### PR TITLE
created minimal install bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
 - pip install --upgrade setuptools
 - pip install "jsonschema>=2.6.0,<3.0.0"
 - pip install pytest pytest-runner pycodestyle coveralls
-- pip install .
+- pip install .[all]
 - pip freeze
 
 script:

--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ Simple! Just open your favourite terminal and type:
 
     $ pip install boutiques
 
-Alongside installing the Boutiques package, this will also ensure the dependencies are installed: `simplejson`, `jsonschema`,
-`requests`, `pytest`, `termcolor`, `oyaml`, `tabulate` and `mock`.
+Alongside installing the Boutiques package, this will also ensure the dependencies are installed for basic functionality: `simplejson`, `jsonschema`, `termcolor`, and `tabulate`. With this, you'll be able to validate and run your tools through Boutiques. For full functionality, you can install the library as follows:
+
+    $ pip install boutiques[all]
+
+This will add some more dependencies, and let you use all of the features: `requests`, `pytest`, `termcolor`, `oyaml`, `tabulate` and `mock`. Now you'll also be able to search for tools and publish your own and records from when you ran your tool!
 
 If you want the latest changes that aren't officially released yet, you can also install directly from GitHub:
 

--- a/boutiques/bosh.py
+++ b/boutiques/bosh.py
@@ -4,7 +4,6 @@ import simplejson as json
 import os
 import sys
 import os.path as op
-import pytest
 from jsonschema import ValidationError
 from boutiques.boshParsers import *
 from boutiques.dataHandler import DataHandlerError
@@ -18,7 +17,7 @@ from boutiques.exporter import ExportError
 from boutiques.importer import ImportError
 from boutiques.localExec import addDefaultValues
 from boutiques.util.utils import loadJson, customSortInvocationByInput
-from boutiques.util.utils import formatSphinxUsage
+from boutiques.util.utils import formatSphinxUsage, importCatcher
 from boutiques.logger import raise_error, print_error, print_info
 from tabulate import tabulate
 import argparse
@@ -289,7 +288,7 @@ def evaluate(*params):
         query_results += [evaluateEngine(executor, query)]
     return query_results[0] if len(query_results) == 1 else query_results
 
-
+@importCatcher()
 def test(*params):
     parser = parser_bosh()
     params = ('test',) + params
@@ -324,6 +323,7 @@ def test(*params):
     test_args = [test_path, "--descriptor", results.descriptor]
     if results.imagepath:
         test_args.extend(["--imagepath", results.imagepath])
+    import pytest
     return pytest.main(args=test_args)
 
 

--- a/boutiques/dataHandler.py
+++ b/boutiques/dataHandler.py
@@ -67,7 +67,7 @@ class DataHandler(object):
         self.verbose = verbose
         self.to_nexus = to_nexus
         if not self.to_nexus:
-            from boutiques.zenodoHelper import ZenodoHelper, ZenodoError
+            from boutiques.zenodoHelper import ZenodoHelper
             self.zenodo_access_token = zenodo_token
             self.zenodo_helper = ZenodoHelper(sandbox, no_int, verbose)
             self.zenodo_endpoint = self.zenodo_helper.zenodo_endpoint

--- a/boutiques/dataHandler.py
+++ b/boutiques/dataHandler.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 import os
-import requests
 import time
 import hashlib
 from boutiques.logger import raise_error, print_info
-from boutiques.util.utils import extractFileName, loadJson
-from boutiques.zenodoHelper import ZenodoHelper, ZenodoError
+from boutiques.util.utils import extractFileName, loadJson, importCatcher
+
 from boutiques.nexusHelper import NexusHelper
 
 
@@ -53,6 +52,7 @@ class DataHandler(object):
     # Function to publish a data set to Zenodo or Nexus
     # Options allow to only publish a single file, publish files individually as
     # data sets or bulk publish all files in the cache as one data set (default)
+    @importCatcher()
     def publish(self, file, zenodo_token, author, nexus_token,
                 nexus_org, nexus_project,
                 individually=False, sandbox=False,
@@ -67,6 +67,7 @@ class DataHandler(object):
         self.verbose = verbose
         self.to_nexus = to_nexus
         if not self.to_nexus:
+            from boutiques.zenodoHelper import ZenodoHelper, ZenodoError
             self.zenodo_access_token = zenodo_token
             self.zenodo_helper = ZenodoHelper(sandbox, no_int, verbose)
             self.zenodo_endpoint = self.zenodo_helper.zenodo_endpoint

--- a/boutiques/importer.py
+++ b/boutiques/importer.py
@@ -121,11 +121,7 @@ class Importer():
 
         return entrypoint
 
-    @importCatcher()
     def import_docopt(self):
-        from docopt import parse_defaults, parse_pattern, parse_argv
-        from docopt import formal_usage, DocoptLanguageError
-        from docopt import AnyOptions, TokenStream, Option, Argument, Command
         # input_descriptor is the .py containing docopt script
         docstring = SourceFileLoader(
             'docopt_script', self.input_descriptor).load_module().__doc__
@@ -537,6 +533,7 @@ class Importer():
             descriptor['output-files'].append(output_config_file)
             return descriptor
 
+        @importCatcher()
         def import_toml(descriptor):
             import toml
             tomlString = _getConfigFileString()
@@ -553,7 +550,9 @@ class Importer():
             descriptor['output-files'].append(output_config_file)
             return descriptor
 
+        @importCatcher()
         def import_yaml(descriptor):
+            import oyaml as yaml
             yamlString = _getConfigFileString()
             input_config = yaml.load(yamlString, Loader=yaml.FullLoader)
             imported_inputs = _getInputsFromConfigDict(input_config)
@@ -591,7 +590,11 @@ class Importer():
 
 
 class Docopt_Importer():
+    @importCatcher()
     def __init__(self, docopt_str, base_descriptor):
+        from docopt import parse_defaults, parse_pattern, parse_argv
+        from docopt import formal_usage, DocoptLanguageError
+        from docopt import AnyOptions, TokenStream, Option
         with open(base_descriptor, "r") as base_desc:
             self.descriptor = collections.OrderedDict(json.load(base_desc))
 
@@ -645,7 +648,9 @@ class Docopt_Importer():
                 'options:', self.docopt_str)), "")\
             .replace("\n\n", "\n").strip()
 
+    @importCatcher()
     def loadDescriptionAndType(self):
+        from docopt import Option
         # using docopt code to extract description and type from args
         for line in (self._parse_section('arguments:', self.docopt_str) +
                      self._parse_section('options:', self.docopt_str)):
@@ -690,6 +695,7 @@ class Docopt_Importer():
             self._loadInputsFromUsage(node)
 
     def _loadInputsFromUsage(self, usage):
+        from docopt import Argument
         ancestors = []
         for arg in usage.children:
             # Traverse usage args and add them to dependencies tree
@@ -819,7 +825,9 @@ class Docopt_Importer():
             new_arg["flag"] = node.long
         return new_arg
 
+    @importCatcher()
     def _addGroupArgumentToDependencies(self, arg, ancestors, optional=False):
+        from docopt import Argument
         # Add mutex choice group arg to dependency tree
         # group_arg contains members as dependency arguments
         options = arg.children[0].children

--- a/boutiques/importer.py
+++ b/boutiques/importer.py
@@ -4,19 +4,14 @@ from argparse import ArgumentParser
 from jsonschema import ValidationError
 from boutiques.validator import validate_descriptor
 from boutiques.util.utils import loadJson, customSortDescriptorByKey
-from boutiques.util.utils import customSortInvocationByInput
+from boutiques.util.utils import customSortInvocationByInput, importCatcher
 from boutiques.logger import raise_error
 import boutiques
-import oyaml as yaml
-import toml
 import simplejson as json
 import os
 import os.path as op
 import re
 import sys
-from docopt import parse_defaults, parse_pattern, parse_argv
-from docopt import formal_usage, DocoptLanguageError
-from docopt import AnyOptions, TokenStream, Option, Argument, Command
 from importlib.machinery import SourceFileLoader
 import collections
 
@@ -126,7 +121,11 @@ class Importer():
 
         return entrypoint
 
+    @importCatcher()
     def import_docopt(self):
+        from docopt import parse_defaults, parse_pattern, parse_argv
+        from docopt import formal_usage, DocoptLanguageError
+        from docopt import AnyOptions, TokenStream, Option, Argument, Command
         # input_descriptor is the .py containing docopt script
         docstring = SourceFileLoader(
             'docopt_script', self.input_descriptor).load_module().__doc__
@@ -175,7 +174,9 @@ class Importer():
         with open(self.output_descriptor, "w") as f:
             f.write(template_string)
 
+    @importCatcher()
     def import_cwl(self):
+        import oyaml as yaml
 
         # Read the CWL descriptor
         with open(self.input_descriptor, 'r') as f:
@@ -537,6 +538,7 @@ class Importer():
             return descriptor
 
         def import_toml(descriptor):
+            import toml
             tomlString = _getConfigFileString()
             input_config = toml.loads(tomlString, _dict=collections.OrderedDict)
             imported_inputs = _getInputsFromConfigDict(input_config)

--- a/boutiques/importer.py
+++ b/boutiques/importer.py
@@ -650,7 +650,7 @@ class Docopt_Importer():
 
     @importCatcher()
     def loadDescriptionAndType(self):
-        from docopt import Option
+        from docopt import Option, Argument
         # using docopt code to extract description and type from args
         for line in (self._parse_section('arguments:', self.docopt_str) +
                      self._parse_section('options:', self.docopt_str)):

--- a/boutiques/nexusHelper.py
+++ b/boutiques/nexusHelper.py
@@ -3,8 +3,8 @@ import os
 from codecs import open
 
 import simplejson as json
+from boutiques.util.utils import importCatcher
 from boutiques.logger import raise_error, print_info
-from requests.exceptions import HTTPError, ConnectionError
 
 
 class NexusError(Exception):
@@ -111,8 +111,9 @@ class NexusHelper(object):
             json_creds = {}
         return json_creds
 
+    @importCatcher()
     def nexus_test_api(self, access_token, org, project):
-
+        from requests.exceptions import HTTPError, ConnectionError
         # Test connection to endpoint without token
         self.nexus.config.set_environment(self.nexus_endpoint)
         try:

--- a/boutiques/publisher.py
+++ b/boutiques/publisher.py
@@ -4,8 +4,8 @@ from boutiques.validator import validate_descriptor, ValidationError
 from boutiques.logger import raise_error, print_info
 from boutiques.zenodoHelper import ZenodoError, ZenodoHelper
 from boutiques.util.utils import customSortDescriptorByKey, loadJson
+from boutiques.util.utils import importCatcher
 import simplejson as json
-import requests
 import os
 
 

--- a/boutiques/publisher.py
+++ b/boutiques/publisher.py
@@ -4,7 +4,6 @@ from boutiques.validator import validate_descriptor, ValidationError
 from boutiques.logger import raise_error, print_info
 from boutiques.zenodoHelper import ZenodoError, ZenodoHelper
 from boutiques.util.utils import customSortDescriptorByKey, loadJson
-from boutiques.util.utils import importCatcher
 import simplejson as json
 import os
 

--- a/boutiques/searcher.py
+++ b/boutiques/searcher.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import requests
 import sys
 from collections import OrderedDict
 import numbers

--- a/boutiques/tests/test_simulate.py
+++ b/boutiques/tests/test_simulate.py
@@ -50,12 +50,18 @@ class TestSimulate(BaseTest):
         desc_json = open(self.example1_descriptor).read()
         test_json = json.loads(desc_json)
         del test_json['groups']
+        # Have to tweak flag_input because it disables number_input
+        target_input = [i for i in test_json["inputs"]
+                        if i["id"] == "flag_input"][0]
+        del target_input["disables-inputs"]
+
+        # Make number_input mandatory
         target_input = [i for i in test_json["inputs"]
                         if i["id"] == "num_input"][0]
         target_input["optional"] = False
+        target_input["exclusive-minimum"] = False
 
         # Test inclusive lower bound
-        target_input["exclusive-minimum"] = False
         mock_random.return_value = -0.001
         self.assertRaises(ExecutorError, bosh.execute, ("simulate",
                                                         json.dumps(test_json),

--- a/boutiques/tests/validator/bad.json
+++ b/boutiques/tests/validator/bad.json
@@ -65,6 +65,7 @@
       "name": "extra 1",
       "type": "File",
       "value-key": "[extra1]",
+      "disables-inputs": ["extra2"],
       "optional": true
     },
     {

--- a/boutiques/util/utils.py
+++ b/boutiques/util/utils.py
@@ -5,7 +5,7 @@ from boutiques.logger import raise_error, print_warning
 from boutiques import __file__ as bfile
 
 
-# Utility function to wrap modules that don't 
+# Utility function to wrap modules that use non-essential libs
 def importCatcher():
   def decorate(f):
     def applicator(*args, **kwargs):

--- a/boutiques/util/utils.py
+++ b/boutiques/util/utils.py
@@ -5,6 +5,21 @@ from boutiques.logger import raise_error, print_warning
 from boutiques import __file__ as bfile
 
 
+# Utility function to wrap modules that don't 
+def importCatcher():
+  def decorate(f):
+    def applicator(*args, **kwargs):
+      try:
+         return f(*args,**kwargs)
+      except ImportError as e:
+         print(e)
+         raise ImportError("Try installing the full version of Boutiques "
+                           "with: \n\t pip install -e boutiques[all]")
+
+    return applicator
+  return decorate
+
+
 # Parses absolute path into filename
 def extractFileName(path):
     # Helps OS path handle case where "/" is at the end of path

--- a/boutiques/validator.py
+++ b/boutiques/validator.py
@@ -340,6 +340,14 @@ def validate_descriptor(descriptor, **kwargs):
                        for ids2 in inp["disables-inputs"]
                        if ids1 == ids2]
 
+        # Verify that disableed inputs cannot be required
+        msg_template = " InputError: \"{0}\" disables required id \"{1}\""
+        if "disables-inputs" in inp.keys():
+            errors += [msg_template.format(inp["id"], ids)
+                       for ids in inp["disables-inputs"]
+                       if ids in inIds and not inById(ids).get("optional")]
+
+
         # Verify required inputs cannot require or disable other parameters
         if "requires-inputs" in inp.keys() or "disables-inputs" in inp.keys():
             msg_template = (" InputError: \"{0}\" cannot require or"

--- a/boutiques/zenodoHelper.py
+++ b/boutiques/zenodoHelper.py
@@ -2,7 +2,7 @@
 import os
 import re
 import simplejson as json
-import requests
+from boutiques.util.utils import importCatcher
 from boutiques.logger import raise_error, print_info
 
 
@@ -58,7 +58,9 @@ class ZenodoHelper(object):
                        .format(endpoint))
         return endpoint
 
+    @importCatcher()
     def record_exists(self, record_id):
+        import requests
         r = requests.get(self.zenodo_endpoint +
                          '/api/records/{}'.format(record_id))
         if r.status_code == 200:
@@ -68,7 +70,9 @@ class ZenodoHelper(object):
         raise_error(ZenodoError,
                     "Cannot test existence of record {}".format(record_id), r)
 
+    @importCatcher()
     def zenodo_get_record(self, zenodo_id):
+        import requests
         r = requests.get(self.zenodo_endpoint +
                          '/api/records/{}'.format(zenodo_id))
         if r.status_code != 200:
@@ -118,7 +122,9 @@ class ZenodoHelper(object):
             json_creds = {}
         return json_creds
 
+    @importCatcher()
     def zenodo_test_api(self, access_token):
+        import requests
         r = requests.get(self.zenodo_endpoint+'/api/deposit/depositions')
         if(r.status_code != 401):
             raise_error(ZenodoError, "Cannot access Zenodo", r)
@@ -132,7 +138,9 @@ class ZenodoHelper(object):
         if(self.verbose):
             print_info("Authentication to Zenodo successful", r)
 
+    @importCatcher()
     def zenodo_deposit(self, metadata, access_token):
+        import requests
         headers = {"Content-Type": "application/json"}
         data = metadata
         r = requests.post(self.zenodo_endpoint+'/api/deposit/depositions',
@@ -148,8 +156,10 @@ class ZenodoHelper(object):
                        format(zid), r)
         return zid
 
+    @importCatcher()
     def zenodo_deposit_updated_version(self, metadata,
                                        access_token, deposition_id):
+        import requests
         r = requests.post(self.zenodo_endpoint +
                           '/api/deposit/depositions/%s/actions/newversion'
                           % deposition_id,
@@ -172,8 +182,10 @@ class ZenodoHelper(object):
         self.zenodo_delete_files(new_zid, r.json()["files"], access_token)
         return new_zid
 
+    @importCatcher()
     def zenodo_update_metadata(self, new_deposition_id, old_doi,
                                metadata, access_token):
+        import requests
         data = metadata
 
         # Add the new DOI to the metadata
@@ -195,7 +207,9 @@ class ZenodoHelper(object):
 
     # When a new version is created, the files from the old version are
     # automatically copied over. This method removes them.
+    @importCatcher()
     def zenodo_delete_files(self, new_deposition_id, files, access_token):
+        import requests
         for file in files:
             file_id = file["id"]
             r = requests.delete(self.zenodo_endpoint +
@@ -207,7 +221,9 @@ class ZenodoHelper(object):
             if(self.verbose):
                 print_info("Deleted old file", r)
 
+    @importCatcher()
     def zenodo_publish(self, access_token, deposition_id, msg_obj):
+        import requests
         r = requests.post(self.zenodo_endpoint +
                           '/api/deposit/depositions/%s/actions/publish'
                           % deposition_id,
@@ -219,7 +235,9 @@ class ZenodoHelper(object):
                        format(msg_obj, r.json()['doi']), r)
         return r.json()['doi']
 
+    @importCatcher()
     def zenodo_search(self, query, query_line):
+        import requests
         # Get all results
         r = requests.get(self.zenodo_endpoint + '/api/records/?q='
                          'keywords:(/Boutiques/) AND '
@@ -227,16 +245,19 @@ class ZenodoHelper(object):
                          '%s'
                          '&file_type=json&type=software&'
                          'page=1&size=%s' % (query_line, 9999))
+        print(r)
         if(r.status_code != 200):
             raise_error(ZenodoError, "Error searching Zenodo", r)
         if(self.verbose):
             print_info("Search successful for query \"%s\"" % query, r)
         return r
 
+    @importCatcher()
     def zenodo_upload_file(self, deposition_id, file_path,
                            zenodo_access_token=None,
                            error_msg="Cannot Upload to Zenodo",
                            verbose_msg="Uploaded to Zenodo"):
+        import requests
         zenodo_access_token = self.get_zenodo_access_token if\
             zenodo_access_token is None else zenodo_access_token
         r = requests.post(self.zenodo_endpoint +

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,8 @@ eDEPS = {
          "toml",
          "docopt",
          "pytest",
+         "pytest-runner",
+         "coverage",
          "nexus-sdk",
          "requests",
          "mock"

--- a/setup.py
+++ b/setup.py
@@ -11,17 +11,21 @@ with open(verfile) as fhandle:
 
 DEPS = [
          "simplejson",
-         "requests",
-         "pytest",
          "termcolor",
-         "oyaml",
          "jsonschema",
          "tabulate",
-         "mock",
+]
+eDEPS = {
+    "all": [
+         "oyaml",
+         "toml",
          "docopt",
+         "pytest",
          "nexus-sdk",
-         "toml"
-       ]
+         "requests",
+         "mock"
+    ]
+}
 
 setup(name="boutiques",
       version=VERSION,
@@ -48,6 +52,7 @@ setup(name="boutiques",
       test_suite="pytest",
       tests_require=["pytest"],
       setup_requires=DEPS,
+      extras_require=eDEPS,
       install_requires=DEPS,
       entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->

## Checklist
<!--- Make sure to check the following items -->
- [x] **DO** Unit tests pass.

## Purpose
<!--- A clear and concise description of what the PR does. -->
Makes Boutiques lighter

## Current behaviour
<!--- Tell us what currently happens -->
Installation with `pip install boutiques` would install every dependency, even if I didn't plan on using many functions w/in the lib.

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
Now, the base install comes with the minimal set of dependencies to use/validate descriptors, and all the rest can be installed with `pip install boutiques[all]`.
 
#### Does this introduce a major change?
- [x] No

## Implementation Detail
- added `importCatcher()` decorator to wrap functions which require non-essential dependencies
- moved non-essential dependency imports to within functions using them
- the above closes #645 
- updated docs
- also addressed #644 by adding a validation condition