### PR TITLE
Use != instead of is not with literal

### DIFF
--- a/tools/python/boutiques/localExec.py
+++ b/tools/python/boutiques/localExec.py
@@ -1063,7 +1063,7 @@ class LocalExecutor(object):
                        template.find(clk) > 0 and is_output):
                         val = op.basename(val)
                 # Here val can be a number so we need to cast it
-                if val is not None and val is not "":
+                if val is not None and val != "":
                     template = template.replace(clk, str(val))
                 else:
                     template = template.replace(' ' + clk, str(val))

--- a/tools/python/boutiques/prettyprint.py
+++ b/tools/python/boutiques/prettyprint.py
@@ -122,7 +122,7 @@ class PrettyPrinter():
                 output_info += temp_info
 
         self.epilog = "\n\n{0}\n\n{1}".format(self.sep, config_info) \
-            if config_info is not "Config Files:" else ""
+            if config_info != "Config Files:" else ""
         self.epilog += "\n\n{0}\n\n{1}".format(self.sep, output_info)
 
     def descGroups(self):
@@ -315,12 +315,12 @@ class PrettyPrinter():
                      + req_inp_desc_footer
 
             # Add args for required inputs
-            if req_inp_descr is not "":
+            if req_inp_descr != "":
                 inp_kwargs['help'] = textwrap.dedent(req_inp_descr)
                 required.add_argument(*inp_args, **inp_kwargs)
 
             # Add args for optional inputs
-            if opt_inp_descr is not "":
+            if opt_inp_descr != "":
                 inp_kwargs['help'] = textwrap.dedent(opt_inp_descr)
                 parsed_flags = list(self.parser._option_string_actions.keys())
                 for i in range(0, len(parsed_flags)):


### PR DESCRIPTION
addresses warnings I got

    /home/yoh/proj/misc/boutiques/tools/python/boutiques/localExec.py:1066: SyntaxWarning: "is not" with a literal. Did you mean "!="?
      if val is not None and val is not "":
    /home/yoh/proj/misc/boutiques/tools/python/boutiques/prettyprint.py:125: SyntaxWarning: "is not" with a literal. Did you mean "!="?
      if config_info is not "Config Files:" else ""
    /home/yoh/proj/misc/boutiques/tools/python/boutiques/prettyprint.py:318: SyntaxWarning: "is not" with a literal. Did you mean "!="?
      if req_inp_descr is not "":
    /home/yoh/proj/misc/boutiques/tools/python/boutiques/prettyprint.py:323: SyntaxWarning: "is not" with a literal. Did you mean "!="?
      if opt_inp_descr is not "":

#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->

