### PR TITLE
Allow missing tool version, assigning "unknown"

### DIFF
--- a/tools/python/boutiques/searcher.py
+++ b/tools/python/boutiques/searcher.py
@@ -118,7 +118,7 @@ class Searcher():
         for hit in results["hits"]["hits"]:
             (id, title, description, downloads) = self.parse_basic_info(hit)
             author = hit["metadata"]["creators"][0]["name"]
-            version = hit["metadata"]["version"]
+            version = hit["metadata"].get("version", "unknown")
             publication_date = hit["metadata"]['publication_date']
             doi = hit["doi"]
             keyword_data = self.get_keyword_data(hit["metadata"]["keywords"])

--- a/tools/python/boutiques/tests/boutiques_mocks.py
+++ b/tools/python/boutiques/tests/boutiques_mocks.py
@@ -74,8 +74,8 @@ def mock_zenodo_delete_files():
     return MockHttpResponse(204)
 
 
-def get_zenodo_record(record):
-    return {
+def get_zenodo_record(record, include_version=True):
+    record = {
         "doi": "10.5281/zenodo.%s" % record.id,
         "files": [
             {
@@ -115,12 +115,15 @@ def get_zenodo_record(record):
             "version_downloads": record.downloads
         }
     }
+    if not include_version:
+        del record['metadata']['version']
+    return record
 
 
-def mock_zenodo_search(mock_records):
+def mock_zenodo_search(mock_records, include_version=True):
     mock_results = []
     for record in mock_records:
-        mock_results.append(get_zenodo_record(record))
+        mock_results.append(get_zenodo_record(record, include_version))
     mock_json = {"hits": {"hits": mock_results, "total": len(mock_results)}}
     return MockHttpResponse(200, mock_json)
 


### PR DESCRIPTION
## Related issues
Fixes #655 

## Checklist
<!--- Make sure to check the following items -->
- [x] **DO** Unit tests pass.
- [x] **DO** If new feature, created unit test.
- [ ] **TRY** If new API function, documented it (refer to
[PEP 257](https://www.python.org/dev/peps/pep-0257/)).

## Purpose
This allows Zenodo records without a version specified to be processed.

## Current behaviour
Bosh search throws a KeyError before returning anything.

## New behaviour
Boutiques will return a record with "VERSION" set to "unknown".
 
#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->

