### PR TITLE
Fixed search following change of behavior in Zenodo API (#658)

### DIFF
--- a/boutiques/zenodoHelper.py
+++ b/boutiques/zenodoHelper.py
@@ -221,16 +221,18 @@ class ZenodoHelper(object):
 
     def zenodo_search(self, query, query_line):
         # Get all results
-        r = requests.get(self.zenodo_endpoint + '/api/records/?q='
+        get_request =  self.zenodo_endpoint + ('/api/records/?q='
                          'keywords:(/Boutiques/) AND '
-                         'keywords:(/schema-version.*/)'
+                         'keywords:(/schema.*/) AND keywords:(/version.*/)'
                          '%s'
                          '&file_type=json&type=software&'
                          'page=1&size=%s' % (query_line, 9999))
+        r = requests.get(get_request)
         if(r.status_code != 200):
             raise_error(ZenodoError, "Error searching Zenodo", r)
         if(self.verbose):
             print_info("Search successful for query \"%s\"" % query, r)
+            print_info(f'GET request: {get_request}')
         return r
 
     def zenodo_upload_file(self, deposition_id, file_path,


### PR DESCRIPTION

## Related issues
#658 

## Checklist
<!--- Make sure to check the following items -->
- [x] **DO** Unit tests pass.
- [x] **DO** If new feature, created unit test.
- [x] **TRY** If new API function, documented it (refer to
[PEP 257](https://www.python.org/dev/peps/pep-0257/)).

## Purpose
Adjust search query to new Zenodo behavior that doesn't match keywords with hyphens (most likely due to a backend update).

## Current behaviour
bosh search returns nothing, because all boutiques tools have "schema-version:0.5" as keyword and keywords with hyphens don't match the query regexp.

## New behaviour
 bosh search now returns correct output.
 
#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Implementation Detail
query is now done separately on keywords "schema" and "version". Best guess is that the backend splits "schema-version" in two keywords.