### PR TITLE
Command-line option for 'bosh data inspect' to display latest provenance file

### DIFF
--- a/boutiques/bosh.py
+++ b/boutiques/bosh.py
@@ -377,7 +377,7 @@ def pull(*params):
 def data(*params):
     parser = parser_bosh()
     params = ('data',) + params
-    try:    
+    try:
         # Try to parse input with argparse
         results, _ = parser.parse_known_args(params)
     except SystemExit as e:

--- a/boutiques/bosh.py
+++ b/boutiques/bosh.py
@@ -377,7 +377,7 @@ def pull(*params):
 def data(*params):
     parser = parser_bosh()
     params = ('data',) + params
-    try:
+    try:    
         # Try to parse input with argparse
         results, _ = parser.parse_known_args(params)
     except SystemExit as e:
@@ -392,7 +392,7 @@ def data(*params):
     elif results.mode == "inspect":
         from boutiques.dataHandler import DataHandler
         dataHandler = DataHandler()
-        return dataHandler.inspect(results.example)
+        return dataHandler.inspect(results.example, results.latest)
     elif results.mode == "publish":
         from boutiques.dataHandler import DataHandler
         dataHandler = DataHandler()

--- a/boutiques/boshParsers.py
+++ b/boutiques/boshParsers.py
@@ -83,6 +83,8 @@ def add_subparser_data(subparsers):
     parser_data_inspect.set_defaults(mode='inspect')
     parser_data_inspect.add_argument("-e", "--example", action="store_true",
                                      help="Display example data file contents.")
+    parser_data_inspect.add_argument("-l","--latest" , action="store_true",
+                                     help="Display latest data file contents.") 
 
     parser_data_publish = data_subparsers.add_parser(
         "publish", description="Publishes record(s) to a data set.")

--- a/boutiques/dataHandler.py
+++ b/boutiques/dataHandler.py
@@ -23,12 +23,21 @@ class DataHandler(object):
     # Option to display an example file which displays an pre-made example file
     # or the first file of the cache if it exists
     # Otherwise displays information about the cache and a list of files
-    def inspect(self, example=False):
+    def inspect(self, example=False, latest=False):
         self.example = example
+        self.latest = latest
         # Display an example json file
         if self.example:
             # Display the first file in cache
             if len(self.record_files) > 0:
+                filename = self.record_files[0]
+                file_path = os.path.join(self.cache_dir, filename)
+                self._display_file(file_path)
+            else:
+                print("No records in the cache at the moment.")
+        elif self.latest:
+            if len(self.record_files) > 0:
+                self.record_files.sort(key=lambda x: os.path.getmtime(os.path.join(self.cache_dir, x)), reverse=True)
                 filename = self.record_files[0]
                 file_path = os.path.join(self.cache_dir, filename)
                 self._display_file(file_path)


### PR DESCRIPTION
---
name: inspect latest provenance file
about: display last created provenance file
title: 'command-line option for the last created provenance'
labels: enhancement
assignees: ''

---


## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.
- [ ] **TRY** If new API function, documented it (refer to
[PEP 257](https://www.python.org/dev/peps/pep-0257/)).

## Purpose
<!--- command-line option that displays latest created provenance file `bosh data inspect --latest`. -->

## Current behaviour
<!--- currently `bosh data inspect -e` displays an example (random file) of a provenance file -->

## New behaviour
<!--- `bosh data inspect -l` or(--latest) displays the latest created provenance file -->
 
#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Implementation Detail
<!--- -->For ease of access to the latest created provenance file, and option `-l, --latest` added to the `bosh data inspect`. The cache directory is sorted by modified timestamp, and the first file is displayed 

