### PR TITLE
[BUG] Reduce max search size for zenodo

### DIFF
--- a/boutiques/searcher.py
+++ b/boutiques/searcher.py
@@ -53,8 +53,8 @@ class Searcher:
             self.max_results = 10
 
         # Zenodo will error if asked for more than 9999 results
-        if self.max_results > 9999:
-            self.max_results = 9999
+        if self.max_results > 25:
+            self.max_results = 25
 
         # Set Zenodo endpoint
         self.zenodo_endpoint = (

--- a/boutiques/zenodoHelper.py
+++ b/boutiques/zenodoHelper.py
@@ -7,8 +7,9 @@ import simplejson as json
 from boutiques.logger import print_info, raise_error
 from boutiques.util.utils import importCatcher
 
-# Zenodo limits search results to 100
-MAX_ZENODO_RESULTS = 100
+# Zenodo limits search results to 25 for non-authenticated requests
+# and 100 for authenticated requests
+MAX_ZENODO_RESULTS = 25
 
 
 class ZenodoError(Exception):
@@ -16,7 +17,6 @@ class ZenodoError(Exception):
 
 
 class ZenodoHelper:
-
     # Constructor
     def __init__(self, sandbox=False, no_int=False, verbose=False):
         self.sandbox = sandbox
@@ -279,7 +279,7 @@ class ZenodoHelper:
         )
         r = requests.get(get_request)
         if r.status_code != 200:
-            raise_error(ZenodoError, "Error searching Zenodo", r)
+            raise_error(ZenodoError, f"Error searching Zenodo: {r.json()}", r)
         if self.verbose:
             print_info(f'Search successful for query "{query}"', r)
             print_info(f"GET request: {get_request}")


### PR DESCRIPTION
Zenodo reduce their API limit again:
- 25 for non-authenticated requests
- 100 for authenticated requests

---
name: Feature or bug fix name
about: Propose modifications in the code
title: 'Feature implementation | Bug fix for issue #<000>'
labels: enhancement
assignees: ''

---

## Related issues
<!-- List the issue(s) that are addressed by this PR -->

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.
- [ ] **TRY** If new API function, documented it (refer to
[PEP 257](https://www.python.org/dev/peps/pep-0257/)).

## Purpose
<!--- A clear and concise description of what the PR does. -->

## Current behaviour
<!--- Tell us what currently happens -->

## New behaviour
<!--- Tell us what will happen when the PR is merged -->

#### Does this introduce a major change?
- [ ] Yes
- [ ] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
