### PR TITLE
Update --container-opts

### DIFF
--- a/boutiques/localExec.py
+++ b/boutiques/localExec.py
@@ -246,6 +246,9 @@ class LocalExecutor:
             (con.get("image") if not self.noContainer else None),
         )
         conIndex = con.get("index")
+        # conOpts can't be forced for docker, as long as there are cases
+        # where _chooseContainerTypeToUse() can fall back to singularity
+        conOptsForced = conOpts is not None and self.forceSingularity
         conOpts = conOpts or con.get("container-opts")
         conIsPresent = conImage is not None
         # Export environment variables,
@@ -308,7 +311,7 @@ class LocalExecutor:
             if conOpts:
                 # Ignore container options if container type is not the one
                 # specified in the descriptor.
-                if conType != conTypeToUse:
+                if conType != conTypeToUse and not conOptsForced:
                     print_warning("Ignoring incompatible container options.")
                 else:
                     for opt in conOpts:

--- a/boutiques/tests/test_example1.py
+++ b/boutiques/tests/test_example1.py
@@ -882,3 +882,29 @@ class TestExample1(BaseTest):
 
         self.assertIn(container_opts, ret.container_command)
         self.assertIn(extra_container_opts, ret.container_command)
+
+    @pytest.mark.xfail(reason="Travis to GH action transition")
+    @pytest.mark.skipif(
+        subprocess.Popen("type singularity", shell=True).wait(),
+        reason="Singularity not installed",
+    )
+    def test_example1_singularity_container_opts(self):
+        # check that container runtime options are not ignored when specified on
+        # command-line, and the container runtime differs from the descriptor
+        container_opts = "--cpus 1"
+
+        ret = bosh.execute(
+            "launch",
+            self.example1_descriptor,
+            self.get_file_path("invocation_no_opts.json"),
+            "--skip-data-collection",
+            "-v",
+            f"{self.get_file_path('example1_mount1')}:/test_mount1",
+            "-v",
+            f"{self.get_file_path('example1_mount2')}:/test_mount2",
+            "--force-singularity",
+            "--container-opts",
+            container_opts,
+        )
+
+        self.assertIn(container_opts, ret.container_command)

--- a/boutiques/tests/test_example1.py
+++ b/boutiques/tests/test_example1.py
@@ -883,7 +883,6 @@ class TestExample1(BaseTest):
         self.assertIn(container_opts, ret.container_command)
         self.assertIn(extra_container_opts, ret.container_command)
 
-    @pytest.mark.xfail(reason="Travis to GH action transition")
     @pytest.mark.skipif(
         subprocess.Popen("type singularity", shell=True).wait(),
         reason="Singularity not installed",


### PR DESCRIPTION
## Related issues
#707 #705

## Checklist
- [x] **DO** Unit tests pass.
- [x] **DO** If new feature, created unit test.
- [x] Documentation: no change

#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Purpose
We need to run a descriptor containing `"type":"docker"` with singularity, so we use `--force-singularity`.
We also need to pass specific runtime options to singularity, so we tried using the `--container-opts` flag recently added in #705.

In such a case, since the container runtime was explicitly selected by the user, we'd expect that the container runtime options passed on command line would be used. But instead, bosh shows `[ WARNING ] Ignoring incompatible container options` and they are ignored. This patch proposes to stop ignoring `--container-opts` when defined on command line, and the container runtime is "forced".

There is a extra subtlety : at the moment, the concept of "forced" a runtime can only be true with `--force-singularity` but not with `--force-docker`, unless we also change the behavior of `_chooseContainerTypeToUse()`  :
-  `--force-singularity` guarantees that either `singularity` will be used, or nothing will run
- `--force-docker` doesn't offer a similar guarantee, because when `docker` is not in `$PATH`, bosh might still call `singularity`. This is the same issue as in the last bullet point of [PR #705](https://github.com/boutiques/boutiques/pull/705). If we agree that `--force-docker` should either run docker or run nothing, I can do an extra patch to "fix" it as well. But our core short-term requirement is only on singularity, so I favored a more backwards-compatible change.
