### PR TITLE
Specify User-agent to prevent TooManyRequest from Zenodo

### DIFF
--- a/boutiques/zenodoHelper.py
+++ b/boutiques/zenodoHelper.py
@@ -4,6 +4,7 @@ import re
 
 import simplejson as json
 
+from boutiques.__version__ import VERSION as BOSH_VERSION
 from boutiques.logger import print_info, raise_error
 from boutiques.util.utils import importCatcher
 
@@ -277,7 +278,7 @@ class ZenodoHelper:
             "&file_type=json&type=software&"
             f"page=1&size={MAX_ZENODO_RESULTS}"
         )
-        r = requests.get(get_request, headers={"User-Agent": "bosh"})
+        r = requests.get(get_request, headers={"User-Agent": f"bosh-{BOSH_VERSION}"})
         if r.status_code != 200:
             raise_error(ZenodoError, f"Error searching Zenodo: {r.json()}", r)
         if self.verbose:


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
fix #735 

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.
- [ ] **TRY** If new API function, documented it (refer to
[PEP 257](https://www.python.org/dev/peps/pep-0257/)).

## Purpose
<!--- A clear and concise description of what the PR does. -->

## Current behaviour
<!--- Tell us what currently happens -->
Zenodo currently returns `TooManyRequest` when using bosh search

## New behaviour
<!--- Tell us what will happen when the PR is merged -->

#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
