### PR TITLE
User-defined provenance filepath as a command-line option

### DIFF
--- a/boutiques/bosh.py
+++ b/boutiques/bosh.py
@@ -107,7 +107,8 @@ def execute(*params):
                                   "provenance": results.provenance,
                                   "noContainer": results.no_container,
                                   "sandbox": results.sandbox,
-                                  "noAutomounts": results.no_automounts})
+                                  "noAutomounts": results.no_automounts,
+                                  "provenancePath": results.provenance_path})
         # Execute it
         return executor.execute(results.volumes)
 

--- a/boutiques/boshParsers.py
+++ b/boutiques/boshParsers.py
@@ -293,6 +293,14 @@ def add_subparser_execute(subparsers):
         action="store_true",
         help="Disable automatic mount of all input files "
         "present in the invocation")
+    parser_exec_launch.add_argument(
+        "--provenance-path",
+        action="store",
+        metavar='',
+        help="Specify another path to copy the provenance file, " 
+        "in addition to the default boutiques cache directory. "
+        "It can be a file path (it's parent directory must exist) or "
+        "an existing directory path (the default provenance filename will be used).") 
     force_group = parser_exec_launch.add_mutually_exclusive_group()
     force_group.add_argument("--force-docker", action="store_true",
                              help="Tries to run Singularity images with "

--- a/boutiques/localExec.py
+++ b/boutiques/localExec.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import os
+import shutil
 import sys
 import re
 import simplejson as json
@@ -1357,6 +1358,19 @@ class LocalExecutor(object):
         file = open(file_path, 'w+')
         file.write(content)
         file.close()
+        if self.provenancePath:
+            if os.path.exists(self.provenancePath):
+                if os.path.isfile(self.provenancePath):
+                    shutil.copy(file_path, self.provenancePath)
+                    print_info("provenance file already exists, overwritting file {}, provenance file saved in {}".format((os.path.basename(self.provenancePath)), self.provenancePath))
+                elif os.path.isdir(self.provenancePath):
+                    shutil.copy(file_path, os.path.join(self.provenancePath, filename))
+                    print_info("provenance file saved as {}".format(os.path.join(self.provenancePath, filename)))
+            elif os.path.exists(os.path.dirname(self.provenancePath)):
+                shutil.copy(file_path, self.provenancePath)
+                print_info("provenance file saved as {}".format(self.provenancePath))
+            else:
+                print_info("Invalid path: {}, provenance file saved in the default directory {}".format(os.path.abspath(self.provenancePath), file_path))
         if self.debug:
             print_info("Data capture from execution saved to cache as {}"
                        .format(filename))


### PR DESCRIPTION
---
name: User-defined path to save provenance file
about: adding a command-line option
title: 'provenance-path'
labels: enhancement
assignees: ''

---


## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.
- [ ] **TRY** If new API function, documented it (refer to
[PEP 257](https://www.python.org/dev/peps/pep-0257/)).

## Purpose
<!---  -->
 Define a specific file path(or path without filename) to copy the provenance file to this directory

## Current behaviour
<!---  --> Provenance file gets created in default cache directory (~.cache/boutiques/data) for each execution of 'bosh exec launch'

## New behaviour
<!--- --> Provenance file still gets created in the default cache directory (~.cache/boutiques/data), and gets copied to a user-defined path (optionally, with a user-defined fine name)
 
#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Implementation Detail
<!--- -->


 Added a command-line option (--provenance-path) and relevant documentation, depending on the user-input, following actions are performed,
1. If user enters a filepath, provenance file with the specified name will be copied to the path
2. If the file already exists, it prints a warning and overwrites the file
3. If user enters only a path(without filename), file will be created with it's default filename
4. If the entered path is incorrect, it print a warning and creates the file in the default boutiques cache directory 
