### PR TITLE
[FIX] error message when no `output-files` exist in descriptor.

### DIFF
--- a/boutiques/boshParsers.py
+++ b/boutiques/boshParsers.py
@@ -299,7 +299,9 @@ def add_subparser_example(subparsers):
 
 
 def add_subparser_execute(subparsers):
-    parser_exec = subparsers.add_parser("exec", description="Boutiques local executor")
+    parser_exec = subparsers.add_parser(
+        "exec", description="Boutiques local executor", aliases=["execute"]
+    )
     parser_exec.set_defaults(function="exec")
     exec_subparsers = parser_exec.add_subparsers(
         help="Mode of operation to use. Launch: takes a "

--- a/boutiques/localExec.py
+++ b/boutiques/localExec.py
@@ -465,21 +465,22 @@ class LocalExecutor:
         missing_files_dict = {}
         output_files = []
         output_files_dict = {}
-        all_files = evaluateEngine(self, "output-files")
-        required_files = evaluateEngine(self, "output-files/optional=False")
-        optional_files = evaluateEngine(self, "output-files/optional=True")
-        for f in all_files.keys():
-            file_name = all_files[f]
-            fd = FileDescription(f, file_name, False)
-            f_glob = glob(file_name)
-            if f_glob:
-                fd.file_name = f_glob[0]
-                output_files.append(fd)
-                output_files_dict[f] = f_glob[0]
-            else:  # file does not exist
-                if f in required_files.keys():
-                    missing_files.append(fd)
-                    missing_files_dict[f] = file_name
+        if "output-files" in list(self.desc_dict.keys()):
+            all_files = evaluateEngine(self, "output-files")
+            required_files = evaluateEngine(self, "output-files/optional=False")
+            optional_files = evaluateEngine(self, "output-files/optional=True")
+            for f in all_files.keys():
+                file_name = all_files[f]
+                fd = FileDescription(f, file_name, False)
+                f_glob = glob(file_name)
+                if f_glob:
+                    fd.file_name = f_glob[0]
+                    output_files.append(fd)
+                    output_files_dict[f] = f_glob[0]
+                else:  # file does not exist
+                    if f in required_files.keys():
+                        missing_files.append(fd)
+                        missing_files_dict[f] = file_name
 
         # Set error messages
         desc_err = ""


### PR DESCRIPTION


---
name: [FIX] error message when no `output-files` exist in descriptor.
about: Propose modifications in the code
title: 'Feature implementation | Bug fix for issue #669'
labels: enhancement
assignees: ''

---

## Related issues
<!-- List the issue(s) that are addressed by this PR -->
fix #669

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.
- [ ] **TRY** If new API function, documented it (refer to
[PEP 257](https://www.python.org/dev/peps/pep-0257/)).

## Purpose
<!--- A clear and concise description of what the PR does. -->
See #669 for details.

## Current behaviour
<!--- Tell us what currently happens -->
When no `output-files` exist in descriptor, `bosh exec  launch` display error message yet succeed.

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
No longer display the error message.

 
#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Verify that the `output-files` key exist before querying it.
