### PR TITLE
[MAINT] Drop python 3.8 and support python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                py: ['3.12', '3.11', '3.10', '3.9', '3.8']
+                py: ['3.13', '3.12', '3.11', '3.10', '3.9']
                 os: [ubuntu-latest, macos-latest, windows-latest]
 
         runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,11 +10,11 @@ authors = [
 classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: OS Independent",
@@ -32,7 +32,7 @@ dynamic = ["version"]
 license = {text = "MIT"}
 name = "boutiques"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 
 [project.optional-dependencies]
 all = [


### PR DESCRIPTION
- drop python 3.8 and support python 3.13
- closes none