### PR TITLE
Ensure temporary files are cleaned up while running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ temp-*.localExec.boshjob.sh
 boutiques-example1-test.simg
 boutiques/tests/import/docopt/test_options_output.json
 boutiques/tests/import/docopt/test_valid_output.json
+boutiques/tests/invocation/good.json
+boutiques/tests/output_files/test_desc.json
+boutiques/tests/publisher/test_forward_slash_toolName.json
 test_temp/*
 
 # Byte-compiled / optimized / DLL files

--- a/boutiques/localExec.py
+++ b/boutiques/localExec.py
@@ -465,7 +465,7 @@ class LocalExecutor:
 
         # Destroy temporary docker script, if desired.
         # By default, keep the script so the dev can look at it.
-        if conIsPresent and not self.debug:
+        if ("pytest" in sys.modules) or (conIsPresent and not self.debug):
             if os.path.isfile(dsname):
                 os.remove(dsname)
 

--- a/boutiques/localExec.py
+++ b/boutiques/localExec.py
@@ -25,6 +25,14 @@ from boutiques.logger import print_info, print_warning, raise_error
 from boutiques.util.utils import conditionalExpFormat, extractFileName, loadJson
 
 
+def cleanup_temp_file(filename: str, *, debug: bool, conIsPresent: bool):
+    # Destroy temporary docker script, if desired.
+    # By default, keep the script so the dev can look at it.
+    if ("pytest" in sys.modules) or (conIsPresent and not debug):
+        if os.path.isfile(filename):
+            os.remove(filename)
+
+
 class ExecutorOutput:
     def __init__(
         self,
@@ -377,6 +385,9 @@ class LocalExecutor:
                     if not Path(abs_path).exists():
                         missing_mounts.append(abs_path)
                 if missing_mounts:
+                    cleanup_temp_file(
+                        dsname, debug=self.debug, conIsPresent=conIsPresent
+                    )
                     raise_error(
                         ExecutorError,
                         f"Missing local mount location: {missing_mounts}",
@@ -463,11 +474,7 @@ class LocalExecutor:
             (stdout, stderr), exit_code = self._localExecute(command)
         time.sleep(0.5)  # Give the OS a (half) second to finish writing
 
-        # Destroy temporary docker script, if desired.
-        # By default, keep the script so the dev can look at it.
-        if ("pytest" in sys.modules) or (conIsPresent and not self.debug):
-            if os.path.isfile(dsname):
-                os.remove(dsname)
+        cleanup_temp_file(dsname, debug=self.debug, conIsPresent=conIsPresent)
 
         # Check for output files
         missing_files = []
@@ -585,7 +592,7 @@ class LocalExecutor:
 
             # Container image does not exist and we can't pull it: just fail
             if self.noPull:
-                raise_error(ExecutorError, "Unable to retrieve Singularity " "image.")
+                raise_error(ExecutorError, "Unable to retrieve Singularity image.")
             # Try to pull the container image
             if self.imagePath:
                 lockDir = self.imagePath + "-lock"
@@ -629,7 +636,7 @@ class LocalExecutor:
             if self._singConExists(conName, imageDir):
                 conPath = op.abspath(op.join(imageDir, conName))
                 return conPath, f"Local ({conName})"
-            raise_error(ExecutorError, "Unable to retrieve Singularity " "image.")
+            raise_error(ExecutorError, "Unable to retrieve Singularity image.")
 
     # Private method that checks if a Singularity image exists locally
     def _singConExists(self, conName, imageDir):
@@ -1135,7 +1142,7 @@ class LocalExecutor:
         # encountered before blowing up
         except Exception as e:  # Avoid BaseExceptions like SystemExit
             sys.stderr.write(
-                "An error occurred in validation\n" "Previously saved issues\n"
+                "An error occurred in validation\nPreviously saved issues\n"
             )
             for err in self.errs:
                 sys.stderr.write("\t" + str(err) + "\n")
@@ -1180,7 +1187,7 @@ class LocalExecutor:
             boutiques.invocation(*args)
         except Exception:  # Avoid catching BaseExceptions like SystemExit
             sys.stderr.write(
-                "An error occurred in validation\n" "Previously saved issues\n"
+                "An error occurred in validation\nPreviously saved issues\n"
             )
             for err in self.errs:
                 # Write any errors we found


### PR DESCRIPTION
## Related issues
<!-- List the issue(s) that are addressed by this PR -->
fix #733


## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.
- [ ] **TRY** If new API function, documented it (refer to
[PEP 257](https://www.python.org/dev/peps/pep-0257/)).

## Purpose
<!--- A clear and concise description of what the PR does. -->
Prevent cluttering of local environment

## Current behaviour
<!--- Tell us what currently happens -->
Multiple tests leave a temp file. It is either due to the executor using (1) `--debug` flag or (2) testing expected failure with the executor raising exception  before cleanup.

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
Temporary files are now cleaned up

#### Does this introduce a major change?
- [ ] Yes
- [ ] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
