### PR TITLE
Update --force-X flags

### DIFF
--- a/boutiques/tests/test_example1.py
+++ b/boutiques/tests/test_example1.py
@@ -765,6 +765,24 @@ class TestExample1(BaseTest):
         self.assertIn("Local (boutiques-example1-test.simg)", ret.container_location)
         self.assertIn("singularity exec", ret.container_command)
 
+    @mock.patch(
+        "boutiques.localExec.LocalExecutor._isCommandInstalled",
+        side_effect=docker_not_installed,
+    )
+    def test_example1_exec_forced_not_found(self, mock_docker_not_installed):
+        with pytest.raises(ExecutorError):
+            bosh.execute(
+                "launch",
+                self.example1_descriptor,
+                self.get_file_path("invocation_no_opts.json"),
+                "--skip-data-collection",
+                "--force-docker",
+                "-v",
+                f"{self.get_file_path('example1_mount1')}:/test_mount1",
+                "-v",
+                f"{self.get_file_path('example1_mount2')}:/test_mount2",
+            )
+
     @pytest.mark.skipif(
         subprocess.Popen("type docker", shell=True).wait(),
         reason="Docker not installed",


### PR DESCRIPTION
## Related issues
#714, #710

## Checklist
- [x] **DO** Unit tests pass.
- [x] **DO** If new feature, created unit test.
- [x] Documentation: no change.

#### Does this introduce a major change?
- [ ] Yes
- [x] No. But there is a small breakage of backward compatibility, as discussed in issue #714.

## Purpose

Change how `--force-docker`,`--force-singularity`,`--force-apptainer` flags are processed on `bosh exec launch`, so that either the forced command is found in `$PATH` and used, or an error is raised.
This small behaviour change fixes an arguable situation where a command other than the "forced" one could end up being run, and also allows `--container-opts` to now be usable with `--force-docker` (addressing the limitation mentionned in #710).
Behaviour when no force flag is used is unchanged.

## Current behaviour

- `--force-docker` : run docker if command is found in `$PATH`, and look for `singularity` then `apptainer` otherwise
- `--force-singularity` : run singularity if command is found in `$PATH`, and look for `apptainer` otherwise
- `--force-apptainer` : run apptainer if command is found in `$PATH`, fail otherwise

## New behaviour

- `--force-docker` : run docker if command is found in `$PATH`, fail otherwise
- `--force-singularity` : run singularity if command is found in `$PATH`, fail otherwise
- `--force-apptainer` : run apptainer if command is found in `$PATH`, fail otherwise
