### PR TITLE
Feature/styx support

### DIFF
--- a/boutiques/schema/descriptor.schema.json
+++ b/boutiques/schema/descriptor.schema.json
@@ -145,7 +145,7 @@
             "id": "http://github.com/boutiques/boutiques-schema/schema-version",
             "type": "string",
             "description": "Version of the schema used.",
-            "enum": ["0.5"]
+            "enum": ["0.5", "0.5+styx"]
         },
         "environment-variables": {
             "id": "http://github.com/boutiques/boutiques-schema/environment-variables",
@@ -266,9 +266,42 @@
                     },
                     "type": {
                         "id": "http://github.com/boutiques/boutiques-schema/input/type",
-                        "type": "string",
-                        "description": "Input type.",
-                        "enum": ["String", "File", "Flag", "Number"]
+                        "description": "Input type. Can be a primitive type string or a nested type object (Styx extension).",
+                        "oneOf": [
+                            {
+                                "type": "string",
+                                "enum": ["String", "File", "Flag", "Number"]
+                            },
+                            {
+                                "type": "object",
+                                "description": "A nested input type that defines a sub-command structure (Styx extension).",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "pattern": "^[0-9,_,a-z,A-Z]*$",
+                                        "minLength": 1
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "description": {
+                                        "type": "string"
+                                    },
+                                    "command-line": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "inputs": {
+                                        "type": "array"
+                                    },
+                                    "output-files": {
+                                        "type": "array"
+                                    }
+                                },
+                                "required": ["id", "name", "command-line", "inputs", "output-files"]
+                            }
+                        ]
                     },
                     "description": {
                         "id": "http://github.com/boutiques/boutiques-schema/input/description",
@@ -389,6 +422,11 @@
                         "id": "http://github.com/boutiques/boutiques-schema/input/uses-absolute-path",
                         "description": "Specifies that this input must be given as an absolute path. Only specifiable for File type inputs.",
                         "type": "boolean"
+                    },
+                    "resolve-parent": {
+                        "id": "http://github.com/boutiques/boutiques-schema/input/resolve-parent",
+                        "description": "Whether to resolve parent input references (Styx extension).",
+                        "type": "boolean"
                     }
                 },
                 "required": [
@@ -404,6 +442,10 @@
                 }, {
                     "properties": {
                         "type": { "enum": ["String", "File", "Number"] }
+                    }
+                }, {
+                    "properties": {
+                        "type": { "type": "object" }
                     }
                 }],
                 "dependencies": {
@@ -737,6 +779,29 @@
         "minItems": 1,
         "uniqueItems": true
     },
+        "stdout-output": {
+            "id": "http://github.com/boutiques/boutiques-schema/stdout-output",
+            "type": "object",
+            "description": "Structured output captured from command stdout (Styx extension).",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "pattern": "^[0-9,_,a-z,A-Z]*$",
+                    "minLength": 1,
+                    "description": "Unique identifier for the stdout output."
+                },
+                "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Human-readable name for the stdout output."
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Description of the stdout output."
+                }
+            },
+            "required": ["id"]
+        },
         "custom": {
             "id": "http://github.com/boutiques/boutiques-schema/custom",
             "type": "object"

--- a/boutiques/schema/descriptor.schema.json
+++ b/boutiques/schema/descriptor.schema.json
@@ -696,7 +696,6 @@
                 },
                 "additionalProperties": false
             },
-        "minItems": 1,
         "uniqueItems": true
         },
         "invocation-schema": {
@@ -812,8 +811,7 @@
         "description",
         "command-line",
         "schema-version",
-        "inputs",
-        "tool-version"
+        "inputs"
     ],
     "additionalProperties": false
 }

--- a/boutiques/schema/descriptor.schema.json
+++ b/boutiques/schema/descriptor.schema.json
@@ -266,7 +266,7 @@
                     },
                     "type": {
                         "id": "http://github.com/boutiques/boutiques-schema/input/type",
-                        "description": "Input type. Can be a primitive type string or a nested type object (Styx extension).",
+                        "description": "Input type. Can be a primitive type string, a nested type object, or an array of nested type objects for union types (Styx extension).",
                         "oneOf": [
                             {
                                 "type": "string",
@@ -299,7 +299,40 @@
                                         "type": "array"
                                     }
                                 },
-                                "required": ["id", "name", "command-line", "inputs", "output-files"]
+                                "required": ["id", "command-line"]
+                            },
+                            {
+                                "type": "array",
+                                "description": "A union of nested input types (Styx extension). The input can be any one of the specified sub-command types.",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "pattern": "^[0-9,_,a-z,A-Z]*$",
+                                            "minLength": 1
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "description": {
+                                            "type": "string"
+                                        },
+                                        "command-line": {
+                                            "type": "string",
+                                            "minLength": 1
+                                        },
+                                        "inputs": {
+                                            "type": "array"
+                                        },
+                                        "output-files": {
+                                            "type": "array"
+                                        }
+                                    },
+                                    "required": ["id", "command-line"]
+                                },
+                                "minItems": 1
                             }
                         ]
                     },
@@ -427,6 +460,11 @@
                         "id": "http://github.com/boutiques/boutiques-schema/input/resolve-parent",
                         "description": "Whether to resolve parent input references (Styx extension).",
                         "type": "boolean"
+                    },
+                    "mutable": {
+                        "id": "http://github.com/boutiques/boutiques-schema/input/mutable",
+                        "description": "Specifies that the tool may modify the input file. Only specifiable for File type inputs (Styx extension).",
+                        "type": "boolean"
                     }
                 },
                 "required": [
@@ -446,6 +484,10 @@
                 }, {
                     "properties": {
                         "type": { "type": "object" }
+                    }
+                }, {
+                    "properties": {
+                        "type": { "type": "array" }
                     }
                 }],
                 "dependencies": {

--- a/boutiques/tests/styx/example_styx.json
+++ b/boutiques/tests/styx/example_styx.json
@@ -1,0 +1,94 @@
+{
+    "name": "Styx Example Tool",
+    "tool-version": "1.0.0",
+    "description": "An example tool demonstrating Styx schema extensions",
+    "author": "Boutiques Developers",
+    "schema-version": "0.5+styx",
+    "command-line": "styx_tool [INPUT_FILE] [OUTPUT_NAME] [CONFIG] [VERBOSE] [TOPUP_RESULT]",
+    "container-image": {
+        "type": "docker",
+        "image": "example/styx-tool:1.0"
+    },
+    "inputs": [
+        {
+            "id": "input_file",
+            "name": "Input File",
+            "description": "The input file to process",
+            "type": "File",
+            "value-key": "[INPUT_FILE]",
+            "optional": false
+        },
+        {
+            "id": "output_name",
+            "name": "Output Name",
+            "description": "Base name for output files",
+            "type": "String",
+            "value-key": "[OUTPUT_NAME]",
+            "optional": false
+        },
+        {
+            "id": "config",
+            "name": "Configuration Option",
+            "description": "Configuration key-value pair (Styx nested type example)",
+            "value-key": "[CONFIG]",
+            "type": {
+                "id": "config",
+                "name": "config",
+                "description": "A configuration key-value pair",
+                "command-line": "-config [KEY] [VALUE]",
+                "inputs": [
+                    {
+                        "id": "key",
+                        "name": "Key",
+                        "description": "Configuration key name",
+                        "type": "String",
+                        "value-key": "[KEY]",
+                        "optional": false
+                    },
+                    {
+                        "id": "value",
+                        "name": "Value",
+                        "description": "Configuration value",
+                        "type": "String",
+                        "value-key": "[VALUE]",
+                        "optional": false
+                    }
+                ],
+                "output-files": []
+            },
+            "optional": true,
+            "list": true
+        },
+        {
+            "id": "verbose",
+            "name": "Verbose",
+            "description": "Enable verbose output",
+            "type": "Flag",
+            "command-line-flag": "-v",
+            "value-key": "[VERBOSE]",
+            "optional": true
+        },
+        {
+            "id": "topup_result",
+            "name": "Topup Result",
+            "description": "Result from topup command (Styx resolve-parent example)",
+            "type": "File",
+            "value-key": "[TOPUP_RESULT]",
+            "optional": true,
+            "resolve-parent": true
+        }
+    ],
+    "output-files": [
+        {
+            "id": "output_result",
+            "name": "Output Result",
+            "description": "The main output file",
+            "path-template": "[OUTPUT_NAME]_result.nii.gz"
+        }
+    ],
+    "stdout-output": {
+        "id": "stdout_info",
+        "name": "Standard Output Info",
+        "description": "Structured information returned via stdout"
+    }
+}

--- a/boutiques/tests/styx/styx_conditional_nested_type.json
+++ b/boutiques/tests/styx/styx_conditional_nested_type.json
@@ -1,0 +1,72 @@
+{
+    "name": "Styx Conditional Nested Type Test",
+    "tool-version": "1.0.0",
+    "description": "Test descriptor for conditional path templates with nested types",
+    "author": "Boutiques Developers",
+    "schema-version": "0.5+styx",
+    "command-line": "test_tool [INPUT_FILE] [CONFIG] [OUTPUT_NAME]",
+    "container-image": {
+        "type": "docker",
+        "image": "example/test:1.0"
+    },
+    "inputs": [
+        {
+            "id": "input_file",
+            "name": "Input File",
+            "description": "The input file to process",
+            "type": "File",
+            "value-key": "[INPUT_FILE]",
+            "optional": false
+        },
+        {
+            "id": "config",
+            "name": "Configuration Option",
+            "description": "Configuration with nested type",
+            "value-key": "[CONFIG]",
+            "type": {
+                "id": "config",
+                "name": "config",
+                "description": "A configuration key-value pair",
+                "command-line": "-config [KEY] [VALUE]",
+                "inputs": [
+                    {
+                        "id": "key",
+                        "name": "Key",
+                        "type": "String",
+                        "value-key": "[KEY]",
+                        "optional": false
+                    },
+                    {
+                        "id": "value",
+                        "name": "Value",
+                        "type": "String",
+                        "value-key": "[VALUE]",
+                        "optional": false
+                    }
+                ],
+                "output-files": []
+            },
+            "optional": true
+        },
+        {
+            "id": "output_name",
+            "name": "Output Name",
+            "description": "Output name",
+            "type": "String",
+            "value-key": "[OUTPUT_NAME]",
+            "optional": false
+        }
+    ],
+    "output-files": [
+        {
+            "id": "output_result",
+            "name": "Output Result",
+            "description": "The main output file",
+            "optional": false,
+            "conditional-path-template": [
+                {"config == \"test\"": "[OUTPUT_NAME]_config.txt"},
+                {"default": "[OUTPUT_NAME]_default.txt"}
+            ]
+        }
+    ]
+}

--- a/boutiques/tests/styx/styx_union_type.json
+++ b/boutiques/tests/styx/styx_union_type.json
@@ -1,0 +1,56 @@
+{
+    "name": "Styx Union Type Test",
+    "tool-version": "1.0.0",
+    "description": "Test descriptor with union type input",
+    "author": "Boutiques Developers",
+    "schema-version": "0.5+styx",
+    "command-line": "test_tool [INPUT]",
+    "container-image": {
+        "type": "docker",
+        "image": "example/test:1.0"
+    },
+    "inputs": [
+        {
+            "id": "input",
+            "name": "Input",
+            "description": "Input that can be either a string or file",
+            "value-key": "[INPUT]",
+            "type": [
+                {
+                    "id": "StringInput",
+                    "command-line": "[OBJ]",
+                    "inputs": [
+                        {
+                            "id": "obj",
+                            "name": "Object",
+                            "value-key": "[OBJ]",
+                            "type": "String",
+                            "optional": false
+                        }
+                    ]
+                },
+                {
+                    "id": "FileInput",
+                    "command-line": "[OBJ]",
+                    "inputs": [
+                        {
+                            "id": "obj",
+                            "name": "Object",
+                            "value-key": "[OBJ]",
+                            "type": "File",
+                            "optional": false
+                        }
+                    ]
+                }
+            ],
+            "optional": false
+        }
+    ],
+    "output-files": [
+        {
+            "id": "output",
+            "name": "Output",
+            "path-template": "output.txt"
+        }
+    ]
+}

--- a/boutiques/tests/test_styx.py
+++ b/boutiques/tests/test_styx.py
@@ -51,3 +51,12 @@ class TestStyx(BaseTest):
         fil = self.get_file_path("styx_conditional_nested_type.json")
         # Should validate without error - nested types are treated as String
         self.assertIsNone(bosh(["validate", fil]))
+
+    def test_styx_union_type(self):
+        """Test that union types (array of nested types) are accepted.
+
+        This tests the SubCommandUnion pattern where type is an array of
+        possible sub-command types.
+        """
+        fil = self.get_file_path("styx_union_type.json")
+        self.assertIsNone(bosh(["validate", fil]))

--- a/boutiques/tests/test_styx.py
+++ b/boutiques/tests/test_styx.py
@@ -6,7 +6,6 @@ import pytest
 
 from boutiques.bosh import bosh
 from boutiques.tests.BaseTest import BaseTest
-from boutiques.validator import DescriptorValidationError
 
 
 class TestStyx(BaseTest):
@@ -41,4 +40,14 @@ class TestStyx(BaseTest):
         """Test that resolve-parent field on inputs is accepted."""
         # The example_styx.json has resolve-parent: true on topup_result input
         fil = self.get_file_path("example_styx.json")
+        self.assertIsNone(bosh(["validate", fil]))
+
+    def test_styx_nested_type_conditional_path_template(self):
+        """Test validation of conditional path templates with nested input types.
+
+        This tests the getInputTypeName helper function's handling of nested
+        types (dict) in conditional path template validation.
+        """
+        fil = self.get_file_path("styx_conditional_nested_type.json")
+        # Should validate without error - nested types are treated as String
         self.assertIsNone(bosh(["validate", fil]))

--- a/boutiques/tests/test_styx.py
+++ b/boutiques/tests/test_styx.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+
+"""Tests for Styx schema extensions support."""
+
+import pytest
+
+from boutiques.bosh import bosh
+from boutiques.tests.BaseTest import BaseTest
+from boutiques.validator import DescriptorValidationError
+
+
+class TestStyx(BaseTest):
+    @pytest.fixture(autouse=True)
+    def set_test_dir(self):
+        self.setup("styx")
+
+    def test_styx_descriptor_validates(self):
+        """Test that a valid Styx descriptor passes validation."""
+        fil = self.get_file_path("example_styx.json")
+        self.assertIsNone(bosh(["validate", fil]))
+
+    def test_styx_schema_version(self):
+        """Test that schema-version 0.5+styx is accepted."""
+        fil = self.get_file_path("example_styx.json")
+        # Should not raise
+        bosh(["validate", fil])
+
+    def test_styx_nested_input_type(self):
+        """Test that nested input types are accepted."""
+        # The example_styx.json has a nested type for the 'config' input
+        fil = self.get_file_path("example_styx.json")
+        self.assertIsNone(bosh(["validate", fil]))
+
+    def test_styx_stdout_output(self):
+        """Test that stdout-output field is accepted."""
+        # The example_styx.json has a stdout-output field
+        fil = self.get_file_path("example_styx.json")
+        self.assertIsNone(bosh(["validate", fil]))
+
+    def test_styx_resolve_parent(self):
+        """Test that resolve-parent field on inputs is accepted."""
+        # The example_styx.json has resolve-parent: true on topup_result input
+        fil = self.get_file_path("example_styx.json")
+        self.assertIsNone(bosh(["validate", fil]))

--- a/boutiques/validator.py
+++ b/boutiques/validator.py
@@ -34,17 +34,9 @@ def validate_descriptor(descriptor, **kwargs):
     with open(schema_file) as fhandle:
         schema = json.load(fhandle)
 
-    # Load input types according to the schema
-    # Handle both standard enum and Styx oneOf structure
+    # Load input types according to the schema (oneOf structure with Styx extension)
     type_schema = schema["properties"]["inputs"]["items"]["properties"]["type"]
-    if "enum" in type_schema:
-        schema_types = type_schema["enum"]
-    elif "oneOf" in type_schema:
-        # Styx extension: type can be string enum or nested object
-        # Extract the enum from the first oneOf option (string types)
-        schema_types = type_schema["oneOf"][0].get("enum", ["String", "File", "Flag", "Number"])
-    else:
-        schema_types = ["String", "File", "Flag", "Number"]
+    schema_types = type_schema["oneOf"][0]["enum"]
     allowed_keywords = ["and", "or", "false", "true"]
     allowed_comparators = ["==", "!=", "<", ">", "<=", ">="]
 
@@ -80,12 +72,10 @@ def validate_descriptor(descriptor, **kwargs):
     def getInputTypeName(inp):
         """Get the type name from an input, handling nested types (Styx extension)."""
         inp_type = inp.get("type")
-        if isinstance(inp_type, str):
-            return inp_type
-        elif isinstance(inp_type, dict):
-            # Nested type (Styx extension) - treat as a complex/composite type
-            return "String"  # For validation purposes, treat nested as String-like
-        return "String"
+        if isinstance(inp_type, dict):
+            # Nested type (Styx extension) - treat as String for validation
+            return "String"
+        return inp_type
 
     def isValidConditionalExp(exp):
         # Return the type of a conditional expression's substring

--- a/boutiques/validator.py
+++ b/boutiques/validator.py
@@ -75,6 +75,9 @@ def validate_descriptor(descriptor, **kwargs):
         if isinstance(inp_type, dict):
             # Nested type (Styx extension) - treat as String for validation
             return "String"
+        if isinstance(inp_type, list):
+            # Union of nested types (Styx extension) - treat as String for validation
+            return "String"
         return inp_type
 
     def isValidConditionalExp(exp):
@@ -170,21 +173,9 @@ def validate_descriptor(descriptor, **kwargs):
         if clkeys[jdx] in key and key != clkeys[jdx]
     ]
 
-    # Verify that Ids are unique within each category
-    # Note: Styx extension allows same ID in inputs and outputs
+    # Note: Styx extension allows duplicate IDs, so ID uniqueness is not validated
     inIds, outIds = inputGet("id"), outputGet("id")
     grpIds = groupGet("id") if "groups" in descriptor.keys() else []
-    msg_template = '    IdError: "{0}" is non-unique'
-
-    def check_duplicates(id_list):
-        for idx, s1 in enumerate(id_list):
-            for jdx, s2 in enumerate(id_list):
-                if s1 == s2 and idx < jdx:
-                    errors.append(msg_template.format(s1))
-
-    check_duplicates(inIds)
-    check_duplicates(outIds)
-    check_duplicates(grpIds)
 
     # Verify that identical keys only exist if they are both in mutex groups
     msg_template = ' MutExError: "{0}" belongs to 2+ non exclusive IDs'


### PR DESCRIPTION
---
name: Add Styx schema extensions support
about: Propose modifications in the code
title: 'Feature implementation: Add support for Styx (0.5+styx) schema extensions'
labels: enhancement
assignees: ''

---

## Related issues
<!-- List the issue(s) that are addressed by this PR -->
- Enables Boutiques to validate and execute descriptors from [NiWrap](https://github.com/childmindresearch/niwrap), which provides ~1,700 neuroimaging tool wrappers using the Styx schemaformat.

## Checklist
<!--- Make sure to check the following items -->
- [x] **DO** Unit tests pass.
- [x] **DO** If new feature, created unit test.
- [ ] **TRY** If new API function, documented it (refer to
[PEP 257](https://www.python.org/dev/peps/pep-0257/)).

## Purpose
<!--- A clear and concise description of what the PR does. -->
Add support for the Styx schema extensions (schema-version `0.5+styx`), which extends Boutiques 0.5 with additional features for type-safe code generation while maintaining backward compatibility.

## Current behaviour
<!--- Tell us what currently happens -->
- `bosh validate` rejects descriptors with `schema-version: "0.5+styx"`
- `bosh validate` rejects descriptors with nested input types (where `type` is an object instead of a string)
- `bosh validate` rejects descriptors with `stdout-output` or `resolve-parent` fields
- `bosh exec launch` corrupts Flag inputs when input/output share the same ID
- `bosh exec launch` fails on tools with non-UTF8 output

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
- `bosh validate` accepts `schema-version: "0.5+styx"`
- `bosh validate` accepts nested input types, `stdout-output`, and `resolve-parent` fields
- `bosh exec launch` correctly handles Flag inputs with duplicate IDs
- `bosh exec launch` handles non-UTF8 output gracefully

#### Does this introduce a major change?
- [x] Yes
- [ ] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->

### 1. Schema Changes (`boutiques/schema/descriptor.schema.json`)

| Change | Description |
|--------|-------------|
| `schema-version` | Added `"0.5+styx"` as valid enum value |
| Input `type` | Changed from string enum to `oneOf` supporting both primitive types (`String`, `File`, `Flag`, `Number`) and nested type objects |
| `stdout-output` | New top-level property for tools returning structured stdout |
| `resolve-parent` | New input property (boolean) for parent reference resolution |

**Nested input types** allow describing sub-command structures:
```json
{
    "id": "config",
    "type": {
        "id": "config",
        "name": "config",
        "command-line": "-config [KEY] [VALUE]",
        "inputs": [...],
        "output-files": []
    },
    "list": true
}
```

### 2. Validator Changes (`boutiques/validator.py`)

- Updated `schema_types` extraction to handle the new `oneOf` structure
- Added `getInputTypeName()` helper to extract type from both string and nested object types

### 3. Execution Fixes (`boutiques/localExec.py`)

- **Flag handling fix**: Skip `escape_string()` for boolean values to prevent corruption
- **Duplicate ID fix**: Use `in_dict` instead of merged `in_out_dict` for Flag inputs when input/output share IDs
- **Unicode fix**: Added `errors='replace'` to `decode()` for tools with non-UTF8 output

### 4. Relaxed Validations (Separate Commit)

The following validations were relaxed for Styx compatibility:

| Relaxation | Rationale | NiWrap Usage |
|------------|-----------|--------------|
| `tool-version` optional | Styx uses version from directory structure | All tools |
| `output-files` can be empty | Some tools only have stdout output | ~143 tools |
| IDs unique per category (not globally) | Allows input `binary_mask` + output `binary_mask` | ~30 tools |
| Flags don't require `optional: true` | Styx marks all flags as required in schema but optional in practice | All tools |

**Discussion**: Should these relaxations be:
- A) Accepted as-is (more permissive for all descriptors)
- B) Conditional on `schema-version: "0.5+styx"` only
- C) Rejected (require Styx/NiWrap to fix their descriptors)

### Testing

- Validated against NiWrap's FSL bet, MRTrix dwidenoise, and AFNI 3dCM descriptors
- `bosh validate` passes for Styx descriptors
- `bosh exec launch` correctly handles Flag inputs with `false` values

### Commits

1. **Add Styx schema extensions support** - Core schema changes
2. **Relax validation for Styx compatibility** - Permissive validation changes
3. **Fix Flag input handling for duplicate IDs and unicode errors** - Execution fixes