### PR TITLE
Feature implementation for issue #650 - apptainer support

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -10,7 +10,7 @@ This guide will help you set up your local environment for coding and testing Bo
 -   **pip**. Most versions of Python will come with it, but in case you don't have it, instructions to install it are [here](https://pip.pypa.io/en/stable/installing/).
 -   **Docker or Singularity**. Depending on the tools you plan to work with and where they are installed, you'll want to have either Docker or Singularity installed (ideally both).
   -   To install Docker, follow the  [instructions](https://docs.docker.com/install/overview/) to install Docker CE.
-  -   To install Singularity, follow the [instructions](https://singularity.lbl.gov/install-linux) to download the latest stable release of Singularity.
+  -   To install Singularity, follow the [instructions](https://apptainer.org/docs/admin/latest/installation.html#installation-on-linux) to download the latest stable release of Singularity.
 -   **Root (sudo) access**. If your system doesn't already have all of the above installed, you'll need root permission to install new programs.
 
 ## 1.   Clone the boutiques repository

--- a/boutiques/bosh.py
+++ b/boutiques/bosh.py
@@ -117,6 +117,7 @@ def execute(*params):
                 "skipDataCollect": results.skip_data_collection,
                 "forceDocker": results.force_docker,
                 "forceSingularity": results.force_singularity,
+                "forceApptainer": results.force_apptainer,
                 "provenance": results.provenance,
                 "noContainer": results.no_container,
                 "sandbox": results.sandbox,

--- a/boutiques/boshParsers.py
+++ b/boutiques/boshParsers.py
@@ -403,6 +403,11 @@ def add_subparser_execute(subparsers):
         action="store_true",
         help="Tries to run Docker images with " "Singularity.",
     )
+    force_group.add_argument(
+        "--force-apptainer",
+        action="store_true",
+        help="Tries to run Docker images with " "Apptainer.",
+    )
 
     parser_exec_prepare = exec_subparsers.add_parser(
         "prepare",

--- a/boutiques/localExec.py
+++ b/boutiques/localExec.py
@@ -278,11 +278,13 @@ class LocalExecutor:
         container_command = ""
         if conIsPresent:
             # Figure out which container type to use
-            conTypeToUse = self._chooseContainerTypeToUse(
-                conType, self.forceSingularity, self.forceDocker
+            (conTypeToUse, conBinName) = self._chooseContainerTypeToUse(
+                conType,
+                self.forceSingularity, self.forceApptainer, self.forceDocker
             )
             # Pull the container
-            (conPath, container_location) = self.prepare(conTypeToUse)
+            (conPath, container_location) = self.prepare(conTypeToUse,
+                                                         conBinName)
             # Generate command script
             # Get the supported shell by the docker or singularity
             cmdString = f"#!{self.shell}"
@@ -437,7 +439,7 @@ class LocalExecutor:
                         envString += f"SINGULARITYENV_{key}='{val}' "
                 singularity_mounts = "-B " + " -B ".join(mount_strings)
                 container_command = (
-                    envString + "singularity exec "
+                    envString + conBinName + " exec "
                     "--cleanenv "
                     + singularity_mounts
                     + " -W "
@@ -514,7 +516,7 @@ class LocalExecutor:
     # Looks for the container image locally and pulls it if not found
     # Returns a tuple containing the container filename (for Singularity)
     # and the container location (local or pulled)
-    def prepare(self, conTypeToUse=None):
+    def prepare(self, conTypeToUse=None, conBinName=None):
         con = self.con
         if con is None:
             return ("", "Descriptor does not specify a container image.")
@@ -528,8 +530,8 @@ class LocalExecutor:
         # If container is present, alter the command template accordingly
         conName = ""
 
-        if conTypeToUse is None:
-            conTypeToUse = self._chooseContainerTypeToUse(conType)
+        if conTypeToUse is None or conBinName is None:
+            (conTypeToUse, conBinName) = self._chooseContainerTypeToUse(conType)
 
         if conTypeToUse == "docker":
             # Pull the docker image
@@ -601,7 +603,8 @@ class LocalExecutor:
                         # Container still does not exist, so pull it
                         else:
                             conPath, container_location = self._pullSingImage(
-                                conName, conIndex, conImage, imageDir, lockDir
+                                conName, conIndex, conImage, imageDir, lockDir,
+                                conBinName
                             )
                         return conPath, container_location
                     finally:
@@ -618,7 +621,8 @@ class LocalExecutor:
         return conName in os.listdir(imageDir)
 
     # Private method that pulls a Singularity image
-    def _pullSingImage(self, conName, conIndex, conImage, imageDir, lockDir):
+    def _pullSingImage(self, conName, conIndex, conImage, imageDir, lockDir,
+                       conBinName):
         # Give the file a temporary name while it's building
         conNameTmp = conName + ".tmp"
         # Set the pull directory to the specified imagePath
@@ -632,7 +636,7 @@ class LocalExecutor:
             "image path)"
         ).format(conName, conIndex, conImage)
         # Pull the singularity image
-        sing_command = "singularity pull --name " + pull_loc
+        sing_command = conBinName + " pull --name " + pull_loc
         (stdout, stderr), return_code = self._localExecute(sing_command)
         if return_code:
             message = (
@@ -660,22 +664,30 @@ class LocalExecutor:
     def _isCommandInstalled(self, command):
         return not subprocess.Popen(f"{command} --version", shell=True).wait()
 
-    # Chooses whether to use Docker or Singularity based on the
-    # descriptor, executor options and if Docker is installed.
-    def _chooseContainerTypeToUse(self, conType, forceSing=False, forceDocker=False):
+    # Chooses whether to use Docker, Singularity or Apptainer based on the
+    # descriptor, executor options and installed commands.
+    # Returns image type and container runtime binary name.
+    def _chooseContainerTypeToUse(self, conType, forceSing=False,
+                                  forceApptainer=False, forceDocker=False):
         if (
-            conType == "docker" and not forceSing or forceDocker
+            conType == "docker" and not (forceSing or forceApptainer)
+            or forceDocker
         ) and self._isCommandInstalled("docker"):
-            return "docker"
+            return ("docker", "docker")
 
-        if self._isCommandInstalled("singularity"):
-            return "singularity"
+        if (
+            not forceApptainer or forceSing
+        ) and self._isCommandInstalled("singularity"):
+            return ("singularity", "singularity")
+
+        if self._isCommandInstalled("apptainer"):
+            return ("singularity", "apptainer")
 
         raise_error(
             ExecutorError,
             (
                 "Could not find any container engine. "
-                + "Make sure that Docker or Singularity "
+                + "Make sure that Docker or Singularity/Apptainer "
                 + "is installed."
             ),
         )

--- a/boutiques/localExec.py
+++ b/boutiques/localExec.py
@@ -279,12 +279,10 @@ class LocalExecutor:
         if conIsPresent:
             # Figure out which container type to use
             (conTypeToUse, conBinName) = self._chooseContainerTypeToUse(
-                conType,
-                self.forceSingularity, self.forceApptainer, self.forceDocker
+                conType, self.forceSingularity, self.forceApptainer, self.forceDocker
             )
             # Pull the container
-            (conPath, container_location) = self.prepare(conTypeToUse,
-                                                         conBinName)
+            (conPath, container_location) = self.prepare(conTypeToUse, conBinName)
             # Generate command script
             # Get the supported shell by the docker or singularity
             cmdString = f"#!{self.shell}"
@@ -603,8 +601,12 @@ class LocalExecutor:
                         # Container still does not exist, so pull it
                         else:
                             conPath, container_location = self._pullSingImage(
-                                conName, conIndex, conImage, imageDir, lockDir,
-                                conBinName
+                                conName,
+                                conIndex,
+                                conImage,
+                                imageDir,
+                                lockDir,
+                                conBinName,
                             )
                         return conPath, container_location
                     finally:
@@ -621,8 +623,9 @@ class LocalExecutor:
         return conName in os.listdir(imageDir)
 
     # Private method that pulls a Singularity image
-    def _pullSingImage(self, conName, conIndex, conImage, imageDir, lockDir,
-                       conBinName):
+    def _pullSingImage(
+        self, conName, conIndex, conImage, imageDir, lockDir, conBinName
+    ):
         # Give the file a temporary name while it's building
         conNameTmp = conName + ".tmp"
         # Set the pull directory to the specified imagePath
@@ -667,17 +670,17 @@ class LocalExecutor:
     # Chooses whether to use Docker, Singularity or Apptainer based on the
     # descriptor, executor options and installed commands.
     # Returns image type and container runtime binary name.
-    def _chooseContainerTypeToUse(self, conType, forceSing=False,
-                                  forceApptainer=False, forceDocker=False):
+    def _chooseContainerTypeToUse(
+        self, conType, forceSing=False, forceApptainer=False, forceDocker=False
+    ):
         if (
-            conType == "docker" and not (forceSing or forceApptainer)
-            or forceDocker
+            conType == "docker" and not (forceSing or forceApptainer) or forceDocker
         ) and self._isCommandInstalled("docker"):
             return ("docker", "docker")
 
-        if (
-            not forceApptainer or forceSing
-        ) and self._isCommandInstalled("singularity"):
+        if (not forceApptainer or forceSing) and self._isCommandInstalled(
+            "singularity"
+        ):
             return ("singularity", "singularity")
 
         if self._isCommandInstalled("apptainer"):

--- a/boutiques/tests/test_example1.py
+++ b/boutiques/tests/test_example1.py
@@ -707,7 +707,6 @@ class TestExample1(BaseTest):
         self.assertIn("Local (boutiques-example1-test.simg)", ret.container_location)
         self.assertIn("apptainer exec", ret.container_command)
 
-
     @pytest.mark.skipif(
         subprocess.Popen("type docker", shell=True).wait(),
         reason="Docker not installed",

--- a/boutiques/tests/test_example1.py
+++ b/boutiques/tests/test_example1.py
@@ -653,6 +653,61 @@ class TestExample1(BaseTest):
         self.assertIn("Local (boutiques-example1-test.simg)", ret.container_location)
         self.assertIn("singularity exec", ret.container_command)
 
+    @pytest.mark.xfail(reason="Travis to GH action transition")
+    @pytest.mark.skipif(
+        subprocess.Popen("type apptainer", shell=True).wait(),
+        reason="Apptainer not installed",
+    )
+    def test_example1_exec_docker_force_apptainer(self):
+        ret = bosh.execute(
+            "launch",
+            self.example1_descriptor,
+            self.get_file_path("invocation_no_opts.json"),
+            "--skip-data-collection",
+            "--force-apptainer",
+            "-v",
+            f"{self.get_file_path('example1_mount1')}:/test_mount1",
+            "-v",
+            f"{self.get_file_path('example1_mount2')}:/test_mount2",
+        )
+
+        self.assert_successful_return(
+            ret,
+            ["./test_temp/log-4-coin;plop.txt"],
+            2,
+            self.assert_reflected_output,
+        )
+        self.assertIn("Local (boutiques-example1-test.simg)", ret.container_location)
+        self.assertIn("apptainer exec", ret.container_command)
+
+    @pytest.mark.xfail(reason="Travis to GH action transition")
+    @pytest.mark.skipif(
+        subprocess.Popen("type apptainer", shell=True).wait(),
+        reason="Apptainer not installed",
+    )
+    def test_example1_exec_docker_Index_force_apptainer(self):
+        ret = bosh.execute(
+            "launch",
+            self.get_file_path("example1_docker_w_index.json"),
+            self.get_file_path("invocation_no_opts.json"),
+            "--skip-data-collection",
+            "-v",
+            f"{self.get_file_path('example1_mount1')}:/test_mount1",
+            "-v",
+            f"{self.get_file_path('example1_mount2')}:/test_mount2",
+            "--force-apptainer",
+        )
+
+        self.assert_successful_return(
+            ret,
+            ["./test_temp/log-4-coin;plop.txt"],
+            2,
+            self.assert_reflected_output,
+        )
+        self.assertIn("Local (boutiques-example1-test.simg)", ret.container_location)
+        self.assertIn("apptainer exec", ret.container_command)
+
+
     @pytest.mark.skipif(
         subprocess.Popen("type docker", shell=True).wait(),
         reason="Docker not installed",


### PR DESCRIPTION
## Related issues
#650, #688

## Checklist
- [x] **DO** Unit tests pass.
- [x] **DO** If new feature, created unit test.
- [x] Documentation: no new API function, one new command-line flag documented in `bosh exec launch --help`

#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Purpose
Add support for apptainer runtime as discussed in [#688](https://github.com/boutiques/boutiques/pull/688#issuecomment-2612600351) and [#650](https://github.com/boutiques/boutiques/issues/650#issuecomment-2612633629).

All changes in this PR should be backwards-compatible, the intent is to support hypothetical environments where the `apptainer` command exists but `singularity` doesn't, and to allow explicit selection of the `apptainer` runtime with `bosh exec launch --force-apptainer`.

Detail of changes:
- possible values for the `container-image.type` descriptor field remain unchanged: only `docker` or `singularity`
- when the `singularity` command is not found, but the `apptainer` command exists, then call apptainer instead of failing. This is handled in `localExec.py:_chooseContainerTypeToUse()`
- add a `--force-apptainer` flag on `bosh exec launch`, which makes the apptainer command take precedence over singularity, in a similar way to the existing flags `--force-singularity` and `--force-docker`
- replace deprecated link to https://singularity.lbl.gov/ with https://apptainer.org/ in `GETTING_STARTED.md`

Some points of attention:
- this PR is based on `develop` as recommended in the contributing guidelines, but the master branch is currently more recent than develop. There is no conflict with either branch at the time of this PR.
- the tests added for this feature were marked as XFAIL, as they are very similar to tests which were also marked XFAIL a few months ago in https://github.com/boutiques/boutiques/commit/fd81dddfedf1edfb3e8f250677bc8c22e1836642. They do work on a local machine.
- I had some hesitation on what to do in the edge case where a `--force-X` flag is used and command X is not installed. For now, I favored backwards compatibility and kept the existing behaviour of defaulting to other available commands. This can already be observed in the existing boutiques implementation: when `--force-docker` is used and `docker` is not installed but `singularity` is, then bosh uses singularity. In the same vein, this PR can end up running `apptainer` even `--force-singularity` is used. If this is not desired behaviour, then we could modify `_chooseContainerTypeToUse()` to do an early abort when `--force-X` is used on an unavailable command.

