### PR TITLE
Update deprecated importlib load_module()

### DIFF
--- a/boutiques/importer.py
+++ b/boutiques/importer.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python
-
 import collections
 import os
 import os.path as op
 import re
 import sys
 from argparse import ArgumentParser
-from importlib.machinery import SourceFileLoader
 
 import simplejson as json
 from jsonschema import ValidationError
@@ -16,6 +14,7 @@ from boutiques.logger import raise_error
 from boutiques.util.utils import (
     customSortDescriptorByKey,
     customSortInvocationByInput,
+    import_from_path,
     importCatcher,
     loadJson,
 )
@@ -136,11 +135,9 @@ class Importer:
 
     def import_docopt(self):
         # input_descriptor is the .py containing docopt script
-        docstring = (
-            SourceFileLoader("docopt_script", self.input_descriptor)
-            .load_module()
-            .__doc__
-        )
+        module = import_from_path("docopt_script", self.input_descriptor)
+        docstring = module.__doc__
+
         # Init docopt importer and start import
         docoptImporter = Docopt_Importer(docstring, self.output_descriptor)
 

--- a/boutiques/util/utils.py
+++ b/boutiques/util/utils.py
@@ -1,10 +1,20 @@
+from __future__ import annotations
+
 import os
+import sys
 from collections import OrderedDict
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from typing import TYPE_CHECKING
 
 import simplejson as json
 
 from boutiques import __file__ as bfile
 from boutiques.logger import print_warning, raise_error
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from types import ModuleType
 
 
 # Utility function to wrap modules that use non-essential libs
@@ -203,3 +213,12 @@ def formatSphinxUsage(func, usage_str):
     args = [f'"{arg.strip()}"' for arg in args]
     args = ", ".join(args)
     return f"[{args}]"
+
+
+def import_from_path(module_name: str, file_path: str | Path) -> ModuleType:
+    loader = SourceFileLoader(module_name, file_path)
+    spec = spec_from_loader(module_name, loader)
+    module = module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module


### PR DESCRIPTION
## Related issues
Closes issue #694

## Checklist
<!--- Make sure to check the following items -->
- [ ] **DO** Unit tests pass.
- [ ] **DO** If new feature, created unit test.
- [ ] **TRY** If new API function, documented it (refer to
[PEP 257](https://www.python.org/dev/peps/pep-0257/)).

## Purpose
<!--- A clear and concise description of what the PR does. -->
Update method to load docopt script as a module since `importlib.load_module` is deprecated and will be removed in Python 3.15.

## Current behaviour
<!--- Tell us what currently happens -->
`bosh import docopt` automatically generates a descriptors JSON file from a user provided Docopt script. Currently the user provided docopt script is loaded as a module using the deprecated `importlib.load_module()`.

## New behaviour
<!--- Tell us what will happen when the PR is merged -->
Functionality remains the same but PR loads the docopt script as a module using importlib recommended approach, see [example](https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly).

#### Does this introduce a major change?
- [ ] Yes
- [x] No

## Implementation Detail
<!--- Provide a detailed description of the change or addition you are proposing -->
Intentionally defined a loader using `SourceFileLoader()` instead of using `spec_from_path()` because `spec_from_path()` checks for `.py` extension under the hood and will fail if the user provided docopt script has no extension.